### PR TITLE
Fix error in controller configuration

### DIFF
--- a/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
@@ -338,8 +338,9 @@ controller_instance_groups:  # noqa: var-naming[no-role-prefix]
                   optional: true
             env:
               - name: CLOUDKIT_PUBLISH_TEMPLATES_NAMESPACE_DEFAULT
-                fieldRef:
-                  fieldPath: metadata.namespace
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
         volumes:
           - name: kube-api-access
             projected:


### PR DESCRIPTION
Our pod template was missing a `valueFrom` directive, resulting in an unset
environment variable.

Closes #103