### PR TITLE
Fix inputs to workflow_nodes module

### DIFF
--- a/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
@@ -99,11 +99,15 @@ controller_workflows:  # noqa: var-naming[no-role-prefix]
     inventory: "{{ aap_prefix }}-cluster-fulfillment"
     workflow_nodes:
       - identifier: "create-cluster"
-        unified_job_template: "{{ aap_prefix }}-create-hosted-cluster"
+        unified_job_template:
+          name: "{{ aap_prefix }}-create-hosted-cluster"
+          type: job_template
         success_nodes:
           - "post-install"
       - identifier: "post-install"
-        unified_job_template: "{{ aap_prefix }}-create-hosted-cluster-post-install"
+        unified_job_template:
+          name: "{{ aap_prefix }}-create-hosted-cluster-post-install"
+          type: job_template
 
 # Create cluster fulfillment and confg-as-code inventories. They are the same
 # for the moment, but spliting them will allow us to diverge easily in the


### PR DESCRIPTION
We were passing a string to the `unified_job_template` parameter, but
this value is supposed to be a dictionary.

Closes #100
