### PR TITLE
Add ESI network role

### DIFF
--- a/collections/ansible_collections/massopencloud/esi/roles/network/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/meta/argument_specs.yaml
@@ -1,0 +1,15 @@
+argument_specs:
+  main:
+    options:
+      network_state:
+        type: "str"
+        default: present
+        choices:
+        - present
+        - absent
+      network_name_or_id:
+        description: |
+          Name of the network when state is `present`.
+          Name or ID of network to be deleted when state is `absent`; the deletion will fail if the network name is not unique.
+        type: "str"
+        required: true

--- a/collections/ansible_collections/massopencloud/esi/roles/network/tasks/create_network.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/tasks/create_network.yaml
@@ -1,0 +1,21 @@
+- name: Check if network exists
+  openstack.cloud.networks_info:
+    name: "{{ network_name_or_id }}"
+  register: networks
+
+- name: Set create_network_result to found network
+  when: networks.networks
+  ansible.builtin.set_fact:
+    create_network_result: "{{ networks.networks[0].id }}"
+
+- name: Create a new network
+  when: not networks.networks
+  block:
+  - name: Create network  # noqa:no-changed-when
+    openstack.cloud.network:
+      name: "{{ network_name_or_id }}"
+    register: network_cmd_result
+
+  - name: Set create_network_result to new network
+    ansible.builtin.set_fact:
+      create_network_result: "{{ network_cmd_result.network.id }}"

--- a/collections/ansible_collections/massopencloud/esi/roles/network/tasks/destroy_network.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/tasks/destroy_network.yaml
@@ -1,0 +1,12 @@
+- name: Check that exactly one network matching the ident exists  # noqa:no-changed-when
+  ansible.builtin.command: >-
+    openstack network show {{ network_name_or_id }} -f json
+  register: network_show_cmd_raw
+
+- name: Unmarshal output from JSON
+  ansible.builtin.set_fact:
+    network_show_cmd_result: "{{ network_show_cmd_raw.stdout | from_json }}"
+
+- name: Destroy network  # noqa:no-changed-when
+  ansible.builtin.command: >-
+    openstack network delete {{ network_show_cmd_result.id }}

--- a/collections/ansible_collections/massopencloud/esi/roles/network/tasks/main.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/tasks/main.yaml
@@ -1,0 +1,7 @@
+- name: Create a new network
+  when: network_state == 'present'
+  ansible.builtin.include_tasks: create_network.yaml
+
+- name: Destroy a network
+  when: network_state == 'absent'
+  ansible.builtin.include_tasks: destroy_network.yaml


### PR DESCRIPTION
* creating a network requires a name, and returns a uuid
* deleting a network requires either a name or a uuid; the openstack network role claims that it can filter by either name or uuid, but the latter does not seem to work