### PR TITLE
Record AAP job id in leases

### DIFF
--- a/playbook_cloudkit_create_hosted_cluster.yml
+++ b/playbook_cloudkit_create_hosted_cluster.yml
@@ -55,6 +55,8 @@
               metadata:
                 name: "{{ cluster_order_lock_name }}"
                 namespace: "{{ cluster_working_namespace }}"
+                labels:
+                  cloudkit.openshift.io/aap-job-id: "{{ awx_job_id|default('unknown') }}"
               spec:
                 holderIdentity: "{{ cluster_order_holder_id }}"
 

--- a/roles/manage_agents/tasks/add_agents.yml
+++ b/roles/manage_agents/tasks/add_agents.yml
@@ -15,6 +15,8 @@
           metadata:
             name: "agent-{{ manage_agents_resource_class }}-lock"
             namespace: "{{ default_agent_namespace }}"
+            labels:
+              cloudkit.openshift.io/aap-job-id: "{{ awx_job_id|default('unknown') }}"
           spec:
             holderIdentity: "{{ cluster_order_holder_id }}"
       register: manage_agents_lease


### PR DESCRIPTION
We are using Kubernetes leases as a locking mechanism in a couple of
difference places. We should record the AAP job id in the lease so that if
our cleanup logic fails, we have a way to identify stale leases.
