### PR TITLE
Rename arguments in hosted_cluster argument spec

### DIFF
--- a/roles/hosted_cluster/meta/argument_specs.yaml
+++ b/roles/hosted_cluster/meta/argument_specs.yaml
@@ -17,10 +17,10 @@ argument_specs:
         type: list
         elements: dict
         options:
-          number_of_nodes:
+          numberOfNodes:
             type: int
             required: true
-          resource_class:
+          resourceClass:
             type: str
             required: true
       hosted_cluster_settings:


### PR DESCRIPTION
roles/hosted_cluster/meta/argument_specs.yaml had some incorrect
parameter names, causing erroneous playbook failures.
