### PR TITLE
Support retries when acquiring a lease

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/lease/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/lease/meta/argument_specs.yaml
@@ -1,11 +1,21 @@
 argument_specs:
   main:
     options:
+      lease_state:
+        type: str
+        required: true
+        choices:
+          - absent
+          - present
       lease_name:
         type: str
         required: true
       lease_holder:
         type: str
         required: true
-      lease_labels:
-        type: dict
+      lease_retries:
+        type: int
+        default: 0
+      lease_delay:
+        type: int
+        default: 1

--- a/collections/ansible_collections/cloudkit/service/roles/lease/tasks/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/lease/tasks/main.yaml
@@ -23,6 +23,10 @@
           cloudkit.openshift.io/aap-job-id: "job-{{ awx_job_id | default('unknown') }}"
       spec:
         holderIdentity: "{{ lease_holder }}"
+  register: lease_object
+  until: lease_object is successful
+  retries: "{{ lease_retries|default(0) }}"
+  delay: "{{ lease_delay|default(1) }}"
 
 - name: "Delete lock {{ lease_name }}"
   when: lease_state == "absent"

--- a/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/select_and_label_new_agents.yml
+++ b/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/select_and_label_new_agents.yml
@@ -21,10 +21,8 @@
         lease_state: present
         lease_name: "agent-{{ manage_agents_resource_class }}-lock"
         lease_holder: "{{ cluster_order_holder_id }}"
-      register: manage_agents_lease
-      until: manage_agents_lease is successful
-      retries: 20
-      delay: 5
+        lease_retries: 20
+        lease_delay: 5
 
     - name: Retrieve the list of available agents with a matching machine resource class
       kubernetes.core.k8s_info:


### PR DESCRIPTION
In #142, we converted the manage_agents role to using the new
cloudkit.service.lease role, but while you can loop over an `include_role`
task with `loop`, you cannot use a until/retries loop.

This commit moves the retry loop into the lease role, with a default
"retries" value of 0, and adds a new "lease_retries" parameter to the role.

