### PR TITLE
Create and use cluster_infra_network_name when creating cluster infra

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/cluster_infra/tasks/create_cluster_infra.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/cluster_infra/tasks/create_cluster_infra.yaml
@@ -9,6 +9,10 @@
     network_suffix: "{{ cluster_infra_name }}"
     network_state: present
 
+- name: Set cluster_infra_network_name
+  ansible.builtin.set_fact:
+    cluster_infra_network_name: "network-{{ cluster_infra_name }}"
+
 # Handle scale down **before** scale up: if we add new agents first,
 # they may not have spec.clusterDeployment.name set by the time
 # we run detach_and_unlabel_all_removed_agents, causing them to be
@@ -47,7 +51,7 @@
     tasks_from: attach_and_approve_all_new_agents
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
-    manage_agents_cluster_network: "{{ create_network_result }}"
+    manage_agents_cluster_network: "{{ cluster_infra_network_name }}"
 
 - name: Approve agents assigned to the cluster
   ansible.builtin.include_role:
@@ -55,4 +59,4 @@
     tasks_from: attach_and_approve_all_new_agents
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
-    manage_agents_cluster_network: "{{ create_network_result | default(omit) }}"
+    manage_agents_cluster_network: "{{ cluster_infra_network_name | default(omit) }}"


### PR DESCRIPTION
\This task previously used `create_network_result` for the network name; however the rest of the playbooks simply construct the network name from the cluster order. This PR changes the `create_cluster_infra` playbook to also derive the cluster network name for consistency.