### PR TITLE
Dynamically get controller token to publish templates

### DIFF
--- a/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
+++ b/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
@@ -5,7 +5,7 @@
   - name: Get innabox client token
     ansible.builtin.command:
       cmd: >
-        oc create token client
+        oc create token controller
         --duration=10m
         -n innabox
     register: innabox_client_token

--- a/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
+++ b/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
@@ -2,6 +2,16 @@
   hosts: localhost
   gather_facts: false
   tasks:
+  - name: Get innabox client token
+    ansible.builtin.command:
+      cmd: >
+        oc create token client
+        --duration=10m
+        -n innabox
+    register: innabox_client_token
+    changed_when: false
+    no_log: true
+
   - name: Discover templates
     ansible.builtin.include_role:
       name: cloudkit.service.enumerate_templates
@@ -9,3 +19,5 @@
   - name: Publish templates
     ansible.builtin.include_role:
       name: cloudkit.service.publish_templates
+    vars:
+      cloudkit_fulfillment_service_token: "{{ innabox_client_token.stdout }}"

--- a/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
+++ b/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
@@ -10,7 +10,6 @@
         -n innabox
     register: innabox_client_token
     changed_when: false
-    no_log: true
 
   - name: Discover templates
     ansible.builtin.include_role:


### PR DESCRIPTION
This change get a short lived token to publish the templates. Here is the definition of the k8s rights that I used:

```
apiVersion: v1
kind: ServiceAccount
metadata:
  name: publish-template-sa
  namespace: fulfillment-aap
---
apiVersion : rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: create-innabox-controller-token
  namespace: innabox
rules:
- apiGroups: [""]
  resources: ["serviceaccounts/token"]
  resourceNames: ["controller"]
  verbs: ["create"]
---
apiVersion : rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: publish-template-rolebinding
  namespace: innabox
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: create-innabox-controller-token
subjects:
- kind: ServiceAccount
  name: publish-template-sa
  namespace: fulfillment-aap
```

And I created dedicated container group in AAP that uses the `publish-template-sa` service account with the following pod spec:

```
apiVersion: v1
kind: Pod
metadata:
  namespace: fulfillment-aap
  labels:
    ansible_job: ''
spec:
  serviceAccountName: publish-template-sa
  affinity:
    podAntiAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
        - weight: 100
          podAffinityTerm:
            labelSelector:
              matchExpressions:
                - key: ansible_job
                  operator: Exists
            topologyKey: kubernetes.io/hostname
  containers:
    - image: >-
        registry.redhat.io/ansible-automation-platform-25/ee-supported-rhel8@sha256:d8400a472e769d0f3d591dafaad318522009c583b08e881c23b6d57a27cc10ed
      name: worker
      args:
        - ansible-runner
        - worker
        - '--private-data-dir=/runner'
      volumeMounts:
        - name: kube-api-access
          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
          readOnly: true
  volumes:
    - name: kube-api-access
      projected:
        sources:
          - serviceAccountToken:
              path: token
              expirationSeconds: 3600
          - configMap:
              name: kube-root-ca.crt
              items:
                - key: ca.crt
                  path: ca.crt
          - downwardAPI:
              items:
                - path: namespace
                  fieldRef:
                    apiVersion: v1
                    fieldPath: metadata.namespace
          - configMap:
              name: openshift-service-ca.crt
              items:
                - key: service-ca.crt
                  path: service-ca.crt
        defaultMode: 420
```

https://github.com/innabox/cloudkit-aap/issues/49