### PR TITLE
Fix cluster create workflow

### DIFF
--- a/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
@@ -102,8 +102,9 @@ controller_workflows:  # noqa: var-naming[no-role-prefix]
         unified_job_template:
           name: "{{ aap_prefix }}-create-hosted-cluster"
           type: job_template
-        success_nodes:
-          - "post-install"
+        related:
+          success_nodes:
+            - "post-install"
       - identifier: "post-install"
         unified_job_template:
           name: "{{ aap_prefix }}-create-hosted-cluster-post-install"


### PR DESCRIPTION
The syntax used for specifying dependent steps was out-of-date; this PR updates that with `related`.