### PR TITLE
Update ESI network/subnet destroy tasks

### DIFF
--- a/collections/ansible_collections/massopencloud/esi/roles/network/tasks/destroy_network.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/tasks/destroy_network.yaml
@@ -7,6 +7,21 @@
   ansible.builtin.set_fact:
     network_show_cmd_result: "{{ network_show_cmd_raw.stdout | from_json }}"
 
+- name: Get related subnets
+  openstack.cloud.subnets_info:
+    filters:
+      network_id: "{{ network_show_cmd_result.id }}"
+  register: subnets
+
+- name: Delete related subnets
+  ansible.builtin.include_role:
+    name: massopencloud.esi.subnet
+  vars:
+    subnet_state: "absent"
+    subnet_name_or_id: "{{ item.id }}"
+  loop: "{{ subnets.subnets }}"
+
 - name: Destroy network  # noqa:no-changed-when
-  ansible.builtin.command: >-
-    openstack network delete {{ network_show_cmd_result.id }}
+  openstack.cloud.network:
+    state: "absent"
+    name: "{{ network_show_cmd_result.id }}"

--- a/collections/ansible_collections/massopencloud/esi/roles/subnet/tasks/destroy_subnet.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/subnet/tasks/destroy_subnet.yaml
@@ -7,6 +7,19 @@
   ansible.builtin.set_fact:
     subnet_show_cmd_result: "{{ subnet_show_cmd_raw.stdout | from_json }}"
 
-- name: Destroy subnet  # noqa:no-changed-when
+- name: Get related ports  # noqa:no-changed-when
   ansible.builtin.command: >-
-    openstack subnet delete {{ subnet_show_cmd_result.id }}
+    openstack port list --fixed-ip subnet="{{ subnet_show_cmd_result.id }}"
+      -f json
+  register: subnet_port_list_cmd_raw
+
+- name: Delete related ports
+  openstack.cloud.port:
+    state: "absent"
+    name: "{{ item.ID }}"
+  loop: "{{ subnet_port_list_cmd_raw.stdout | from_json }}"
+
+- name: Destroy subnet  # noqa:no-changed-when
+  openstack.cloud.subnet:
+    state: "absent"
+    name: "{{ subnet_show_cmd_result.id }}"


### PR DESCRIPTION
* Use existing OpenStack role for deletion, as it takes name or ID
* Deleting a subnet will destroy associated ports first
* Deleting a network will call our subnet destroy task to ensure subnet is properly deleted