### PR TITLE
Add openstack/esi integration roles

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,0 +1,2 @@
+playbook_cloudkit_delete_hosted_cluster.yml var-naming[no-role-prefix]
+playbook_cloudkit_create_hosted_cluster.yml var-naming[no-role-prefix]

--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -1,0 +1,2 @@
+skip_list:
+- role-name[path]

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,0 +1,1 @@
+../execution-environment/requirements.yaml

--- a/playbook_cloudkit_create_hosted_cluster.yml
+++ b/playbook_cloudkit_create_hosted_cluster.yml
@@ -2,6 +2,8 @@
 - name: Create a hosted control plane cluster from a ClusterOrder
   hosts: localhost
   gather_facts: false
+  environment:
+    OS_CLOUD: "{{ openstack_cloud_name|default('devstack') }}"
 
   vars:
     cluster_order: "{{ ansible_eda.event.payload }}"
@@ -14,9 +16,23 @@
     - role: cluster_settings
       vars:
         cluster_settings_template_id: "{{ cluster_order.spec.templateID }}"
-        cluster_settings_template_parameters: "{{ cluster_order.spec.templateParameters }}"
+        cluster_settings_template_parameters: "{{ cluster_order.spec.templateParameters | from_json }}"
 
     - role: hosted_cluster
+      vars:
+        hosted_cluster_name: "{{ cluster_order.metadata.name }}"
+        hosted_cluster_namespace: "{{ cluster_working_namespace_result }}"
+        hosted_cluster_settings: "{{ cluster_settings_result }}"
+        hosted_cluster_state: present
+
+    - role: infrastructure/api
+      vars:
+        hosted_cluster_name: "{{ cluster_order.metadata.name }}"
+        hosted_cluster_namespace: "{{ cluster_working_namespace_result }}"
+        hosted_cluster_settings: "{{ cluster_settings_result }}"
+        hosted_cluster_state: present
+
+    - role: infrastructure/ingress
       vars:
         hosted_cluster_name: "{{ cluster_order.metadata.name }}"
         hosted_cluster_namespace: "{{ cluster_working_namespace_result }}"

--- a/playbook_cloudkit_delete_hosted_cluster.yml
+++ b/playbook_cloudkit_delete_hosted_cluster.yml
@@ -2,6 +2,8 @@
 - name: Teardown a hosted control plane cluster from a ClusterOrder
   hosts: localhost
   gather_facts: false
+  environment:
+    OS_CLOUD: "{{ openstack_cloud_name|default('devstack') }}"
 
   vars:
     cluster_order: "{{ ansible_eda.event.payload }}"
@@ -17,6 +19,20 @@
         cluster_settings_template_parameters: "{{ cluster_order.spec.templateParameters }}"
 
     - role: hosted_cluster
+      vars:
+        hosted_cluster_name: "{{ cluster_order.metadata.name }}"
+        hosted_cluster_namespace: "{{ cluster_working_namespace_result }}"
+        hosted_cluster_settings: "{{ cluster_settings_result }}"
+        hosted_cluster_state: absent
+
+    - role: infrastructure/api
+      vars:
+        hosted_cluster_name: "{{ cluster_order.metadata.name }}"
+        hosted_cluster_namespace: "{{ cluster_working_namespace_result }}"
+        hosted_cluster_settings: "{{ cluster_settings_result }}"
+        hosted_cluster_state: absent
+
+    - role: infrastructure/ingress
       vars:
         hosted_cluster_name: "{{ cluster_order.metadata.name }}"
         hosted_cluster_namespace: "{{ cluster_working_namespace_result }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,12 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "ansible>=11.4.0",
+    "boto3>=1.37.29",
+    "botocore>=1.37.29",
+    "jmespath>=1.0.1",
     "kubernetes>=32.0.1",
     "python-esiclient>=1.1.0",
     "python-esileapclient>=1.0.0",
     "python-ironicclient>=5.10.0",
-    "python-openstackclient>=6.0.1",
+    "python-openstackclient>=7.4.0",
 ]

--- a/roles/infrastructure/api/defaults/main.yaml
+++ b/roles/infrastructure/api/defaults/main.yaml
@@ -1,0 +1,2 @@
+api_kube_apiserver_port: 6443         # noqa:var-naming[no-role-prefix]
+api_internal_ip_network: hypershift   # noqa:var-naming[no-role-prefix]

--- a/roles/infrastructure/api/meta/main.yaml
+++ b/roles/infrastructure/api/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+- role: infrastructure/common

--- a/roles/infrastructure/api/tasks/create_api_infra.yaml
+++ b/roles/infrastructure/api/tasks/create_api_infra.yaml
@@ -1,0 +1,54 @@
+- name: Get kube-apiserver service
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Service
+    namespace: "{{ hosted_cluster_namespace }}-{{ hosted_cluster_name }}"
+    name: kube-apiserver
+  register: kube_apiserver_service
+
+  # wait until the service exists and has a loadbalancer ip
+  until: >-
+    kube_apiserver_service.resources and
+    kube_apiserver_service.resources[0].status.loadBalancer.ingress | default(false)
+  retries: "{{ kube_apiserver_wait_retries | default(infrastructure_resource_wait_retries) }}"
+  delay: "{{ kube_apiserver_wait_delay | default(infrastructure_resource_wait_delay) }}"
+
+- name: Set api_internal_ip
+  ansible.builtin.set_fact:
+    api_internal_ip: "{{ kube_apiserver_service.resources[0].status.loadBalancer.ingress[0].ip }}"
+
+- name: Allocate api floating ip
+  ansible.builtin.include_role:
+    name: infrastructure
+    tasks_from: allocate_floating_ip
+  vars:
+    floating_ip_name: "{{ hosted_cluster_name }}-api"  # noqa:var-naming[no-role-prefix]
+
+- name: Set api_floating_ip
+  ansible.builtin.set_fact:
+    api_floating_ip: "{{ allocate_floating_ip_result }}"
+
+# FIXME: This will fail erroneously because the command is not idempotent;
+# see https://github.com/CCI-MOC/python-esiclient/issues/82. Unfortunately,
+# it will also fail legitimately if we failed to clean up from a previous
+# cluster and there exists a port forwarding to the same internal ip
+# address.
+- name: Create port forwarding  # noqa:no-changed-when
+  ansible.builtin.command: >-
+    openstack esi port forwarding create {{ api_internal_ip }} {{ api_floating_ip }}
+      --internal-ip-network "{{ api_internal_ip_network }}"
+      -p {{ api_kube_apiserver_port }} -d "{{ hosted_cluster_name }}" -f json
+  register: create_forwarding
+  failed_when: >-
+    create_forwarding.rc != 0 and "duplicate port forwarding" not in create_forwarding.stderr
+
+- name: Create dns record
+  amazon.aws.route53:
+    state: present
+    zone: "{{ hosted_cluster_settings.base_domain }}"
+    record: "api.{{ hosted_cluster_name }}.{{ hosted_cluster_settings.base_domain }}"
+    type: A
+    ttl: "{{ infrastructure_dns_ttl }}"
+    value: "{{ api_floating_ip }}"
+    wait: true
+    overwrite: true

--- a/roles/infrastructure/api/tasks/destroy_api_infra.yaml
+++ b/roles/infrastructure/api/tasks/destroy_api_infra.yaml
@@ -1,0 +1,25 @@
+- name: Wait for hostedcluster to finish deleting
+  kubernetes.core.k8s_info:
+    api_version: hypershift.openshift.io/v1beta1
+    kind: HostedCluster
+    namespace: "{{ hosted_cluster_namespace }}"
+    name: "{{ hosted_cluster_name }}"
+  register: hosted_cluster_check
+  until: not hosted_cluster_check.resources
+  retries: 360
+  delay: 5
+
+- name: Destroy api floating ip
+  ansible.builtin.include_role:
+    name: infrastructure
+    tasks_from: destroy_floating_ip.yaml
+  vars:
+    floating_ip_name: "{{ hosted_cluster_name }}-api"  # noqa:var-naming[no-role-prefix]
+
+- name: Delete api dns record
+  amazon.aws.route53:
+    state: absent
+    zone: "{{ hosted_cluster_settings.base_domain }}"
+    record: "api.{{ hosted_cluster_name }}.{{ hosted_cluster_settings.base_domain }}"
+    type: A
+    wait: true

--- a/roles/infrastructure/api/tasks/main.yaml
+++ b/roles/infrastructure/api/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Create api infrastructure
+  when: hosted_cluster_state == "present"
+  ansible.builtin.include_tasks: create_api_infra.yaml
+
+- name: Destroy api infrastructure
+  when: hosted_cluster_state == "absent"
+  ansible.builtin.include_tasks: destroy_api_infra.yaml

--- a/roles/infrastructure/common/defaults/main.yaml
+++ b/roles/infrastructure/common/defaults/main.yaml
@@ -1,0 +1,3 @@
+infrastructure_dns_ttl: 1800
+infrastructure_resource_wait_retries: 360
+infrastructure_resource_wait_delay: 5

--- a/roles/infrastructure/defaults/main.yaml
+++ b/roles/infrastructure/defaults/main.yaml
@@ -1,0 +1,1 @@
+infrastructure_floating_ip_network: external

--- a/roles/infrastructure/ingress/meta/main.yaml
+++ b/roles/infrastructure/ingress/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+- role: infrastructure/common

--- a/roles/infrastructure/ingress/tasks/create_ingress_infra.yaml
+++ b/roles/infrastructure/ingress/tasks/create_ingress_infra.yaml
@@ -1,0 +1,54 @@
+- name: Wait until agents are available
+  kubernetes.core.k8s_info:
+    api_version: agent-install.openshift.io/v1beta1
+    kind: Agent
+    namespace: "hardware-inventory"
+    label_selectors:
+    - "cloudkit.openshift.io/clusterorder={{ hosted_cluster_name }}"
+  register: agents
+
+  # wait until agents are assigned to the cluster
+  until: agents.resources
+  retries: "{{ agent_wait_retries | default(infrastructure_resource_wait_retries) }}"
+  delay: "{{ agent_wait_delay | default(infrastructure_resource_wait_delay) }}"
+
+- name: Set worker_node_ip
+  ansible.builtin.set_fact:
+    worker_node_ip: >-
+      {{
+      agents |
+      json_query('resources[*].status.inventory.interfaces[?ipV4Addresses][].ipV4Addresses[]') |
+      shuffle |
+      first |
+      ansible.utils.ipaddr('address')
+      }}
+
+- name: Allocate ingress floating ip
+  ansible.builtin.include_role:
+    name: infrastructure
+    tasks_from: allocate_floating_ip.yaml
+  vars:
+    floating_ip_name: "{{ hosted_cluster_name }}-ingress"  # noqa:var-naming[no-role-prefix]
+
+- name: Set ingress_floating_ip
+  ansible.builtin.set_fact:
+    ingress_floating_ip: "{{ allocate_floating_ip_result }}"
+
+- name: Create port forwarding for ingress  # noqa:no-changed-when
+  ansible.builtin.command: >-
+    openstack esi port forwarding create {{ worker_node_ip }} {{ ingress_floating_ip }}
+      -p 80 -p 443 -d "{{ hosted_cluster_name }}-ingress" -f json
+  register: create_forwarding
+  failed_when: >-
+    create_forwarding.rc != 0 and "duplicate port forwarding" not in create_forwarding.stderr
+
+- name: Create ingress dns record
+  amazon.aws.route53:
+    state: present
+    zone: "{{ hosted_cluster_settings.base_domain }}"
+    record: "*.apps.{{ hosted_cluster_name }}.{{ hosted_cluster_settings.base_domain }}"
+    type: A
+    ttl: "{{ infrastructure_dns_ttl }}"
+    value: "{{ ingress_floating_ip }}"
+    wait: true
+    overwrite: true

--- a/roles/infrastructure/ingress/tasks/destroy_ingress_infra.yaml
+++ b/roles/infrastructure/ingress/tasks/destroy_ingress_infra.yaml
@@ -1,0 +1,14 @@
+- name: Destroy ingress floating ip
+  ansible.builtin.include_role:
+    name: infrastructure
+    tasks_from: destroy_floating_ip.yaml
+  vars:
+    floating_ip_name: "{{ hosted_cluster_name }}-ingress"  # noqa:var-naming[no-role-prefix]
+
+- name: Delete ingress dns record
+  amazon.aws.route53:
+    state: absent
+    zone: "{{ hosted_cluster_settings.base_domain }}"
+    record: "*.apps.{{ hosted_cluster_name }}.{{ hosted_cluster_settings.base_domain }}"
+    type: A
+    wait: true

--- a/roles/infrastructure/ingress/tasks/main.yaml
+++ b/roles/infrastructure/ingress/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Create ingress infrastructure
+  when: hosted_cluster_state == "present"
+  ansible.builtin.include_tasks: create_ingress_infra.yaml
+
+- name: Destroy ingress infrastructure
+  when: hosted_cluster_state == "absent"
+  ansible.builtin.include_tasks: destroy_ingress_infra.yaml

--- a/roles/infrastructure/meta/main.yaml
+++ b/roles/infrastructure/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+- role: infrastructure/common

--- a/roles/infrastructure/tasks/allocate_floating_ip.yaml
+++ b/roles/infrastructure/tasks/allocate_floating_ip.yaml
@@ -1,0 +1,26 @@
+- name: Check if floating ip exists
+  openstack.cloud.floating_ip_info:
+    description: "{{ floating_ip_name }}"
+  register: fips
+
+- name: Set allocate_floating_ip_result to found ip
+  when: fips.floating_ips
+  ansible.builtin.set_fact:
+    allocate_floating_ip_result: "{{ fips.floating_ips[0].floating_ip_address }}"
+
+- name: Allocate a new floating ip
+  when: not fips.floating_ips
+  block:
+  - name: Allocate floating ip  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack floating ip create {{ infrastructure_floating_ip_network }} --description "{{ floating_ip_name }}"
+        -f json
+    register: fip_cmd_raw
+
+  - name: Unmarshal output from JSON
+    ansible.builtin.set_fact:
+      fip_cmd_result: "{{ fip_cmd_raw.stdout | from_json }}"
+
+  - name: Set allocate_floating_ip_result to new ip
+    ansible.builtin.set_fact:
+      allocate_floating_ip_result: "{{ fip_cmd_result.floating_ip_address }}"

--- a/roles/infrastructure/tasks/destroy_floating_ip.yaml
+++ b/roles/infrastructure/tasks/destroy_floating_ip.yaml
@@ -1,0 +1,23 @@
+- name: Look for floating ip
+  openstack.cloud.floating_ip_info:
+    description: "{{ floating_ip_name }}"
+  register: fips
+
+- name: Destroy floating floating_ip_address
+  when: fips.floating_ips
+  block:
+  - name: Extract ip address to destroy
+    ansible.builtin.set_fact:
+      destroy_floating_ip: "{{ fips.floating_ips[0].floating_ip_address }}"
+
+  - name: Remove port forwardings  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack esi port forwarding purge {{ destroy_floating_ip }} -f json
+
+  - name: Unset floating ip port  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack floating ip unset --port {{ destroy_floating_ip }}
+
+  - name: Delete floating ip  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack floating ip delete {{ destroy_floating_ip }}

--- a/uv.lock
+++ b/uv.lock
@@ -81,6 +81,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.37.32"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/be6dfbe66f3a04434240edbb5425c0756f848af40c52194109afc0d265e9/boto3-1.37.32.tar.gz", hash = "sha256:bc08c95a88ffeb51d78d25cb8bd72593b8cce1d8fdcc650030aff98c15437d04", size = 111354 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/3c/27d76e8e2400e129d5253837841849b8f66cbdda9fbdeae61c3d6713c6a6/boto3-1.37.32-py3-none-any.whl", hash = "sha256:6f0d3863abfeed366b365fb3ad2fa508d7f2becd64ca712d4b70b593da7f9763", size = 139561 },
+]
+
+[[package]]
+name = "botocore"
+version = "1.37.32"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/68/407e8a712694eab28ca95ca2f9135d66e92975a54a37dda1aeefd26f8cd5/botocore-1.37.32.tar.gz", hash = "sha256:3e5d097690b3423adeefdf257384e964d0ba7f9575d77bf3f8998273b92ef700", size = 13815793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/7a/f0813da18b6f194e994666e0fd772a8cd8bc46b3c71e93994fdd8f6e573a/botocore-1.37.32-py3-none-any.whl", hash = "sha256:c25989e09e29b382c1edcc994f795c4faadf2f30470269754024a55269a7a47d", size = 13481235 },
+]
+
+[[package]]
 name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -164,6 +192,9 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "ansible" },
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "jmespath" },
     { name = "kubernetes" },
     { name = "python-esiclient" },
     { name = "python-esileapclient" },
@@ -174,11 +205,14 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "ansible", specifier = ">=11.4.0" },
+    { name = "boto3", specifier = ">=1.37.29" },
+    { name = "botocore", specifier = ">=1.37.29" },
+    { name = "jmespath", specifier = ">=1.0.1" },
     { name = "kubernetes", specifier = ">=32.0.1" },
     { name = "python-esiclient", specifier = ">=1.1.0" },
     { name = "python-esileapclient", specifier = ">=1.0.0" },
     { name = "python-ironicclient", specifier = ">=5.10.0" },
-    { name = "python-openstackclient", specifier = ">=6.0.1" },
+    { name = "python-openstackclient", specifier = ">=7.4.0" },
 ]
 
 [[package]]
@@ -546,10 +580,9 @@ wheels = [
 
 [[package]]
 name = "openstacksdk"
-version = "1.2.0"
+version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appdirs" },
     { name = "cryptography" },
     { name = "decorator" },
     { name = "dogpile-cache" },
@@ -557,15 +590,17 @@ dependencies = [
     { name = "jmespath" },
     { name = "jsonpatch" },
     { name = "keystoneauth1" },
-    { name = "netifaces" },
     { name = "os-service-types" },
     { name = "pbr" },
+    { name = "platformdirs" },
+    { name = "psutil" },
     { name = "pyyaml" },
     { name = "requestsexceptions" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/7f/a3535e523ef1ae853229bb30af8f32d98f3fd21b50c0f42e917b6174afb2/openstacksdk-1.2.0.tar.gz", hash = "sha256:bc4b340fde80503b839bda72a32eb7d630ccde5c2c1ff4952840d79fca5bce7f", size = 1160015 }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/72/0b7fe12a18f871dc57119651dba1a9c9976b8adcdfbad95b2e7224b06849/openstacksdk-4.5.0.tar.gz", hash = "sha256:ab7a1240207a6969ba09ceee8f16653805730677b4497a806cd956733651fe68", size = 1284921 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/62/0e53c59ea032cff8c7346dc6b94797a0eb5166ad65fb8f62fbc47c12d618/openstacksdk-1.2.0-py3-none-any.whl", hash = "sha256:d73b5b9825b14230d8faca0acc9dbbfacf1299eb8eceae1f0f6900ed17aede6e", size = 1626258 },
+    { url = "https://files.pythonhosted.org/packages/cb/f1/8c5ceee7e1f9519fb4dd1e33a8120c3b960dcdc8d7558ec92103df7c1ee2/openstacksdk-4.5.0-py3-none-any.whl", hash = "sha256:8ee80c594a2b710a3f4dc6a75334455bb8deb40f0bd42a706520210e82efc171", size = 1809217 },
 ]
 
 [[package]]
@@ -582,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "osc-lib"
-version = "3.2.0"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cliff" },
@@ -594,9 +629,9 @@ dependencies = [
     { name = "requests" },
     { name = "stevedore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/db/0a907d200719f755f00579f116526abea404a8a7961d8cd4019f1e1235ed/osc-lib-3.2.0.tar.gz", hash = "sha256:5f706be145daf0e58068e3763ec56bde2f43ed229a738628e4c0fb1defb4ed9e", size = 99180 }
+sdist = { url = "https://files.pythonhosted.org/packages/47/84/ecd798d1aee59b5501de21e8e69f98f5ba275464053be62309a4d4a4b85b/osc_lib-4.0.0.tar.gz", hash = "sha256:1dd15dd64c2b62101487a0f774821839df6b2baa5abc1a572c8e6c53314ee3e7", size = 101874 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/cf/97bf2cfc86dfe15efdf238f49de3f918c677025bd4619b452f75ad5a1363/osc_lib-3.2.0-py3-none-any.whl", hash = "sha256:01c063f289c193a5e1867e5f557058ddd4222e6a56cefdc24ed5ed0a8a0951bd", size = 89257 },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/db614f18e2a171cd4b2b2d660dcb5ed386ebe6caa6016b9a4f5746e211a1/osc_lib-4.0.0-py3-none-any.whl", hash = "sha256:7980be4452a6458f3eeb2f09d9b92f4dcc56a2f9c0b28513c99017158f89dfc1", size = 93121 },
 ]
 
 [[package]]
@@ -876,7 +911,7 @@ wheels = [
 
 [[package]]
 name = "python-esileapclient"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "esisdk" },
@@ -885,14 +920,14 @@ dependencies = [
     { name = "python-openstackclient" },
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/99/2bb399819f805b3a5a3df24ff6752ce99967daff69f9c87bd61e9ef4d54b/python_esileapclient-1.0.0.tar.gz", hash = "sha256:caaab74d5d72749bad5b5d02ef259f9b2f3678284991a36fe06272d6f8787d79", size = 39812 }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/cc/8b29dc822a10eb65320e63413e8e369858b8332294f8ed30c65d1f20470e/python_esileapclient-1.1.0.tar.gz", hash = "sha256:e192cd847827e68019ad1b33ead5b21702bf2a604be5b78cbde14810c5acf6f8", size = 40922 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/ee/7eb240563825c43305dc5883bd684d6df68f34cc2e0ddbd834252c371a02/python_esileapclient-1.0.0-py3-none-any.whl", hash = "sha256:fb581c982bfe9f0824e3703eabbd80284f4ebbf94f6a83183358d81c7590c3f7", size = 63361 },
+    { url = "https://files.pythonhosted.org/packages/af/34/4b70ec908209f4fae553c648fd2a1f0f8e455a4e5828234ff47d21b461e6/python_esileapclient-1.1.0-py3-none-any.whl", hash = "sha256:eba10e1cf009356a883da5b47e9d46ce51142499d5e57d28f84245a97600645e", size = 63144 },
 ]
 
 [[package]]
 name = "python-ironicclient"
-version = "5.10.0"
+version = "5.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cliff" },
@@ -908,9 +943,9 @@ dependencies = [
     { name = "requests" },
     { name = "stevedore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/be/c8fa91c8c3554eceff66ba998af9f8b90b94c467353e251c9c05618f4eb7/python-ironicclient-5.10.0.tar.gz", hash = "sha256:120d9e6a4ae2e7ed613ee2b2abdf9fe1d2f7de297a1b82d82d9be85987d4e0b6", size = 222766 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/06/740598bc5f2d9c3aad5956e2efb3c623bed06434a7494a5a87f20807a6bf/python_ironicclient-5.10.1.tar.gz", hash = "sha256:d263411bf590eda7d51ed8c515333f2092d4e13032a588acdaadbd11db5d05f7", size = 223033 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/72/fac8eb2490312925fe26b49ac3b93372d1d140fe5bd8dc09b79a5576958f/python_ironicclient-5.10.0-py3-none-any.whl", hash = "sha256:4fe07f4c9a4c5f22c423f38a0d2284fb023a41f673470810e71f3ac279b9b9de", size = 240973 },
+    { url = "https://files.pythonhosted.org/packages/85/50/4c58bdd2c2a0536cc8a772221ce41de8f6e67c13e0d1a5c44ca3298ed564/python_ironicclient-5.10.1-py3-none-any.whl", hash = "sha256:662cfd05c91a1aec5d93705b6aa1a0b204cc4cd24c3c180dc311985844837932", size = 240943 },
 ]
 
 [[package]]
@@ -955,24 +990,24 @@ wheels = [
 
 [[package]]
 name = "python-openstackclient"
-version = "6.0.1"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cliff" },
+    { name = "cryptography" },
     { name = "iso8601" },
     { name = "openstacksdk" },
     { name = "osc-lib" },
     { name = "oslo-i18n" },
-    { name = "oslo-utils" },
     { name = "pbr" },
     { name = "python-cinderclient" },
     { name = "python-keystoneclient" },
-    { name = "python-novaclient" },
+    { name = "requests" },
     { name = "stevedore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/a5/ed0dcfa4dcc2effb0d9963d650d8923407544296713aa45447469124553b/python-openstackclient-6.0.1.tar.gz", hash = "sha256:0b9d9e856d906d4ed6cd21cf80b2716c85b7e7b01e35840f0c4af212ca04cda2", size = 839450 }
+sdist = { url = "https://files.pythonhosted.org/packages/81/81/afb257489a665cfc330129cc8bb74c4131a085c310eeb74cc86391c3dd06/python_openstackclient-8.0.0.tar.gz", hash = "sha256:5b7a5e06893f833b5d296d019c50d42c7368e37748ee6be8e9b15655b999424e", size = 914450 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/8d/8b9a2fd630f1e2798f0690fdc4aaf58aac5c8dd2934d77b3c2d58a344ce6/python_openstackclient-6.0.1-py3-none-any.whl", hash = "sha256:08574fcb61e6cdd6ced276faa07ea9faea9c06fa5d987a9ba48cdac3dc63f1df", size = 999571 },
+    { url = "https://files.pythonhosted.org/packages/23/55/a3df5e4e0fdee95b4375100b00dd834c65d9ff7b37586324c4643cfcbfd5/python_openstackclient-8.0.0-py3-none-any.whl", hash = "sha256:b4c0c8436679d250a30d170446661d783964039d8fc9e6c9e3194ed321fd5944", size = 1066118 },
 ]
 
 [[package]]
@@ -1107,6 +1142,18 @@ wheels = [
 ]
 
 [[package]]
+name = "s3transfer"
+version = "0.11.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/ec/aa1a215e5c126fe5decbee2e107468f51d9ce190b9763cb649f76bb45938/s3transfer-0.11.4.tar.gz", hash = "sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679", size = 148419 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/62/8d3fc3ec6640161a5649b2cddbbf2b9fa39c92541225b33f117c37c5a2eb/s3transfer-0.11.4-py3-none-any.whl", hash = "sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d", size = 84412 },
+]
+
+[[package]]
 name = "setuptools"
 version = "78.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1160,11 +1207,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.1"
+version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/ad/cd3e3465232ec2416ae9b983f27b9e94dc8171d56ac99b345319a9475967/typing_extensions-4.13.1.tar.gz", hash = "sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff", size = 106633 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/c5/e7a0b0f5ed69f94c8ab7379c599e6036886bffcde609969a5325f47f1332/typing_extensions-4.13.1-py3-none-any.whl", hash = "sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69", size = 45739 },
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806 },
 ]
 
 [[package]]
@@ -1178,11 +1225,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add roles to set up floating ip addresses, port forwarding, and dns records for cluster api and ingress endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded cloud automation support with new integration collections and dependencies: `openstack.cloud`, `amazon.aws`, `community.general`, and `ansible.utils`.
  - Introduced dynamic role-based workflows to automate the creation and deletion of hosted clusters.
  - Enhanced configuration options for environment variables, network settings, and DNS record management.
  - Added support for managing ingress infrastructure within Kubernetes environments.

- **Chores**
  - Streamlined processes for floating IP allocation and removal.
  - Upgraded common infrastructure settings to improve resource provisioning and overall operational reliability.
  - Customized linting behavior by adding specific entries to ignore certain rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->