### PR TITLE
Use explicit fqdn in api service publishing configuration

### DIFF
--- a/roles/hosted_cluster/tasks/main.yml
+++ b/roles/hosted_cluster/tasks/main.yml
@@ -61,6 +61,8 @@
           - service: APIServer
             servicePublishingStrategy:
               type: LoadBalancer
+              loadBalancer:
+                hostname: "api.{{ hosted_cluster_name }}.{{ hosted_cluster_settings.base_domain }}"
           - service: OAuthServer
             servicePublishingStrategy:
               type: Route


### PR DESCRIPTION
Previously, the installer was embedding the load balancer ip address into both the generated kubeconfig and into the worker node configuration. Because the loadbalancer ip is unreachable, this required manual editing of the kubeconfig and meant that worker nodes were unable to join the cluster.

If we set an explicit hostname in the loadbalancer configuration, like this...

    services:
    - service: APIServer servicePublishingStrategy: loadBalancer: hostname: api.larstest1.box.massopen.cloud type: LoadBalancer

...then the installer will use that both in the kubeconfig and in worker node configurations, allowing the install to proceed as expected.