### PR TITLE
Add ocp_virt_vm template for OpenShift Virtualization VMs

### DIFF
--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/defaults/main.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/defaults/main.yaml
@@ -1,0 +1,27 @@
+---
+# Default VM configuration values
+
+# Default OS and Image Configuration
+default_vm_os_type: "linux"
+default_vm_image_source: "quay.io/containerdisks/fedora:latest"
+
+# Network Configuration Defaults
+default_vm_network_type: "pod"
+default_vm_expose_service: false
+default_vm_service_type: "ClusterIP"
+
+# Default service ports for common applications
+default_vm_service_ports:
+  ssh:
+    - name: "ssh"
+      port: 22
+      target_port: 22
+      protocol: "TCP"
+
+# Storage Defaults
+default_vm_storage_class: "nfs-client"  # NFS storage operator storage class
+default_additional_disks: []
+default_ssh_public_key: ""
+
+# Labels applied to all VM resources
+default_vm_labels: "{{ {vm_order_label: vm_order_name} }}"

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/meta/argument_specs.yaml
@@ -1,0 +1,54 @@
+argument_specs:
+  main:
+    options:
+      vm_order:
+        type: dict
+        required: true
+        description: VM configuration
+      template_parameters:
+        type: dict
+        description: VM configuration parameters
+        options:
+          vm_name:
+            description: >
+              Name of the virtual machine to create. If not specified,
+              will generate a random name using adjective-noun pairs.
+            type: str
+            required: false
+          vm_image_source:
+            description: >
+              Container disk image or data source for the VM root disk.
+              Can be a container image URL or PVC reference.
+            type: str
+            required: false
+            default: "quay.io/containerdisks/fedora:latest"
+          vm_os_type:
+            description: >
+              Operating system type for VM optimization and features.
+            type: str
+            required: false
+            default: "linux"
+            choices:
+              - linux
+              - windows
+          cloud_init_config:
+            description: >
+              Cloud-init configuration for VM initialization.
+              Can include user data, network config, etc.
+            type: dict
+            required: false
+          vm_network_type:
+            description: >
+              Network attachment type for the VM.
+            type: str
+            required: false
+            default: "pod"
+            choices:
+              - pod
+              - multus
+          ssh_public_key:
+            description: >
+              SSH public key to inject into the VM for remote access.
+            type: str
+            required: false
+            default: ""

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/meta/cloudkit.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/meta/cloudkit.yaml
@@ -1,0 +1,7 @@
+# Define the display name and description of the template
+title: Simple VM Template
+description: >
+  Simple VM
+
+# Specify this is a VM template (not a cluster template)
+template_type: vm

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/create.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/create.yaml
@@ -1,0 +1,162 @@
+---
+- name: Set VM facts
+  ansible.builtin.set_fact:
+    vm_name: "{{ vm_order.metadata.name }}"
+    vm_cpu_cores: "2"
+    vm_memory: "2Gi"
+    vm_disk_size: "10Gi"
+    vm_image_source: "{{ template_parameters.vm_image_source | default(default_vm_image_source) }}"
+    vm_os_type: "{{ template_parameters.vm_os_type | default(default_vm_os_type) }}"
+    storage_class: "{{ default_vm_storage_class }}"
+    vm_expose_service: "{{ default_vm_expose_service }}"
+    vm_service_type: "{{ default_vm_service_type }}"
+    vm_service_ports: "{{ default_vm_service_ports }}"
+    vm_network_type: "{{ template_parameters.vm_network_type | default(default_vm_network_type) }}"
+    ssh_public_key: "{{ template_parameters.ssh_public_key | default(default_ssh_public_key) }}"
+
+- name: Create cloud-init secret
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ vm_name }}-cloud-init"
+        namespace: "{{ vm_target_namespace }}"
+      type: Opaque
+      data:
+        userData: "{{ (template_parameters.cloud_init_config | to_nice_yaml) | b64encode }}"
+    state: present
+
+- name: Append 'docker://' if needed
+  ansible.builtin.set_fact:
+    vm_os_type: "docker://{{ vm_os_type }}"
+  when: not vm_os_type.startswith('docker://')
+
+- name: Create DataVolume for VM root disk
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: cdi.kubevirt.io/v1beta1
+      kind: DataVolume
+      metadata:
+        name: "{{ vm_name }}-root-disk"
+        namespace: "{{ vm_target_namespace }}"
+      spec:
+        source:
+          registry:
+            url: "docker://{{ vm_image_source }}"
+        pvc:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: "{{ vm_disk_size }}"
+          storageClassName: "{{ storage_class }}"
+    state: present
+
+- name: Create VirtualMachine
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: kubevirt.io/v1
+      kind: VirtualMachine
+      metadata:
+        name: "{{ vm_name }}"
+        namespace: "{{ vm_target_namespace }}"
+        labels: "{{ default_vm_labels }}"
+      spec:
+        running: true
+        template:
+          metadata:
+            labels: "{{ default_vm_labels }}"
+          spec:
+            domain:
+              cpu:
+                cores: "{{ vm_cpu_cores }}"
+              memory:
+                guest: "{{ vm_memory }}"
+              devices:
+                disks:
+                  - name: root-disk
+                    disk:
+                      bus: virtio
+                  - name: cloud-init-disk
+                    disk:
+                      bus: virtio
+                    serial: cloud-init
+                interfaces:
+                  - name: default
+                    masquerade: {}
+                rng: {}
+              features:
+                smm:
+                  enabled: true
+                acpi: {}
+                apic: {}
+                hyperv:
+                  relaxed: {}
+                  vapic: {}
+                  spinlocks:
+                    spinlocks: 8191
+            networks:
+              - name: default
+                pod: {}
+            volumes: "{{ base_volumes }}"
+    state: present
+  vars:
+    base_volumes:
+      - name: root-disk
+        dataVolume:
+          name: "{{ vm_name }}-root-disk"
+      - name: cloud-init-disk
+        cloudInitNoCloud:
+          secretRef:
+            name: "{{ vm_name }}-cloud-init"
+
+- name: Show VM Namespace and VM Name
+  debug:
+    msg: "Namespace {{ vm_target_namespace }} - Name: {{ vm_name }}"
+
+- name: Wait for VM to be ready
+  kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachine
+    name: "{{ vm_name }}"
+    namespace: "{{ vm_target_namespace }}"
+    wait: true
+    wait_condition:
+      type: Ready
+      status: "True"
+    wait_timeout: 600
+
+- name: Create VM service
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ vm_name }}-service"
+        namespace: "{{ vm_target_namespace }}"
+        labels: "{{ default_vm_labels }}"
+      spec:
+        type: "{{ vm_service_type }}"
+        selector: "{{ default_vm_labels }}"
+        ports: "{{ vm_service_ports }}"
+    state: present
+  when: vm_expose_service and vm_service_ports | length > 0
+
+- name: Get VM status
+  kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachine
+    name: "{{ vm_name }}"
+    namespace: "{{ vm_target_namespace }}"
+  register: vm_status
+
+- name: Display VM information
+  ansible.builtin.debug:
+    msg:
+      - "Virtual Machine '{{ vm_name }}' created successfully"
+      - "Namespace: {{ vm_target_namespace }}"
+      - "CPU Cores: {{ vm_cpu_cores }}"
+      - "Memory: {{ vm_memory }}"
+      - "Root Disk Size: {{ vm_disk_size }}"
+      - "Status: {{ vm_status.resources[0].status.printableStatus | default('Unknown') }}"

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/delete.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/delete.yaml
@@ -1,0 +1,71 @@
+---
+- name: Set VM facts
+  ansible.builtin.set_fact:
+    vm_name: "{{ template_parameters.vm_name }}"
+
+- name: Stop VirtualMachine
+  kubernetes.core.k8s:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachine
+    name: "{{ vm_name }}"
+    namespace: "{{ vm_target_namespace }}"
+    state: present
+    definition:
+      spec:
+        running: false
+
+- name: Wait for VM to stop
+  kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachine
+    name: "{{ vm_name }}"
+    namespace: "{{ vm_target_namespace }}"
+    wait: true
+    wait_condition:
+      type: Ready
+      status: "False"
+    wait_timeout: 300
+
+- name: Delete VirtualMachine
+  kubernetes.core.k8s:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachine
+    name: "{{ vm_name }}"
+    namespace: "{{ vm_target_namespace }}"
+    state: absent
+    wait: true
+    wait_timeout: 300
+
+- name: Delete VM service (if it exists)
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Service
+    name: "{{ vm_name }}-service"
+    namespace: "{{ vm_target_namespace }}"
+    state: absent
+
+- name: Delete root disk DataVolume
+  kubernetes.core.k8s:
+    api_version: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    name: "{{ vm_name }}-root-disk"
+    namespace: "{{ vm_target_namespace }}"
+    state: absent
+    wait: true
+    wait_timeout: 300
+
+- name: Delete cloud-init secret
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Secret
+    name: "{{ vm_name }}-cloud-init"
+    namespace: "{{ vm_target_namespace }}"
+    state: absent
+  ignore_errors: true
+
+- name: Display deletion status
+  ansible.builtin.debug:
+    msg:
+      - "Virtual Machine '{{ vm_name }}' deletion completed"
+      - "Namespace: {{ vm_target_namespace }}"
+      - "All associated resources have been removed"

--- a/group_vars/all/vmaas_common_labels.yaml
+++ b/group_vars/all/vmaas_common_labels.yaml
@@ -1,1 +1,2 @@
+vm_order_label: "cloudkit.openshift.io/virtualmachine"
 vm_settings_cloudkit_finalizer: "cloudkit-aap.openshift.io/finalizer"


### PR DESCRIPTION
## Summary
- Add new VM template for provisioning virtual machines on OpenShift using the Virtualization operator
- Template supports configurable CPU, memory, and storage resources
- Includes create and delete task workflows for VM lifecycle management
