### PR TITLE
Resolve publish job failures

### DIFF
--- a/collections/ansible_collections/cloudkit/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/cloudkit/service/plugins/filter/find_template_roles.py
@@ -151,8 +151,8 @@ class TemplateParameter(Base):
 class NodeRequest(Base):
     """NodeRequest represents the bare metal resources requested for a cluster"""
 
-    resource_class: str
-    number_of_nodes: int
+    resource_class: str = pydantic.Field(..., validation_alias="resourceClass")
+    number_of_nodes: int = pydantic.Field(..., validation_alias="numberOfNodes")
 
 
 class Metadata(Base):

--- a/collections/ansible_collections/cloudkit/service/roles/enumerate_templates/defaults/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/enumerate_templates/defaults/main.yaml
@@ -1,0 +1,2 @@
+cloudkit_template_collections:
+- cloudkit.templates


### PR DESCRIPTION
Due to recent changes in our playbooks, we need to set validation aliases
on the fields in the NodeRequest class.

And while we're at it, we set a sane default value for
`cloudkit_template_collections`.
