### PR TITLE
Lock failure must fail playbook

### DIFF
--- a/playbook_cloudkit_create_hosted_cluster.yml
+++ b/playbook_cloudkit_create_hosted_cluster.yml
@@ -84,10 +84,6 @@
 
       rescue:
 
-        - name: Exit due to lock failure
-          when: not lock_acquired | default(false)
-          ansible.builtin.meta: end_play
-
         # Without this, a failure in the template would show up as
         # a successful job run.
         - name: Propagate failure


### PR DESCRIPTION
Previously, we treated failure to acquire a lease as a "successful failure", but now that we're using a workflow template this doesn't make sense: this causes the post-install playbook to execute after a lock failure, which is generally the wrong thing to do.

With this commit, failure to acquire a lock results in an actual playbook failure.