### PR TITLE
Add `node_sets` field to output of Template filter model

### DIFF
--- a/collections/ansible_collections/cloudkit/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/cloudkit/service/plugins/filter/find_template_roles.py
@@ -173,9 +173,9 @@ class Template(Base):
     name: str = pydantic.Field(..., exclude=True)
     title: str | None = None
     description: str | None = None
+    node_sets: list[NodeRequest] = pydantic.Field(validation_alias="default_node_request")
 
     # Not currently supported by the API
-    default_node_request: list[NodeRequest] = pydantic.Field(..., exclude=True)
     allowed_resource_classes: list[str] | None = pydantic.Field(None, exclude=True)
 
     parameters: list[TemplateParameter]


### PR DESCRIPTION
Addresses https://github.com/innabox/issues/issues/137. 

As part of adding visibility into the default node requests for a cluster template, this change adds the `node_sets` field to the output of the Template filter model, which will be consumed by the fulfillment API when discovering cluster templates.
