### PR TITLE
wait for hostedcluster infrastructure to be ready

### DIFF
--- a/roles/hosted_cluster/tasks/main.yml
+++ b/roles/hosted_cluster/tasks/main.yml
@@ -100,3 +100,15 @@
               matchLabels: "{{ hosted_cluster_default_cluster_order_label }}"
         release:
           image: "quay.io/openshift-release-dev/ocp-release:{{ hosted_cluster_settings.ocp_version }}"
+
+- name: Wait for HostedCluster infrastructure to be ready
+  kubernetes.core.k8s_info:
+    kind: HostedCluster
+    namespace: "{{ hosted_cluster_namespace }}"
+    name: "{{ hosted_cluster_name }}"
+    wait_condition:
+      reason: "AsExpected"
+      status: "True"
+      type: "InfrastructureReady"
+    wait_timeout: 600
+  register: hosted_cluster_result

--- a/roles/hosted_cluster/tasks/main.yml
+++ b/roles/hosted_cluster/tasks/main.yml
@@ -103,6 +103,7 @@
 
 - name: Wait for HostedCluster infrastructure to be ready
   kubernetes.core.k8s_info:
+    api_version: hypershift.openshift.io/v1alpha1
     kind: HostedCluster
     namespace: "{{ hosted_cluster_namespace }}"
     name: "{{ hosted_cluster_name }}"


### PR DESCRIPTION
Wait for the infrastructure to be ready so the HostedCluster returned in
`hosted_cluster_result` will contain the control plane IP and port.

https://github.com/openshift/hypershift/blob/main/control-plane-operator/controllers/hostedcontrolplane/hostedcontrolplane_controller.go#L636-L650


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced an automated mechanism to monitor and wait for the HostedCluster infrastructure to be fully operational before proceeding, ensuring improved deployment reliability and system stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->