### PR TITLE
Use fully qualified role name for retrieve_kubeconfig

### DIFF
--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/tasks/install.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/tasks/install.yaml
@@ -31,7 +31,7 @@
 
 - name: Retrieve kubeconfig
   ansible.builtin.include_role:
-    name: retrieve_kubeconfig
+    name: cloudkit.service.retrieve_kubeconfig
   vars:
     retrieve_kubeconfig_cluster_name: "{{ hosted_cluster_name }}"
     retrieve_kubeconfig_namespace: "{{ cluster_working_namespace }}"


### PR DESCRIPTION
We were attempting to call `retreive_kubeconfig`, but the role name is in
fact `cloudkit.service.retrieve_kubeconfig`.
