### PR TITLE
no need to pass cluster order namespace

### DIFF
--- a/playbook_cloudkit_create_hosted_cluster.yml
+++ b/playbook_cloudkit_create_hosted_cluster.yml
@@ -10,7 +10,6 @@
     - role: cluster_working_namespace
       vars:
         cluster_working_namespace_cluster_order_name: "{{ cluster_order.metadata.name }}"
-        cluster_working_namespace_cluster_order_namespace: "{{ cluster_order.metadata.namespace }}"
 
     - role: cluster_settings
       vars:

--- a/playbook_cloudkit_delete_hosted_cluster.yml
+++ b/playbook_cloudkit_delete_hosted_cluster.yml
@@ -10,7 +10,6 @@
     - role: cluster_working_namespace
       vars:
         cluster_working_namespace_cluster_order_name: "{{ cluster_order.metadata.name }}"
-        cluster_working_namespace_cluster_order_namespace: "{{ cluster_order.metadata.namespace }}"
 
     - role: cluster_settings
       vars:


### PR DESCRIPTION
Leftover from https://github.com/innabox/cloudkit-aap/pull/6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined hosted cluster management by removing a redundant internal setting from both the creation and deletion processes, enhancing overall process clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->