### PR TITLE
Add a role to manage finalizers

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/finalizer/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/finalizer/meta/argument_specs.yaml
@@ -1,0 +1,28 @@
+argument_specs:
+  main:
+    options:
+      finalizer_state:
+        type: str
+        required: true
+        choices:
+          - absent
+          - present
+      finalizer_name:
+        type: str
+        required: true
+      finalizer_target:
+        type: dict
+        required: true
+        options:
+          api_version:
+            type: str
+            required: true
+          kind:
+            type: str
+            required: true
+          namespace:
+            type: str
+            required: true
+          name:
+            type: str
+            required: true

--- a/collections/ansible_collections/cloudkit/service/roles/finalizer/tasks/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/finalizer/tasks/main.yaml
@@ -1,0 +1,38 @@
+- name: Look up finalizer target
+  kubernetes.core.k8s_info:
+    api_version: "{{ finalizer_target.api_version }}"
+    kind: "{{ finalizer_target.kind }}"
+    namespace: "{{ finalizer_target.namespace }}"
+    name: "{{ finalizer_target.name }}"
+  register: finalizer_resources
+
+- name: Set finalizer_target_resource variable
+  ansible.builtin.set_fact:
+    finalizer_target_resource: "{{ finalizer_resources.resources|first }}"
+
+- name: "Add finalizer to {{ finalizer_target.kind }}/{{ finalizer_target.name }}"
+  when: finalizer_state == "present"
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: "{{ finalizer_target.api_version }}"
+      kind: "{{ finalizer_target.kind }}"
+      metadata:
+        namespace: "{{ finalizer_target.namespace }}"
+        name: "{{ finalizer_target.name }}"
+        finalizers: "{{ (finalizer_target_resource.metadata.finalizers | default([])) | union([finalizer_name]) }}"
+
+- name: "Remove finalizer from {{ finalizer_target.kind }}/{{ finalizer_target.name }}"
+  when: finalizer_state == "absent"
+  kubernetes.core.k8s:
+    state: present
+    apply: true
+    definition:
+      apiVersion: "{{ finalizer_target.api_version }}"
+      kind: "{{ finalizer_target.kind }}"
+      metadata:
+        namespace: "{{ finalizer_target.namespace }}"
+        name: "{{ finalizer_target.name }}"
+        finalizers: "{{ finalizer_list | default(none, true) }}"
+  vars:
+    finalizer_list: "{{ (finalizer_target_resource.metadata.finalizers | default([])) | difference([finalizer_name]) }}"


### PR DESCRIPTION
Add a utility role to properly manage finalizers. This is necessary because
a simple JSON patch approach won't always work; code like this...

      kubernetes.core.k8s_json_patch:
        ...
        patch:
          - op: add
            path: /metadata/finalizers/0
            value: some-finalizer

...will fail with an HTTP 422 "Unprocessable Entity" error if there are no
existing finalizers, because you cannot append an item to a list that
doesn't exist.

The cloudkit.service.finalizer module will correctly handle both the
situation in which we are appending to an existing list of finalizers and the
situation in which there are no existing finalizers.

Part of: [#239](https://github.com/innabox/issues/issues/239)
