### PR TITLE
Update vm playbooks to use cloudkit.service.finalizer role

### DIFF
--- a/playbook_cloudkit_create_vm.yml
+++ b/playbook_cloudkit_create_vm.yml
@@ -32,15 +32,16 @@
           - "Template ID: {{ template_id }}"
 
     - name: "Set the finalizer on the Cloudkit VM  {{ vm_order.metadata.name }}"
-      kubernetes.core.k8s_json_patch:
-        kind: VirtualMachine
-        namespace: "{{ vm_order.metadata.namespace }}"
-        name: "{{ vm_order.metadata.name }}"
-        api_version: cloudkit.openshift.io/v1alpha1
-        patch:
-          - op: add
-            path: /metadata/finalizers/0
-            value: "{{ vm_settings_cloudkit_finalizer }}"
+      ansible.builtin.include_role:
+        name: cloudkit.service.finalizer
+      vars:
+        finalizer_state: present
+        finalizer_name: "{{ vm_settings_cloudkit_finalizer }}"
+        finalizer_target:
+          api_version: cloudkit.openshift.io/v1alpha1
+          kind: VirtualMachine
+          namespace: "{{ vm_order.metadata.namespace }}"
+          name: "{{ vm_order.metadata.name }}"
 
     - name: Call the selected VM template
       ansible.builtin.include_role:

--- a/playbook_cloudkit_delete_vm.yml
+++ b/playbook_cloudkit_delete_vm.yml
@@ -44,13 +44,14 @@
           vm_name: "{{ vm_order_name }}"
           vm_namespace: "{{ vm_target_namespace }}"
 
-    - name: "Remove the finalizer on the Cloudkit VM {{ vm_order.metadata.name }}"
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: cloudkit.openshift.io/v1alpha1
+    - name: "Remove the finalizer on the Cloudkit VM  {{ vm_order.metadata.name }}"
+      ansible.builtin.include_role:
+        name: cloudkit.service.finalizer
+      vars:
+        finalizer_state: absent
+        finalizer_name: "{{ vm_settings_cloudkit_finalizer }}"
+        finalizer_target:
+          api_version: cloudkit.openshift.io/v1alpha1
           kind: VirtualMachine
-          metadata:
-            namespace: "{{ vm_order.metadata.namespace }}"
-            name: "{{ vm_order.metadata.name }}"
-            finalizers: "{{ (vm_order.metadata.finalizers | default([])) | difference([vm_settings_cloudkit_finalizer]) }}"
+          namespace: "{{ vm_order.metadata.namespace }}"
+          name: "{{ vm_order.metadata.name }}"


### PR DESCRIPTION
In #145 we introduced a role to manage finalizers. This commit updates the
playbook_cloudkit_create_vm.yml and playbook_cloudkit_delete_vm.yml
playbooks to use the cloudkit.service.finalizer role.
