### PR TITLE
Grant eda service account permission to execute create workflow

### DIFF
--- a/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/aap.yml
+++ b/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/aap.yml
@@ -17,3 +17,5 @@ controller_roles:  # noqa: var-naming[no-role-prefix]
     job_templates:
       - "{{ aap_prefix }}-create-hosted-cluster"
       - "{{ aap_prefix }}-delete-hosted-cluster"
+    workflows:
+      - "{{ aap_prefix }}-create-hosted-cluster-workflow"


### PR DESCRIPTION
The EDA account used by our rulebook activations did not have permissions
to execute the created-hosted-cluster-workflow workflow template. This
commit adds the appropriate permission.
