### PR TITLE
Update check used to see if agent is removed from a cluster

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/detach_and_unlabel_all_removed_agents.yml
+++ b/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/detach_and_unlabel_all_removed_agents.yml
@@ -11,7 +11,7 @@
 - name: List agents removed from the cluster
   ansible.builtin.set_fact:
     manage_agents_removed: >
-      {{ manage_agents_allocated.resources | selectattr('spec.clusterDeploymentName.name', 'undefined') }}
+      {{ manage_agents_allocated.resources | json_query('[?metadata.labels."agent-install.openshift.io/clusterdeployment-namespace"==``]') }}
 
 - name: Move agents to idle agents network
   ansible.builtin.include_role:

--- a/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/select_and_label_new_agents.yml
+++ b/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/select_and_label_new_agents.yml
@@ -39,7 +39,7 @@
       ansible.builtin.set_fact:
         manage_agents_available: >
           {{ manage_agents_available.resources
-          | selectattr('spec.clusterDeploymentName.name', 'undefined') }}
+          | json_query('[?metadata.labels."agent-install.openshift.io/clusterdeployment-namespace"==``]') }}
 
     - name: Count the number of agents to add to the cluster
       ansible.builtin.set_fact:

--- a/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/wait_for_agents_to_be_removed.yml
+++ b/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/wait_for_agents_to_be_removed.yml
@@ -32,7 +32,7 @@
     register: manage_agents_allocated
     until: >
       (manage_agents_allocated.resources
-      | selectattr('spec.clusterDeploymentName.name', 'undefined')
+      | json_query('[?metadata.labels."agent-install.openshift.io/clusterdeployment-namespace"==``]')
       | length) >= manage_agents_removed_count | int
-    retries: 10
+    retries: 40
     delay: 30


### PR DESCRIPTION
The previous check (seeing if `spec.clusterDeploymentName.name` is undefined) did not take into account the full agent removal workflow. The new check looks at the `agent-install.openshift.io/clusterdeployment-namespace` label, which is removed as part of the final step of the scale down workflow.