### PR TITLE
Remove hardcoded namespace and service account

### DIFF
--- a/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
@@ -284,6 +284,13 @@ controller_instance_groups:  # noqa: var-naming[no-role-prefix]
               - name: kube-api-access
                 mountPath: /var/run/secrets/kubernetes.io/serviceaccount
                 readOnly: true
+            env:
+              - name: CLOUDKIT_PUBLISH_TEMPLATES_NAMESPACE
+                fieldRef:
+                  fieldPath: metadata.namespace
+              - name: CLOUDKIT_PUBLISH_TEMPLATES_SERVICE_ACCOUNT
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
         volumes:
           - name: kube-api-access
             projected:

--- a/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
+++ b/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
@@ -1,13 +1,16 @@
 - name: Discover and publish templates to fulfillment service
   hosts: localhost
   gather_facts: false
+  vars:
+    publish_templates_service_account: "{{ lookup('env', 'CLOUDKIT_PUBLISH_TEMPLATES_SERVICE_ACCOUNT') }}"
+    publish_templates_namespace: "{{ lookup('env', 'CLOUDKIT_PUBLISH_TEMPLATES_NAMESPACE') }}"
   tasks:
-  - name: Get innabox client token
+  - name: Get client token
     ansible.builtin.command:
       cmd: >
-        oc create token controller
+        oc create token -n {{ publish_templates_namespace }}
+        {{ publish_templates_service_account }}
         --duration=10m
-        -n innabox
     register: innabox_client_token
     changed_when: false
 


### PR DESCRIPTION
The publish templates playbook had a hardcoded namespace name and service
account name. This commit replaces those with variables that get default
values from the `CLOUDKIT_PUBLISH_TEMPLATES_NAMESPACE` and
`CLOUDKIT_PUBLISH_TEMPLATES_SERVICE_ACCOUNT` environment variables.

The config-as-code roles are modified to set these environment variables
using `fieldRef` expressions [1] on the pod that runs the publish templates
job.

[1]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
