### PR TITLE
Fix cluster scale down when resource class is completely removed

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/cluster_infra/tasks/create_cluster_infra.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/cluster_infra/tasks/create_cluster_infra.yaml
@@ -19,6 +19,37 @@
 # we run detach_and_unlabel_all_removed_agents, causing them to be
 # erroneously detached.
 
+- name: Retrieve all currently allocated node pools
+  kubernetes.core.k8s_info:
+    api_version: hypershift.openshift.io/v1beta1
+    kind: NodePool
+    namespace: "{{ cluster_working_namespace }}"
+  register: current_node_pools
+
+- name: Set resource classes included in the request
+  ansible.builtin.set_fact:
+    requested_resource_classes: >
+      {{ cluster_infra_node_requests | map(attribute='resourceClass') }}
+
+- name: Determine which resource classes are no longer needed
+  ansible.builtin.set_fact:
+    removed_resource_classes: "{{ removed_resource_classes | default([]) + [item.metadata.labels[esi_agent_resource_class_label]] }}"
+  with_items: "{{ current_node_pools.resources }}"
+  when: item.metadata.labels[esi_agent_resource_class_label] not in requested_resource_classes
+
+- name: Display additional resource classes to be removed
+  ansible.builtin.debug:
+    msg: "The following resource classes are no longer requested: {{ removed_resource_classes | default([]) }}"
+
+- name: Initialize updated cluster infra node requests that will include removed resource classes
+  ansible.builtin.set_fact:
+    updated_cluster_infra_node_requests: "{{ cluster_infra_node_requests }}"
+
+- name: Add removed resource classes to updated cluster infra node requests
+  ansible.builtin.set_fact:
+    updated_cluster_infra_node_requests: "{{ updated_cluster_infra_node_requests + [{'numberOfNodes': '0', 'resourceClass': item}] }}"
+  with_items: "{{ removed_resource_classes | default([]) }}"
+
 - name: Wait for the Agents to be removed from the cluster
   ansible.builtin.include_role:
     name: manage_agents
@@ -27,7 +58,7 @@
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
     manage_agents_desired_count: "{{ item.numberOfNodes | int }}"
     manage_agents_resource_class: "{{ item.resourceClass }}"
-  loop: "{{ cluster_infra_node_requests }}"
+  loop: "{{ updated_cluster_infra_node_requests }}"
 
 - name: Detach agents from cluster
   ansible.builtin.include_role:

--- a/collections/ansible_collections/cloudkit/service/roles/hosted_cluster/tasks/create_hosted_cluster.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/hosted_cluster/tasks/create_hosted_cluster.yaml
@@ -77,6 +77,10 @@
         infrastructureAvailabilityPolicy: HighlyAvailable
         olmCatalogPlacement: management
 
+- name: Set nodepool prefix
+  ansible.builtin.set_fact:
+    nodepool_prefix: "nodepool-{{ hosted_cluster_name }}"
+
 - name: Create NodePool resources
   kubernetes.core.k8s:
     state: present
@@ -84,9 +88,9 @@
       apiVersion: hypershift.openshift.io/v1beta1
       kind: NodePool
       metadata:
-        name: "nodepool-{{ hosted_cluster_name }}-{{ item.resourceClass }}"
+        name: "{{ nodepool_prefix }}-{{ item.resourceClass }}"
         namespace: "{{ hosted_cluster_namespace }}"
-        labels: "{{ hosted_cluster_default_cluster_order_label }}"
+        labels: "{{ {esi_agent_resource_class_label: item.resourceClass} | combine(hosted_cluster_default_cluster_order_label) }}"
       spec:
         clusterName: "{{ hosted_cluster_name }}"
         replicas: "{{ item.numberOfNodes | int }}"
@@ -103,3 +107,41 @@
   loop: "{{ hosted_cluster_node_requests }}"
   loop_control:
     label: "Create NodePool nodepool-{{ hosted_cluster_name }}-{{ item.resourceClass }}"
+
+- name: Remove node pools matching resource classes that are no longer requested
+  block:
+    - name: Set requested resource classes
+      ansible.builtin.set_fact:
+        hosted_cluster_requested_resource_classes: "{{ hosted_cluster_node_requests | map(attribute='resourceClass') }}"
+
+    - name: Retrieve all currently allocated nodepools
+      kubernetes.core.k8s_info:
+        api_version: hypershift.openshift.io/v1beta1
+        kind: NodePool
+        namespace: "{{ hosted_cluster_namespace }}"
+      register: hosted_cluster_nodepools
+
+    - name: Determine which resource classes are no longer needed
+      ansible.builtin.set_fact:
+        hosted_cluster_removed_resource_classes: "{{ hosted_cluster_removed_resource_classes | default([]) + [item.metadata.labels[esi_agent_resource_class_label]] }}"
+      with_items: "{{ hosted_cluster_nodepools.resources }}"
+      when: item.metadata.labels[esi_agent_resource_class_label] not in hosted_cluster_requested_resource_classes
+
+    - name: Set nodepools to be removed
+      ansible.builtin.set_fact:
+        hosted_cluster_removed_nodepools: "{{ hosted_cluster_removed_resource_classes | default([]) | map('regex_replace', '^', nodepool_prefix + '-') }}"
+
+    - name: Display resource classes to be removed
+      ansible.builtin.debug:
+        msg: "The following NodePools are no longer needed and will be removed: {{ hosted_cluster_removed_nodepools }}"
+
+    - name: Delete NodePool resources
+      kubernetes.core.k8s:
+        state: absent
+        api_version: hypershift.openshift.io/v1beta1
+        kind: NodePool
+        namespace: "{{ hosted_cluster_namespace }}"
+        name: "{{ item }}"
+      loop: "{{ hosted_cluster_removed_nodepools }}"
+      loop_control:
+        label: "Delete NodePool {{ item }}"

--- a/collections/ansible_collections/cloudkit/service/roles/hosted_cluster/tasks/delete_hosted_cluster.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/hosted_cluster/tasks/delete_hosted_cluster.yaml
@@ -26,7 +26,7 @@
   kubernetes.core.k8s:
     state: absent
     api_version: hypershift.openshift.io/v1beta1
-    kind: HostedCluster
+    kind: NodePool
     namespace: "{{ hosted_cluster_namespace }}"
     name: "nodepool-{{ hosted_cluster_name }}-{{ item.resourceClass }}"
   loop: "{{ hosted_cluster_node_requests }}"


### PR DESCRIPTION
The cluster scaledown playbook did not work when a resource class was completely removed, as it only iterated over the resource classes in the incoming request. This PR fixes that by doing the following:

* updating NodePool creation to include a resource class label
* changing the scaledown playbook to
  * compare existing NodePool resource classes against the resource classes in the request
  * updating the node request array to include a 0-count entry for the unneeded resource classes