### PR TITLE
Automount service token

### DIFF
--- a/collections/ansible_collections/cloudkit/config_as_code/playbooks/vars/config.yml
+++ b/collections/ansible_collections/cloudkit/config_as_code/playbooks/vars/config.yml
@@ -1,5 +1,5 @@
 ---
-current_namespace: "{{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/namespace') }}"
+current_namespace: "{{ lookup('env', 'NAMESPACE') }}"
 aap_instance_name: "{{ lookup('env', 'AAP_INSTANCE_NAME', default='innabox-aap') }}"
 aap_hostname: "{{ lookup('env', 'AAP_HOSTNAME', default='http://' + aap_instance_name) }}"
 aap_username: "{{ lookup('env', 'AAP_USERNAME', default='admin') }}"

--- a/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
@@ -254,7 +254,6 @@ controller_instance_groups:  # noqa: var-naming[no-role-prefix]
           ansible_job: ''
       spec:
         serviceAccountName: default
-        automountServiceAccountToken: false
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
@@ -278,6 +277,10 @@ controller_instance_groups:  # noqa: var-naming[no-role-prefix]
                   name: config-as-code-ig
                   optional: true
             env:
+              - name: NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
               - name: AAP_PASSWORD
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
Commit 7f6dacbea7 expects to read the namespace from a mounted service
account token:

    current_namespace: "{{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/namespace') }}"

But the pod template for that job was explicitly setting:

    automountServiceAccountToken: false

So the job was failing:

    The 'file' lookup had an issue accessing the file
    '/var/run/secrets/kubernetes.io/serviceaccount/namespace'. file not
    found, use -vvvvv to see paths searched

This commit (a) removes the `automountServiceAccountToken: false`
directive, but also (b) just exposes the namespace as an environment
variable, since that's how we're handling pretty much everything else.
