### PR TITLE
Remove hardcoded namespace in container group

### DIFF
--- a/collections/ansible_collections/cloudkit/config_as_code/README.md
+++ b/collections/ansible_collections/cloudkit/config_as_code/README.md
@@ -149,7 +149,7 @@ oc apply -f aap.yml
 
 ### Apply CloudKit configuration on AAP instance
 
-#### Config-as-code configauration
+#### Config-as-code configuration
 
 Create the secrets required for the configuration of AAP:
 
@@ -169,7 +169,7 @@ oc create secret generic <your AAP organization>-<your AAP project>-config-as-co
 oc create secret generic <your AAP organization>-<your AAP project>-config-as-code-manifest-ig --from-file=license.zip=/path/to/license.zip` -n fulfillment-aap
 ```
 
-#### Fulfilment operations configuration
+#### Fulfillment operations configuration
 
 Create service account and secret required for the fulfillment operations, such
 as AWS and OpenStack credentials:

--- a/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
@@ -144,7 +144,6 @@ controller_instance_groups:  # noqa: var-naming[no-role-prefix]
       apiVersion: v1
       kind: Pod
       metadata:
-        namespace: fulfillment-aap
         labels:
           ansible_job: ''
       spec:
@@ -206,7 +205,6 @@ controller_instance_groups:  # noqa: var-naming[no-role-prefix]
       apiVersion: v1
       kind: Pod
       metadata:
-        namespace: fulfillment-aap
         labels:
           ansible_job: ''
       spec:
@@ -257,7 +255,6 @@ controller_instance_groups:  # noqa: var-naming[no-role-prefix]
       apiVersion: v1
       kind: Pod
       metadata:
-        namespace: fulfillment-aap
         labels:
           ansible_job: ''
       spec:


### PR DESCRIPTION
That way, AAP will create pods in the namespace it lives on.
