### PR TITLE
Fix the apiVersion for the HostedCluster resource

### DIFF
--- a/roles/hosted_cluster/tasks/main.yml
+++ b/roles/hosted_cluster/tasks/main.yml
@@ -32,7 +32,7 @@
   kubernetes.core.k8s:
     state: "{{ hosted_cluster_state }}"
     definition:
-      apiVersion: hypershift.openshift.io/v1alpha1
+      apiVersion: hypershift.openshift.io/v1beta1
       kind: HostedCluster
       metadata:
         name: "{{ hosted_cluster_name }}"


### PR DESCRIPTION
We were using v1alpha1 in the playbooks, but the current API version is v1beta1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

These updates ensure the platform remains aligned with the latest infrastructure standards, promoting improved long-term compatibility. While you may not notice any immediate changes to system behavior, this upgrade lays the groundwork for enhanced future performance.

- **Chores**
  - Upgraded the cluster configuration to the latest supported API version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->