### PR TITLE
Implement a locking mechanism to manage concurrency

### DIFF
--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/meta/argument_specs.yaml
@@ -19,6 +19,11 @@ argument_specs:
             required: true
             choices:
             - fc430
+      cluster_template_state:
+        type: str
+        choices:
+        - absent
+        - present
       template_parameters:
         type: dict
         options:

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small_github/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small_github/meta/argument_specs.yaml
@@ -19,6 +19,11 @@ argument_specs:
             required: true
             choices:
             - fc430
+      cluster_template_state:
+        type: str
+        choices:
+        - absent
+        - present
       template_parameters:
         type: dict
         options:

--- a/playbook_cloudkit_create_hosted_cluster.yml
+++ b/playbook_cloudkit_create_hosted_cluster.yml
@@ -9,19 +9,93 @@
     cluster_order: "{{ ansible_eda.event.payload }}"
 
   pre_tasks:
+    - name: Set cluster order name
+      ansible.builtin.set_fact:
+        cluster_order_name: "{{ cluster_order.metadata.name }}"
+
+    - name: Set lock name and holder identity
+      ansible.builtin.set_fact:
+        cluster_order_lock_name: "{{ cluster_order_name }}-lock"
+        cluster_order_holder_id: >-
+          {{ cluster_order_name }}-{{ awx_job_id | default("unknown") }}-{{
+            lookup('community.general.random_string', special=false, numbers=false, upper=false)
+          }}
+
+    - name: Apply default settings
+      ansible.builtin.include_role:
+        name: cluster_settings
+
     - name: Extract template info
       ansible.builtin.include_role:
         name: extract_template_info
 
-  tasks:
     - name: Determine working namespace
       ansible.builtin.include_role:
         name: cluster_working_namespace
       vars:
-        cluster_working_namespace_cluster_order_name: "{{ cluster_order.metadata.name }}"
+        cluster_working_namespace_cluster_order_name: "{{ cluster_order_name }}"
 
-    - name: Call the selected template
-      ansible.builtin.include_role:
-        name: "{{ template_id }}"
-      vars:
-        cluster_template_state: present
+  tasks:
+    - name: Create cluster
+      block:
+
+        # By using service_side_apply and registering this job run as the
+        # field manager, we ensure that future attempts to create/modify
+        # this lock will fail (because of the conflict setting
+        # spec.holderIdentity).
+        - name: Acquire lock
+          kubernetes.core.k8s:
+            state: present
+            apply: true
+            server_side_apply:
+              field_manager: "{{ cluster_order_holder_id }}"
+            definition:
+              apiVersion: coordination.k8s.io/v1
+              kind: Lease
+              metadata:
+                name: "{{ cluster_order_lock_name }}"
+                namespace: "{{ cluster_working_namespace }}"
+              spec:
+                holderIdentity: "{{ cluster_order_holder_id }}"
+
+        - name: Set lock_acquired
+          ansible.builtin.set_fact:
+            lock_acquired: true
+
+        - name: Display cluster order information
+          ansible.builtin.debug:
+            msg:
+              - "Cluster order: {{ cluster_order_name }}"
+              - "Cluster working namespace: {{ cluster_working_namespace }}"
+              - "Template ID: {{ template_id }}"
+
+        - name: Call the selected template
+          ansible.builtin.include_role:
+            name: "{{ template_id }}"
+          vars:
+            cluster_template_state: present
+
+      rescue:
+
+        - name: Exit due to lock failure
+          when: not lock_acquired | default(false)
+          ansible.builtin.meta: end_play
+
+        # Without this, a failure in the template would show up as
+        # a successful job run.
+        - name: Propogate failure
+          ansible.builtin.fail:
+            msg: Propogating earlier failure from rescue block
+
+      always:
+
+        - name: Delete lock
+          when: lock_acquired | default(false)
+          kubernetes.core.k8s:
+            state: absent
+            definition:
+              apiVersion: coordination.k8s.io/v1
+              kind: Lease
+              metadata:
+                name: "{{ cluster_order_lock_name }}"
+                namespace: "{{ cluster_working_namespace }}"

--- a/playbook_cloudkit_delete_hosted_cluster.yml
+++ b/playbook_cloudkit_delete_hosted_cluster.yml
@@ -9,17 +9,23 @@
     cluster_order: "{{ ansible_eda.event.payload }}"
 
   pre_tasks:
+    - name: Apply default settings
+      ansible.builtin.include_role:
+        name: cluster_settings
+
     - name: Extract template info
       ansible.builtin.include_role:
         name: extract_template_info
       vars:
         cluster_working_namespace_cluster_order_name: "{{ cluster_order.metadata.name }}"
 
-  tasks:
     - name: Determine working namespace
       ansible.builtin.include_role:
         name: cluster_working_namespace
+      vars:
+        cluster_working_namespace_cluster_order_name: "{{ cluster_order.metadata.name }}"
 
+  tasks:
     - name: Call the selected template
       ansible.builtin.include_role:
         name: "{{ template_id }}"

--- a/roles/cluster_settings/defaults/main.yml
+++ b/roles/cluster_settings/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+cluster_settings_default_credentials_secret_name: "default-cluster-credentials"
+cluster_settings_default_credentials_secret_namespace: "fulfillment-aap"
+cluster_settings_template_defaults: {}

--- a/roles/cluster_settings/tasks/main.yml
+++ b/roles/cluster_settings/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+- name: Get template parameters from cluster order
+  ansible.builtin.set_fact:
+    cluster_settings_template_parameters: "{{ cluster_order.spec.templateParameters | from_json }}"
+
+- name: Get default pull-secret and ssh-key
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ cluster_settings_default_credentials_secret_name }}"
+    namespace: "{{ cluster_settings_default_credentials_secret_namespace }}"
+  register: default_cluster_credentials
+  when: >-
+    cluster_settings_template_parameters.ssh_public_key is not defined
+    or cluster_settings_template_parameters.pull_secret is not defined
+  no_log: true
+
+- name: Set default pull-secret and ssh-key as template default parameters
+  ansible.builtin.set_fact:
+    cluster_settings_template_defaults: >
+      {{ cluster_settings_template_defaults | combine({
+          'pull_secret': '{{ default_cluster_credentials.resources[0].data.pull_secret | b64decode }}',
+          'ssh_public_key': '{{ default_cluster_credentials.resources[0].data.ssh_public_key | b64decode }}'
+          })
+      }}
+  when: >-
+    cluster_settings_template_parameters.ssh_public_key is not defined
+    or cluster_settings_template_parameters.pull_secret is not defined
+  no_log: true
+
+- name: Merge default template parameters with user-provided template parameters
+  ansible.builtin.set_fact:
+    cluster_settings_template_defaults: >-
+      {{ cluster_settings_template_defaults | combine(cluster_settings_template_parameters) }}
+  no_log: true
+
+- name: Merge update template parameters into cluster order
+  ansible.builtin.set_fact:
+    cluster_order: >-
+      {{
+      cluster_order | combine({
+        "spec": {
+          "templateParameters": cluster_settings_template_defaults|to_json,
+        }
+      }, recursive=true)
+      }}
+  no_log: true
+
+- name: Set default nodeRequests
+  when: >-
+    not cluster_order.spec.nodeRequests|default([])
+  ansible.builtin.set_fact:
+    cluster_order: >-
+      {{
+      cluster_order | combine({
+        "spec": {
+          "nodeRequests": [
+            {"numberOfNodes": 2, "resourceClass": "fc430"}
+          ]
+        }
+      }, recursive=true)
+      }}
+  no_log: true

--- a/roles/extract_template_info/tasks/main.yaml
+++ b/roles/extract_template_info/tasks/main.yaml
@@ -1,9 +1,23 @@
 - name: Extract template id
-  when: template_id is not defined
+  when: >-
+    template_id is not defined
   ansible.builtin.set_fact:
     template_id: "{{ cluster_order.spec.templateID }}"
 
+- name: Handle unqualfied template ids
+  when: >-
+    "." not in template_id
+  ansible.builtin.set_fact:
+    template_id: "cloudkit.templates.{{ template_id }}"
+
 - name: Extract template parameters
-  when: template_parameters is not defined
+  when: >-
+    template_parameters is not defined
   ansible.builtin.set_fact:
     template_parameters: "{{ cluster_order.spec.templateParameters | from_json }}"
+
+- name: Extract node requests
+  when: >-
+    node_requests is not defined
+  ansible.builtin.set_fact:
+    node_requests: "{{ cluster_order.spec.nodeRequests }}"

--- a/roles/hosted_cluster/tasks/main.yml
+++ b/roles/hosted_cluster/tasks/main.yml
@@ -10,10 +10,9 @@
         namespace: "{{ hosted_cluster_namespace }}"
         labels: "{{ hosted_cluster_default_cluster_order_label }}"
       data:
-        .dockerconfigjson: >-
-          {{ hosted_cluster_settings.pull_secret }}
+        .dockerconfigjson: "{{ hosted_cluster_settings.pull_secret | to_json | b64encode }}"
       type: kubernetes.io/dockerconfigjson
-  no_log: true
+# no_log: true
 
 - name: Manage Secret resource containing ssh-key
   kubernetes.core.k8s:


### PR DESCRIPTION
We would like to prevent multiple playbooks for the same cluster running
concurrently. This pull request implements a locking mechanism using
Kubernetes Lease objects [1]. If the create cluster playbook cannot acquire
a lock, it will exit immediately (and successfully).

This PR also revives the `cluster_settings` role in order to handle some
skew between the current template implementation and the fulfillment
service.

[1]: https://kubernetes.io/docs/concepts/architecture/leases/
