### PR TITLE
Disable all rulebook activations before running AAP configuration

### DIFF
--- a/collections/ansible_collections/cloudkit/config_as_code/roles/aap/tasks/main.yml
+++ b/collections/ansible_collections/cloudkit/config_as_code/roles/aap/tasks/main.yml
@@ -3,6 +3,20 @@
   ansible.builtin.include_vars:
     dir: vars/
 
+- name: Disable rulebook activations in configuration
+  ansible.builtin.set_fact:
+    rulebook_activations_disabled: >
+      {{ rulebook_activations_disabled | default([]) + [item | combine({'state': 'disabled'})] }}
+  loop: "{{ eda_rulebook_activations }}"
+
+- name: Disable rulebook activations
+  ansible.builtin.include_role:
+    name: infra.aap_configuration.eda_rulebook_activations
+    apply:
+      ignore_errors: true  # rulebook activations may not be present yet
+  vars:
+    eda_rulebook_activations: "{{ rulebook_activations_disabled }}"
+
 - name: Cloudkit AAP
   ansible.builtin.include_role:
     name: infra.aap_configuration.dispatch


### PR DESCRIPTION
Existing rulebook activations can't be configured when they are already
enabled. This change disables them before running the configuration,
rulebook activations will be enabled after the configuration is
performed.

Fixes #128
