### PR TITLE
Prevent Ansible from number-izing our labels

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/publish_templates/tasks/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/publish_templates/tasks/main.yaml
@@ -9,7 +9,7 @@
   ansible.builtin.set_fact:
     template_ids: >-
       {{
-      template_check|json_query("json.items[].id")
+      template_check | json_query("json.items[].id")
       }}
 
 - name: Update existing template

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small_github/tasks/create_template.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small_github/tasks/create_template.yaml
@@ -10,9 +10,6 @@
     name: "{{ cluster_order.metadata.name }}-admin-kubeconfig"
   register: admin_kubeconfig_secret
 
-- debug:
-    var: admin_kubeconfig_secret
-
 - name: Extract kubeconfig
   ansible.builtin.set_fact:
     admin_kubeconfig: "{{ admin_kubeconfig_secret.resources[0].data.kubeconfig | b64decode | from_yaml }}"

--- a/playbook_cloudkit_create_hosted_cluster.yml
+++ b/playbook_cloudkit_create_hosted_cluster.yml
@@ -56,7 +56,7 @@
                 name: "{{ cluster_order_lock_name }}"
                 namespace: "{{ cluster_working_namespace }}"
                 labels:
-                  cloudkit.openshift.io/aap-job-id: "{{ awx_job_id|default('unknown') }}"
+                  cloudkit.openshift.io/aap-job-id: "job-{{ awx_job_id | default('unknown') }}"
               spec:
                 holderIdentity: "{{ cluster_order_holder_id }}"
 

--- a/roles/hosted_cluster/tasks/main.yml
+++ b/roles/hosted_cluster/tasks/main.yml
@@ -12,7 +12,7 @@
       data:
         .dockerconfigjson: "{{ hosted_cluster_settings.pull_secret | to_json | b64encode }}"
       type: kubernetes.io/dockerconfigjson
-# no_log: true
+  no_log: true
 
 - name: Manage Secret resource containing ssh-key
   kubernetes.core.k8s:

--- a/roles/manage_agents/tasks/add_agents.yml
+++ b/roles/manage_agents/tasks/add_agents.yml
@@ -16,7 +16,7 @@
             name: "agent-{{ manage_agents_resource_class }}-lock"
             namespace: "{{ default_agent_namespace }}"
             labels:
-              cloudkit.openshift.io/aap-job-id: "{{ awx_job_id|default('unknown') }}"
+              cloudkit.openshift.io/aap-job-id: "job-{{ awx_job_id | default('unknown') }}"
           spec:
             holderIdentity: "{{ cluster_order_holder_id }}"
       register: manage_agents_lease


### PR DESCRIPTION
Ansible is unhelpfully converting a string into a number. We're asking for
this:

    labels:
      cloudkit.openshift.io/aap-job-id: "{{ awx_job_id|default('unknown') }}"

And Ansible is producing something like this:

    labels:
      cloudkit.openshift.io/aap-job-id: 1234

Which fails because label values can only be strings. We can prevent this
behavior by ensuring that the label value cannot be interpreted as a
number:

    labels:
      cloudkit.openshift.io/aap-job-id: "job-{{ awx_job_id|default('unknown') }}"

