### PR TITLE
stop using cluster order to find out working namespace

### DIFF
--- a/roles/cluster_working_namespace/defaults/main.yml
+++ b/roles/cluster_working_namespace/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
 cluster_working_namespace_cluster_order_name_label: "cloudkit.openshift.io/clusterorder"
-cluster_working_namespace_cluster_order_namespace_label: "cloudkit.openshift.io/clusterordernamespace"

--- a/roles/cluster_working_namespace/tasks/main.yml
+++ b/roles/cluster_working_namespace/tasks/main.yml
@@ -4,7 +4,6 @@
     kind: Namespace
     label_selectors:
       - "{{ cluster_working_namespace_cluster_order_name_label }}={{ cluster_working_namespace_cluster_order_name }}"
-      - "{{ cluster_working_namespace_cluster_order_namespace_label }}={{ cluster_working_namespace_cluster_order_namespace }}"
   register: cluster_working_namespace_list
 
 - name: Check if the working cluster namespace is found


### PR DESCRIPTION
Related to https://github.com/innabox/cloudkit-operator/pull/22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an obsolete filter from the namespace retrieval configuration. This update refines how the active working namespace is selected for improved operational consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->