### PR TITLE
Another batch of AAP fixes

### DIFF
--- a/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/cloudkit/config_as_code/roles/aap/vars/controller.yml
@@ -97,6 +97,7 @@ controller_workflows:  # noqa: var-naming[no-role-prefix]
     organization: "{{ aap_organization_name }}"
     ask_variables_on_launch: true
     inventory: "{{ aap_prefix }}-cluster-fulfillment"
+    allow_simultaneous: true
     workflow_nodes:
       - identifier: "create-cluster"
         unified_job_template:

--- a/collections/ansible_collections/cloudkit/service/roles/external_access/tasks/create_external_access.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/external_access/tasks/create_external_access.yaml
@@ -79,7 +79,7 @@
       addr: "{{ external_access_ingress_floating_ip }}"
 
 - name: Wait for DNS records
-  include_role:
+  ansible.builtin.include_role:
     name: cloudkit.service.wait_for
     tasks_from: wait_for_dns
   vars:
@@ -90,14 +90,14 @@
     - "default-router.{{ external_access_ingress_domain }}"
 
 - name: Get managed cluster admin kubeconfig secret
-  include_role:
+  ansible.builtin.include_role:
     name: cloudkit.service.retrieve_kubeconfig
   vars:
     retrieve_kubeconfig_namespace: "{{ cluster_working_namespace }}"
     retrieve_kubeconfig_cluster_name: "{{ cluster_order.metadata.name }}"
 
 - name: Wait for cluster to become ready
-  include_role:
+  ansible.builtin.include_role:
     name: cloudkit.service.wait_for
     tasks_from: wait_for_cluster
   vars:

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/tasks/delete.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/tasks/delete.yaml
@@ -24,7 +24,7 @@
   ansible.builtin.import_role:
     name: cloudkit.service.cluster_infra
   vars:
-    cluster_infra_state: present
+    cluster_infra_state: absent
     cluster_infra_name: "{{ cluster_order.metadata.name }}"
     cluster_infra_namespace: "{{ cluster_working_namespace }}"
     cluster_infra_node_requests: []

--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/create_port_forwarding.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/create_port_forwarding.yaml
@@ -5,9 +5,8 @@
       --internal-ip-network "{{ internal_network }}"
       {% for portarg in ports %}-p {{ portarg }} {% endfor %}
       -d "{{ description }}" -f json
-  # XXX: This is sensitive to the ordering of nodes returned by `openstack esi node network list`.
-  # If we pick a different node than was originally selected, this will fail with a "duplicate port forwarding"
-  # error. Ignore duplicate port forwarding errors for now.
   register: create_port_fwd_result
-  failed_when: >
-    create_port_fwd_result.rc != 0 and "duplicate port forwarding" not in create_port_fwd_result.stderr
+
+- name: Show port forwarding result
+  debug:
+    var: create_port_fwd_result

--- a/execution-environment/execution-environment.yaml
+++ b/execution-environment/execution-environment.yaml
@@ -19,6 +19,7 @@ dependencies:
     - systemd-devel
     - gcc
     - python3.12-devel
+    - git-core
 
 options:
   package_manager_path: /usr/bin/dnf

--- a/execution-environment/requirements.txt
+++ b/execution-environment/requirements.txt
@@ -277,7 +277,7 @@ python-dateutil==2.9.0.post0
     #   aiobotocore
     #   botocore
     #   kubernetes
-python-esiclient==1.3.0
+python-esiclient @ git+https://github.com/cci-moc/python-esiclient.git@b9c4d2971193b6b1c755e0dfdd22fb4eab07f7f7
     # via cloudkit-aap (../pyproject.toml)
 python-esileapclient==1.1.0
     # via cloudkit-aap (../pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,6 @@ dependencies = [
 
 [dependency-groups]
 development = ["ansible-lint>=25.2.1", "antsibull-changelog>=0.33.0"]
+
+[tool.uv.sources]
+python-esiclient = { git = "https://github.com/cci-moc/python-esiclient.git", rev = "1.4" }

--- a/uv.lock
+++ b/uv.lock
@@ -448,7 +448,7 @@ requires-dist = [
     { name = "jmespath", specifier = ">=1.0.1" },
     { name = "kubernetes", specifier = ">=32.0.1" },
     { name = "pydantic", specifier = ">=2.11.3" },
-    { name = "python-esiclient", specifier = ">=1.3.0" },
+    { name = "python-esiclient", git = "https://github.com/cci-moc/python-esiclient.git?rev=1.4" },
     { name = "python-esileapclient", specifier = ">=1.0.0" },
     { name = "python-ironicclient", specifier = ">=5.10.0" },
     { name = "python-openstackclient", specifier = ">=7.4.0" },
@@ -1396,8 +1396,8 @@ wheels = [
 
 [[package]]
 name = "python-esiclient"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+version = "1.4.0"
+source = { git = "https://github.com/cci-moc/python-esiclient.git?rev=1.4#b9c4d2971193b6b1c755e0dfdd22fb4eab07f7f7" }
 dependencies = [
     { name = "ansible-runner" },
     { name = "babel" },
@@ -1415,10 +1415,6 @@ dependencies = [
     { name = "simplejson" },
     { name = "six" },
     { name = "websocket-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/99/46/84aaccb0d2bee7e6b24511cef1a892a0b70bafa552c06101c1d85d2ba230/python_esiclient-1.3.0.tar.gz", hash = "sha256:7d1eb13e058de3d2eeef00e0dcd95f2d956817d61cadd754c4f66004c3bf8493", size = 63948, upload-time = "2025-05-19T14:02:03.182Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/f4/f19bba742e7a41808c5099bbd3b877e34508c9514693e81a4315d84be3dd/python_esiclient-1.3.0-py3-none-any.whl", hash = "sha256:6037eb6432116806005902381e012c87acca02b40034ea25992e7b5ee0f660c8", size = 86554, upload-time = "2025-05-19T14:02:02.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is today's set of cloudkit-aap changes:

- Actually tear down cluster infrastructure
- Error on duplicate port forwarding
- Enable concurrent instances of the create cluster workflow
- Update python-esiclient
- Consistently use fully qualified module names

Details in commit messages.