### PR TITLE
Tag ESI resources for easier cleanup

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/cluster_infra/tasks/create_cluster_infra.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/cluster_infra/tasks/create_cluster_infra.yaml
@@ -8,6 +8,7 @@
   vars:
     network_suffix: "{{ cluster_infra_name }}"
     network_state: present
+    network_tags: ['o-sac', '{{ cluster_infra_name }}']
 
 - name: Set cluster_infra_network_name
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/cloudkit/service/roles/external_access/tasks/create_external_access.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/external_access/tasks/create_external_access.yaml
@@ -30,6 +30,7 @@
   vars:
     floating_ip_state: present
     floating_ip_name: "{{ external_access_name }}-api"  # noqa:var-naming[no-role-prefix]
+    floating_ip_tags: ['o-sac', '{{ external_access_name }}']
 
 - name: Set api_floating_ip
   ansible.builtin.set_fact:
@@ -53,6 +54,7 @@
   vars:
     floating_ip_state: present
     floating_ip_name: "{{ external_access_name }}-ingress"  # noqa:var-naming[no-role-prefix]
+    floating_ip_tags: ['o-sac', '{{ external_access_name }}']
 
 - name: Set external_access_ingress_floating_ip
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/defaults/main.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/defaults/main.yaml
@@ -1,1 +1,2 @@
 floating_ip_network: external
+floating_ip_tags: []

--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/meta/argument_specs.yaml
@@ -10,6 +10,11 @@ argument_specs:
       floating_ip_name:
         type: "str"
         required: true
+      floating_ip_tags:
+        description: |
+          List of tags to apply to the floating IP
+        type: "list"
+        required: false
   create_port_forwarding:
     options:
       internal_ip:

--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/allocate_floating_ip.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/allocate_floating_ip.yaml
@@ -13,8 +13,12 @@
   block:
   - name: Allocate floating ip  # noqa:no-changed-when
     ansible.builtin.command: >-
-      openstack floating ip create {{ floating_ip_network }} --description "{{ floating_ip_name }}"
-        -f json
+      openstack floating ip create {{ floating_ip_network }}
+      --description "{{ floating_ip_name }}"
+      {% for tag in floating_ip_tags %}
+      --tag "{{ tag }}"
+      {% endfor %}
+      -f json
     register: fip_cmd_raw
 
   - name: Unmarshal output from JSON

--- a/collections/ansible_collections/massopencloud/esi/roles/l2/defaults/main.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l2/defaults/main.yaml
@@ -1,1 +1,2 @@
 l2_network_mtu: 1500
+l2_network_tags: []

--- a/collections/ansible_collections/massopencloud/esi/roles/l2/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l2/meta/argument_specs.yaml
@@ -18,6 +18,11 @@ argument_specs:
           Name of network to be deleted when state is `absent`; the deletion will fail if the network name is not unique.
         type: "str"
         required: true
+      l2_network_tags:
+        description: |
+          List of tags to apply to the network
+        type: "list"
+        required: false
   set_networks_for_node:
     options:
       networks:

--- a/collections/ansible_collections/massopencloud/esi/roles/l2/tasks/create_network.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l2/tasks/create_network.yaml
@@ -11,12 +11,11 @@
 - name: Create a new network
   when: not networks.networks
   block:
-  - name: Create network
-    openstack.cloud.network:
-      name: "{{ network_name }}"
-      mtu: "{{ l2_network_mtu }}"
+  - name: Create network  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack network create {% for tag in l2_network_tags %}--tag "{{ tag }}" {% endfor %}--mtu "{{ l2_network_mtu }}" "{{ network_name }}" -f json
     register: network_cmd_result
 
   - name: Set create_network_result to new network
     ansible.builtin.set_fact:
-      create_network_result: "{{ network_cmd_result.network.id }}"
+      create_network_result: "{{ (network_cmd_result.stdout | from_json).id }}"

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/defaults/main.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/defaults/main.yaml
@@ -5,3 +5,4 @@ l3_subnet_allocation_pool_start: 192.168.50.10
 l3_subnet_allocation_pool_end: 192.168.50.200
 l3_subnet_dns_nameservers:
   - 8.8.8.8
+l3_network_tags: []

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/meta/argument_specs.yaml
@@ -11,6 +11,11 @@ argument_specs:
           Name of the subnet to be created
         type: "str"
         required: true
+      l3_network_tags:
+        description: |
+          List of tags to apply to the subnet and router
+        type: "list"
+        required: false
   destroy_subnet:
     options:
       subnet_name:

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/create_router.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/create_router.yaml
@@ -11,13 +11,24 @@
 - name: Create a new router
   when: not routers.routers
   block:
-  - name: Create router
-    openstack.cloud.router:
-      name: "{{ router_name }}"
-      network: "{{ l3_router_external_network }}"
-      interfaces: "{{ router_subnets }}"
+  - name: Create router  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack router create
+      --external-gateway "{{ l3_router_external_network }}"
+      {% for tag in l3_network_tags %}
+      --tag "{{ tag }}"
+      {% endfor %}
+      "{{ router_name }}"
+      -f json
     register: router_cmd_result
 
   - name: Set create_router_result to new router
     ansible.builtin.set_fact:
-      create_router_result: "{{ router_cmd_result.router.id }}"
+      create_router_result: "{{ (router_cmd_result.stdout | from_json).id }}"
+
+  - name: Add subnets to router  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack router add subnet "{{ router_name }}" "{{ item }}"
+    loop: "{{ router_subnets }}"
+    register: router_add_subnet_result
+    failed_when: router_add_subnet_result.rc != 0

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/create_subnet.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/create_subnet.yaml
@@ -11,17 +11,21 @@
 - name: Create a new subnet
   when: not subnets.subnets
   block:
-  - name: Create subnet
-    openstack.cloud.subnet:
-      name: "{{ subnet_name }}"
-      network: "{{ network_id }}"
-      gateway_ip: "{{ l3_subnet_gateway_ip }}"
-      cidr: "{{ l3_subnet_cidr }}"
-      dns_nameservers: "{{ l3_subnet_dns_nameservers }}"
-      allocation_pool_start: "{{ l3_subnet_allocation_pool_start }}"
-      allocation_pool_end: "{{ l3_subnet_allocation_pool_end }}"
+  - name: Create subnet  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack subnet create
+      --network "{{ network_id }}"
+      --gateway "{{ l3_subnet_gateway_ip }}"
+      --subnet-range "{{ l3_subnet_cidr }}"
+      --allocation-pool start="{{ l3_subnet_allocation_pool_start }}",end="{{ l3_subnet_allocation_pool_end }}"
+      --dns-nameserver {{ l3_subnet_dns_nameservers | join(' --dns-nameserver ') }}
+      {% for tag in l3_network_tags %}
+      --tag "{{ tag }}"
+      {% endfor %}
+      "{{ subnet_name }}"
+      -f json
     register: subnet_cmd_result
 
   - name: Set create_subnet_result to new subnet
     ansible.builtin.set_fact:
-      create_subnet_result: "{{ subnet_cmd_result.subnet.id }}"
+      create_subnet_result: "{{ (subnet_cmd_result.stdout | from_json).id }}"

--- a/collections/ansible_collections/massopencloud/esi/roles/network/defaults/main.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/defaults/main.yaml
@@ -6,3 +6,4 @@ network_l3_subnet_allocation_pool_start: 192.168.50.10
 network_l3_subnet_allocation_pool_end: 192.168.50.200
 network_l3_subnet_dns_nameservers:
   - 8.8.8.8
+network_tags: []

--- a/collections/ansible_collections/massopencloud/esi/roles/network/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/meta/argument_specs.yaml
@@ -47,6 +47,11 @@ argument_specs:
           External network used for the router.
         type: "list"
         required: false
+      network_tags:
+        description: |
+          List of tags to apply to all network resources (network, subnet, router).
+        type: "list"
+        required: false
   get_node_network_info:
     options:
       node:

--- a/collections/ansible_collections/massopencloud/esi/roles/network/tasks/create_network.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/tasks/create_network.yaml
@@ -5,6 +5,7 @@
     network_state: "present"
     network_name: "{{ 'network-' + network_suffix }}"
     l2_network_mtu: "{{ network_l2_network_mtu }}"
+    l2_network_tags: "{{ network_tags }}"
 
 - name: Create subnet
   ansible.builtin.include_role:
@@ -18,6 +19,7 @@
     l3_subnet_allocation_pool_start: "{{ network_l3_subnet_allocation_pool_start }}"
     l3_subnet_allocation_pool_end: "{{ network_l3_subnet_allocation_pool_end }}"
     l3_subnet_dns_nameservers: "{{ network_l3_subnet_dns_nameservers }}"
+    l3_network_tags: "{{ network_tags }}"
 
 - name: Create router
   ansible.builtin.include_role:
@@ -28,3 +30,4 @@
     router_subnets:
       - "{{ create_subnet_result }}"
     l3_router_external_network: "{{ network_l3_router_external_network }}"
+    l3_network_tags: "{{ network_tags }}"


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/innabox/issues/issues/209). I used the following ansible playbook to test the new changes:
```
---
- hosts: localhost
  gather_facts: false
  vars:
    test_network_suffix: "test-tagging"
    test_tags: ['o-sac', 'cluster-test']

  tasks:
    - name: Test network creation with tagging
      ansible.builtin.include_role:
        name: massopencloud.esi.network
      vars:
        network_suffix: "{{ test_network_suffix }}"
        network_state: present
        network_tags: "{{ test_tags }}"

    - name: Verify network was created with tag
      ansible.builtin.command: >-
        openstack network show "network-{{ test_network_suffix }}" -f json
      register: network_info
      changed_when: false

    - name: Display network tags
      ansible.builtin.debug:
        msg: "Network tags: {{ (network_info.stdout | from_json).tags }}"

    - name: Create floating ip
      ansible.builtin.include_role:
        name: massopencloud.esi.floating_ip
      vars:
        floating_ip_name: "{{ test_network_suffix }}-floating-ip"
        floating_ip_state: present
        floating_ip_tags: "{{ test_tags }}"

    - name: Verify floating ip was created with tag
      ansible.builtin.command: >-
        openstack floating ip show "{{ allocate_floating_ip_result }}" -f json
      register: floating_ip_info
      changed_when: false

    - name: Display floating ip tags
      ansible.builtin.debug:
        msg: "Floating ip tags: {{ (floating_ip_info.stdout | from_json).tags }}"

    - name: Delete floating ip
      ansible.builtin.command: >-
        openstack floating ip delete "{{ allocate_floating_ip_result }}"
      register: floating_ip_delete_result
      changed_when: false

    - name: Delete test network
      ansible.builtin.include_role:
        name: massopencloud.esi.network
      vars:
        network_suffix: "{{ test_network_suffix }}"
        network_state: absent
```