### PR TITLE
fix manage_agents_cluster_order_name expansion

### DIFF
--- a/roles/hosted_cluster/defaults/main.yml
+++ b/roles/hosted_cluster/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 hosted_cluster_base_domain: box.massopen.cloud
 hosted_cluster_default_agent_namespace: "hardware-inventory"
-hosted_cluster_default_cluster_order_label:
-  "{{ cluster_order_label }}": "{{ hosted_cluster_name }}"
+hosted_cluster_default_cluster_order_label: "{{ {cluster_order_label: hosted_cluster_name} }}"


### PR DESCRIPTION
It is not valid to use a template as a dictionnary key:
https://github.com/ansible/ansible/issues/17324#issuecomment-685102595.
