### PR TITLE
Configure metallb for managed cluster ingress

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/external_access/tasks/create_external_access.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/external_access/tasks/create_external_access.yaml
@@ -72,31 +72,40 @@
   retries: "{{ external_access_resource_wait_retries }}"
   delay: "{{ external_access_resource_wait_delay }}"
 
-- name: Get esi node name of an agent
+- name: Set ingress_internal_subnet_name
   ansible.builtin.set_fact:
-    external_access_worker_node_name: >-
-      {{
-      agents.resources[0].spec.hostname
-      }}
+    ingress_internal_subnet_name: "subnet-{{ external_access_name }}"
 
-- name: Get network details from esi  # noqa:no-changed-when
+- name: Get ingress internal subnet
   ansible.builtin.include_role:
-    name: massopencloud.esi.network
-    tasks_from: get_node_network_info
+    name: massopencloud.esi.l3
+    tasks_from: get_subnet
   vars:
-    node: "{{ external_access_worker_node_name }}"
-    network: "{{ external_access_ingress_internal_network }}"
+    subnet_name: "{{ ingress_internal_subnet_name }}"
 
-- name: Get worker node address
+- name: Set external_access_metallb_ingress_ip
   ansible.builtin.set_fact:
-    external_access_worker_node_ip: >-
-      {{
-        (node_network_info.stdout|from_json)[0]['Fixed IP']
-      }}
+    external_access_metallb_ingress_ip: "{{ subnet_info.cidr | ansible.utils.nthhost(-10) }}"
 
-- name: Show discovered address
-  ansible.builtin.debug:
-    msg: "Found address {{ external_access_worker_node_ip }} for node {{ external_access_worker_node_name }}"
+- name: Get managed cluster admin kubeconfig secret
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ cluster_working_namespace }}"
+    name: "{{ cluster_order.metadata.name }}-admin-kubeconfig"
+  register: managed_cluster_admin_kubeconfig_secret
+
+- name: Extract kubeconfig
+  ansible.builtin.set_fact:
+    managed_cluster_admin_kubeconfig: "{{ managed_cluster_admin_kubeconfig_secret.resources[0].data.kubeconfig | b64decode | from_yaml }}"
+
+- name: Configure metallb for ingress
+  ansible.builtin.include_role:
+    name: metallb_ingress
+    tasks_from: configure_metallb_ingress
+  vars:
+    metallb_ingress_admin_kubeconfig: "{{ managed_cluster_admin_kubeconfig }}"
+    metallb_ingress_ip: "{{ external_access_metallb_ingress_ip }}"
 
 - name: Allocate ingress floating ip
   ansible.builtin.include_role:
@@ -114,7 +123,7 @@
     name: massopencloud.esi.floating_ip
     tasks_from: create_port_forwarding
   vars:
-    internal_ip: "{{ external_access_worker_node_ip }}"
+    internal_ip: "{{ external_access_metallb_ingress_ip }}"
     floating_ip: "{{ external_access_ingress_floating_ip }}"
     internal_network: "{{ external_access_ingress_internal_network }}"
     ports:

--- a/collections/ansible_collections/cloudkit/service/roles/metallb_ingress/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/metallb_ingress/meta/argument_specs.yaml
@@ -1,0 +1,10 @@
+---
+argument_specs:
+  configure_metallb_ingress:
+    options:
+      metallb_ingress_admin_kubeconfig:
+        type: str
+        required: true
+      metallb_ingress_ip:
+        type: str
+        required: true

--- a/collections/ansible_collections/cloudkit/service/roles/metallb_ingress/tasks/configure_metallb_ingress.yml
+++ b/collections/ansible_collections/cloudkit/service/roles/metallb_ingress/tasks/configure_metallb_ingress.yml
@@ -1,0 +1,116 @@
+# this playbook follows the instructions detailed at https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/hosted_control_planes/managing-hosted-control-planes#hcp-bm-ingress_hcp-manage-bm
+
+- name: Set metallb namespace
+  ansible.builtin.set_fact:
+    metallb_namespace: metallb-system
+
+- name: Create metallb namespace
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ metallb_ingress_admin_kubeconfig }}"
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ metallb_namespace }}"
+        labels:
+          openshift.io/cluster-monitoring: "true"
+        annotations:
+          workload.openshift.io/allowed: management
+
+- name: Create metallb operator group
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ metallb_ingress_admin_kubeconfig }}"
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: metallb-operator-operatorgroup
+        namespace: "{{ metallb_namespace }}"
+
+- name: Create metallb subscription
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ metallb_ingress_admin_kubeconfig }}"
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: metallb-operator
+        namespace: "{{ metallb_namespace }}"
+      spec:
+        channel: "stable"
+        name: metallb-operator
+        source: redhat-operators
+        sourceNamespace: openshift-marketplace
+
+- name: Create metallb instance
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ metallb_ingress_admin_kubeconfig }}"
+    definition:
+      apiVersion: metallb.io/v1beta1
+      kind: MetalLB
+      metadata:
+        name: metallb
+        namespace: "{{ metallb_namespace }}"
+  register: metallb_ingress_instance
+  until: metallb_ingress_instance is successful
+  retries: 20
+  delay: 5
+
+- name: Create metallb ip address pool
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ metallb_ingress_admin_kubeconfig }}"
+    definition:
+      apiVersion: metallb.io/v1beta1
+      kind: IPAddressPool
+      metadata:
+        name: ingress-ipaddresspool
+        namespace: "{{ metallb_namespace }}"
+      spec:
+        autoAssign: false
+        addresses:
+          - "{{ metallb_ingress_ip }}-{{ metallb_ingress_ip }}"
+
+- name: Create metallb l2advertisement
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ metallb_ingress_admin_kubeconfig }}"
+    definition:
+      apiVersion: metallb.io/v1beta1
+      kind: L2Advertisement
+      metadata:
+        name: ingress-l2-advertisement
+        namespace: "{{ metallb_namespace }}"
+      spec:
+        ipAddressPools:
+          - ingress-ipaddresspool
+
+- name: Create metallb ingress service
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ metallb_ingress_admin_kubeconfig }}"
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        annotations:
+          metallb.universe.tf/address-pool: ingress-ipaddresspool
+        name: external-ingress
+        namespace: openshift-ingress
+      spec:
+        ports:
+          - name: http
+            protocol: TCP
+            port: 80
+            targetPort: 80
+          - name: https
+            protocol: TCP
+            port: 443
+            targetPort: 443
+        selector:
+          ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
+        type: LoadBalancer

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/meta/argument_specs.yaml
@@ -18,6 +18,13 @@ argument_specs:
           Name or ID of the subnet to be destroyed
         type: "str"
         required: true
+  get_subnet:
+    options:
+      subnet_name:
+        description: |
+          Name or ID of the subnet to be destroyed
+        type: "str"
+        required: true
   create_router:
     options:
       router_name:

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/get_subnet.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/get_subnet.yaml
@@ -1,0 +1,9 @@
+- name: Get subnets by name
+  openstack.cloud.subnets_info:
+    name: "{{ subnet_name }}"
+  register: subnets
+
+- name: Set subnet_info to found subnet
+  when: subnets.subnets
+  ansible.builtin.set_fact:
+    subnet_info: "{{ subnets.subnets[0] }}"


### PR DESCRIPTION
Previously, the external floating IP used to access the managed cluster's ingress service was tied to a specific worker node. This change configures metallb for managed cluster ingress, and then points the external floating IP at the metallb VIP