### PR TITLE
Fix role names in post install playbook

### DIFF
--- a/playbook_cloudkit_create_hosted_cluster_post_install.yml
+++ b/playbook_cloudkit_create_hosted_cluster_post_install.yml
@@ -13,7 +13,7 @@
   pre_tasks:
     - name: Extract template info
       ansible.builtin.include_role:
-        name: extract_template_info
+        name: cloudkit.service.extract_template_info
 
   tasks:
     - name: Post-install hosted cluster configuration


### PR DESCRIPTION
The playbook calls the `extract_template_info` role, but this was moved to
`cloudkit.service.extract_template_info` in c79991fe32.
