### PR TITLE
Ignore duplicate port forwarding errors

### DIFF
--- a/roles/external_access/tasks/create_external_access.yaml
+++ b/roles/external_access/tasks/create_external_access.yaml
@@ -109,6 +109,13 @@
       --internal-ip-network "{{ external_access_ingress_internal_network }}"
       -p 80 -p 443 -d "{{ external_access_name }}-ingress" -f json
 
+# XXX: This is sensitive to the ordering of nodes returned by `openstack esi node network list`.
+# If we pick a different node than was originally selected, this will fail with a "duplicate port forwarding"
+# error. Ignore duplicate port forwarding errors for now.
+  register: port_fwd_result
+  failed_when: >
+    port_fwd_result.rc != 0 and "duplicate port forwarding" not in port_fwd_result.stderr
+
 - name: Create ingress dns record
   amazon.aws.route53:
     state: present

--- a/roles/manage_agents/tasks/select_and_label_new_agents.yml
+++ b/roles/manage_agents/tasks/select_and_label_new_agents.yml
@@ -57,6 +57,9 @@
         manage_agents_selected_count: >
           {{ manage_agents_desired_count | int - manage_agents_allocated.resources | length }}
 
+    - debug:
+        var: manage_agents_available
+
     - name: Add selected agents to the cluster
       kubernetes.core.k8s_json_patch:
         api_version: agent-install.openshift.io/v1beta1


### PR DESCRIPTION
Our current solution for setting up ingress port forwarding is sensitive to
the ordering of nodes. If this ordering changes (e.g., when adding a new
node to a cluster), we end up failing with duplicate port forwarding errors
because we're trying to set up forwarding for a different internal address
than the existing configuration.

This commit arranges to ignore duplicate port forwarding errors for now,
but we need a more robust solution.
