### PR TITLE
Add role to publish templates to fulfillment service

### DIFF
--- a/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
+++ b/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
@@ -1,0 +1,11 @@
+- name: Discover and publish templates to fulfillment service
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: Discover templates
+    ansible.builtin.include_role:
+      name: cloudkit.service.enumerate_templates
+
+  - name: Publish templates
+    ansible.builtin.include_role:
+      name: cloudkit.service.publish_templates

--- a/collections/ansible_collections/cloudkit/service/roles/enumerate_templates/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/enumerate_templates/meta/argument_specs.yaml
@@ -4,6 +4,3 @@ argument_specs:
       cloudkit_template_collections:
         type: list
         required: true
-      cloudkit_fulfillment_service_uri:
-        type: str
-        required: true

--- a/collections/ansible_collections/cloudkit/service/roles/enumerate_templates/tasks/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/enumerate_templates/tasks/main.yaml
@@ -1,7 +1,3 @@
 - name: Enumerate templates
   ansible.builtin.set_fact:
     cloudkit_templates: "{{ cloudkit_template_collections | cloudkit.service.find_template_roles }}"
-
-- name: Publish templates to fulfillment service
-  ansible.builtin.debug:
-    var: cloudkit_templates

--- a/collections/ansible_collections/cloudkit/service/roles/publish_templates/defaults/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/publish_templates/defaults/main.yaml
@@ -1,0 +1,1 @@
+publish_templates_api_endpoint: "{{ cloudkit_fulfillment_service_uri }}/api/fulfillment/v1/cluster_templates"

--- a/collections/ansible_collections/cloudkit/service/roles/publish_templates/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/publish_templates/meta/argument_specs.yaml
@@ -1,0 +1,11 @@
+argument_specs:
+  main:
+    options:
+      cloudkit_templates:
+        type: list
+      cloudkit_fulfillment_service_uri:
+        type: str
+        required: true
+      cloudkit_fulfillment_service_token:
+        type: str
+        required: true

--- a/collections/ansible_collections/cloudkit/service/roles/publish_templates/tasks/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/publish_templates/tasks/main.yaml
@@ -1,0 +1,41 @@
+- name: Get list of existing templates
+  ansible.builtin.uri:
+    url: "{{ publish_templates_api_endpoint }}"
+    headers:
+      authorization: Bearer {{ cloudkit_fulfillment_service_token }}
+  register: template_check
+
+- name: Create list of existing template template ids
+  ansible.builtin.set_fact:
+    template_ids: >-
+      {{
+      template_check|json_query("json.items[].id")
+      }}
+
+- name: Update existing template
+  loop: "{{ cloudkit_templates }}"
+  loop_control:
+    label: "{{ template.id }}"
+    loop_var: template
+  when: template.id in template_ids
+  ansible.builtin.uri:
+    url: "{{ publish_templates_api_endpoint }}/{{ template.id }}"
+    method: PATCH
+    headers:
+      authorization: Bearer {{ cloudkit_fulfillment_service_token }}
+    body_format: json
+    body: "{{ template }}"
+
+- name: Create new template
+  loop: "{{ cloudkit_templates }}"
+  loop_control:
+    label: "{{ template.id }}"
+    loop_var: template
+  when: template.id not in template_ids
+  ansible.builtin.uri:
+    url: "{{ publish_templates_api_endpoint }}"
+    method: POST
+    headers:
+      authorization: Bearer {{ cloudkit_fulfillment_service_token }}
+    body_format: json
+    body: "{{ template }}"

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/meta/cloudkit.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/meta/cloudkit.yaml
@@ -1,8 +1,7 @@
 # Define the display name and description of the template
-display_name: OpenShift 4.17 Cluster + GitHub
+title: Simple OpenShift 4.17 Cluster
 description: >
-  This template will build a minimally configured OpenShift 4.17 cluster. It
-  will be configured to support authentication via GitHub.
+  This template will build a minimally configured OpenShift 4.17 cluster.
 
 # This sets the nodeRequest field in the ClusterOrder manifest. There must be at
 # least one entry in this list.

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small_github/meta/cloudkit.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small_github/meta/cloudkit.yaml
@@ -1,7 +1,8 @@
 # Define the display name and description of the template
-display_name: Simple OpenShift 4.17 Cluster
+title: OpenShift 4.17 Cluster + GitHub
 description: >
-  This template will build a minimally configured OpenShift 4.17 cluster.
+  This template will build a minimally configured OpenShift 4.17 cluster. It
+  will be configured to support authentication via GitHub.
 
 # This sets the nodeRequest field in the ClusterOrder manifest. There must be at
 # least one entry in this list.


### PR DESCRIPTION
The `cloudkit.service.publish_templates` role will publish the templates in
`cloudkit_templates` to the fulfillment service. This commit includes
changes to the `find_template_roles` filter and to the `cloudkit.yaml`
metadata files so that they match the requirements of the fulfillment
service.
