### PR TITLE
enable parallel processing of events in EDA

### DIFF
--- a/rulebooks/cluster_fulfillment.yml
+++ b/rulebooks/cluster_fulfillment.yml
@@ -1,6 +1,7 @@
 ---
 - name: Fulfillment webhook
   hosts: localhost
+  execution_strategy: parallel
   sources:
     - ansible.eda.webhook:
         host: 0.0.0.0


### PR DESCRIPTION
We currently observe that client are getting timeouts from the EDA
webhooks. One reason of this is might be because the processing of the
events is sequencial by default.

This PR enables parallel processing of event in EDA, which should fix the
client timeouts we currently experience.

Doc ref: https://ansible.readthedocs.io/projects/rulebook/en/latest/rulebooks.html#rulesets