### PR TITLE
Add finalizer to clusterorder for infra cleanup

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/finalizer/tasks/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/finalizer/tasks/main.yaml
@@ -10,7 +10,7 @@
   ansible.builtin.set_fact:
     finalizer_target_resource: "{{ finalizer_resources.resources|first }}"
 
-- name: "Add finalizer to {{ finalizer_target.kind }}/{{ finalizer_target.name }}"
+- name: "Add finalizer to {{ finalizer_target.kind }}/{{ finalizer_target.name }}" # noqa: name[template]
   when: finalizer_state == "present"
   kubernetes.core.k8s:
     state: present
@@ -22,7 +22,7 @@
         name: "{{ finalizer_target.name }}"
         finalizers: "{{ (finalizer_target_resource.metadata.finalizers | default([])) | union([finalizer_name]) }}"
 
-- name: "Remove finalizer from {{ finalizer_target.kind }}/{{ finalizer_target.name }}"
+- name: "Remove finalizer from {{ finalizer_target.kind }}/{{ finalizer_target.name }}" # noqa: name[template]
   when: finalizer_state == "absent"
   kubernetes.core.k8s:
     state: present

--- a/group_vars/all/cloudkit_common_labels.yaml
+++ b/group_vars/all/cloudkit_common_labels.yaml
@@ -1,2 +1,2 @@
----
 cluster_order_label: "cloudkit.openshift.io/clusterorder"
+cluster_order_infrastructure_finalizer: "cloudkit.openshift.io/infrastructure"

--- a/playbook_cloudkit_create_hosted_cluster.yml
+++ b/playbook_cloudkit_create_hosted_cluster.yml
@@ -49,10 +49,22 @@
         lease_holder: "{{ cluster_order_holder_id }}"
         lease_name: "cluster-{{ cluster_order_name }}-lock"
 
+    - name: Add infrastructure finalizer to clusterorder
+      ansible.builtin.include_role:
+        name: cloudkit.service.finalizer
+      vars:
+        finalizer_state: present
+        finalizer_name: "{{ cluster_order_infrastructure_finalizer }}"
+        finalizer_target:
+          api_version: cloudkit.openshift.io/v1alpha1
+          kind: ClusterOrder
+          namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+          name: "{{ cluster_order.metadata.name }}"
+
     - name: Display cluster order information
       ansible.builtin.debug:
         msg:
-          - "Cluster order: {{ cluster_order_name }}"
+          - "Cluster order: {{ cluster_order.metadata.name }}"
           - "Cluster working namespace: {{ cluster_working_namespace }}"
           - "Template ID: {{ template_id }}"
 

--- a/playbook_cloudkit_delete_hosted_cluster.yml
+++ b/playbook_cloudkit_delete_hosted_cluster.yml
@@ -26,3 +26,15 @@
       ansible.builtin.include_role:
         name: "{{ template_id }}"
         tasks_from: "delete"
+
+    - name: Remove infrastructure finalizer from clusterorder
+      ansible.builtin.include_role:
+        name: cloudkit.service.finalizer
+      vars:
+        finalizer_state: absent
+        finalizer_name: "{{ cluster_order_infrastructure_finalizer }}"
+        finalizer_target:
+          api_version: cloudkit.openshift.io/v1alpha1
+          kind: ClusterOrder
+          namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+          name: "{{ cluster_order.metadata.name }}"


### PR DESCRIPTION
We don't start cleaning up the ESI infrastructure until after the
HostedCluster has been destroyed. This is also what triggers the operator
to delete the ClusterOrder resource. Previously, this meant that if there
was a failure cleaning up ESI resources, we would never have a chance to
retry the delete: with the ClusterOrder deleted, the delete webhook will
never receive another notification for the cluster.

By adding a finalizer to the ClusterOrder, we ensure that it hangs around
until we have successfully completely infrastructure cleanup.

Part of: https://github.com/innabox/issues/issues/239
