### PR TITLE
Add playbooks for adding/removing ESI nodes as agents

### DIFF
--- a/collections/ansible_collections/cloudkit/service/plugins/filter/agents.py
+++ b/collections/ansible_collections/cloudkit/service/plugins/filter/agents.py
@@ -1,0 +1,22 @@
+def mac_to_agent_name(v: list[str], agents) -> str | None:
+    """Returns the name of the agent with matching MAC address"""
+
+    target_addresses = set(v)
+    for agent in agents:
+        # Use set intersection
+        interfaces = agent.get("status", {}) \
+                          .get("inventory", {}) \
+                          .get("interfaces", [])
+        agent_addresses = {iface["macAddress"] for iface in interfaces}
+
+        if target_addresses.intersection(agent_addresses):
+            return agent['metadata']['name']
+
+    return None
+
+
+class FilterModule:
+    def filters(self):
+        return {
+            "mac_to_agent_name": mac_to_agent_name,
+        }

--- a/collections/ansible_collections/cloudkit/service/roles/manage_agents/defaults/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/manage_agents/defaults/main.yaml
@@ -1,0 +1,3 @@
+manage_agents_provisioning_network_name: provisioning
+manage_agents_namespace: hardware-inventory
+manage_agents_infraenv_name: hardware-inventory

--- a/collections/ansible_collections/cloudkit/service/roles/manage_agents/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/manage_agents/meta/argument_specs.yaml
@@ -38,3 +38,18 @@ argument_specs:
       manage_agents_cluster_order_name:
         type: str
         required: true
+  import_agents:
+    options:
+      manage_agents_node_names:
+        type: list
+        elements: str
+        required: true
+      manage_agents_idle_agents_network:
+        type: str
+        required: true
+  remove_agents:
+    options:
+      manage_agents_node_names:
+        type: list
+        elements: str
+        required: true

--- a/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/import_agents.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/import_agents.yaml
@@ -1,0 +1,131 @@
+- name: Display node names that will be added as agents
+  ansible.builtin.debug:
+    var: manage_agents_node_names
+
+- name: Get all agents
+  kubernetes.core.k8s_info:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ manage_agents_namespace }}"
+  register: initial_agents_result
+
+- name: Extract initial agents
+  ansible.builtin.set_fact:
+    initial_agents: "{{ initial_agents_result.resources }}"
+
+- name: Filter non-agent node names
+  when: initial_agents | length > 0
+  ansible.builtin.set_fact:
+    manage_agents_node_names: >-
+      {{
+        manage_agents_node_names |
+        difference(initial_agents |
+          selectattr('spec.hostname', 'defined') |
+          map(attribute='spec.hostname') |
+          list
+        )
+      }}
+
+- name: Get combined node and port info
+  ansible.builtin.include_role:
+    name: massopencloud.esi.node
+    tasks_from: get_nodes
+  vars:
+    node_filter_names: "{{ manage_agents_node_names }}"
+# set_fact: node_info_list
+
+- name: Get InfraEnv information
+  kubernetes.core.k8s_info:
+    kind: InfraEnv
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ manage_agents_namespace }}"
+    name: "{{ manage_agents_infraenv_name }}"
+  register: infraenv
+
+- name: Set discovery_url
+  ansible.builtin.set_fact:
+    discovery_url: "{{ infraenv.resources[0].status.isoDownloadURL }}"
+  when: not discovery_url|default(false)
+
+- name: Provision nodes
+  when: >-
+    node_info.ports |
+    map(attribute='address') |
+    cloudkit.service.mac_to_agent_name(initial_agents) is none
+  ansible.builtin.include_role:
+    name: massopencloud.esi.node
+    tasks_from: provision_node
+  vars:
+    node_name: "{{ node_info.name }}"
+    node_provisioning_network_name: "{{ manage_agents_provisioning_network_name }}"
+    node_discovery_url: "{{ discovery_url }}"
+    node_agent_namespace: "{{ manage_agents_namespace }}"
+    node_deploy_wait: false
+  loop: "{{ node_info_list }}"
+  loop_control:
+    loop_var: node_info
+    label: "{{ node_info.name }}"
+
+- name: Wait for nodes to register as agents
+  kubernetes.core.k8s_info:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ manage_agents_namespace }}"
+  register: current_agents
+  until: >
+    node_info.ports |
+    map(attribute='address') |
+    cloudkit.service.mac_to_agent_name(current_agents.resources) is not none
+  retries: 90
+  delay: 10
+  loop: "{{ node_info_list }}"
+  loop_control:
+    loop_var: node_info
+    label: "{{ node_info.name }}"
+
+- name: Get all agents
+  kubernetes.core.k8s_info:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ manage_agents_namespace }}"
+  register: final_agents_result
+
+- name: Extract final agents
+  ansible.builtin.set_fact:
+    final_agents: "{{ final_agents_result.resources }}"
+
+- name: Configure agent metadata for all nodes
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: agent-install.openshift.io/v1beta1
+      kind: Agent
+      metadata:
+        name: "{{ agent_metadata.name }}"
+        namespace: "{{ manage_agents_namespace }}"
+        annotations: "{{ agent_metadata.annotations }}"
+        labels: "{{ agent_metadata.labels }}"
+      spec:
+        approved: true
+        hostname: "{{ agent_metadata.hostname | lower }}"
+  loop: >-
+    {{
+      node_info_list |
+      massopencloud.esi.get_agent_metadata(final_agents)
+    }}
+  loop_control:
+    loop_var: agent_metadata
+    label: "{{ agent_metadata.name }}"
+
+- name: Move agents to idle agents network
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l2
+    tasks_from: set_networks_for_node
+  vars:
+    node: "{{ node_info.name }}"
+    networks:
+    - "{{ manage_agents_idle_agents_network }}"
+  loop: "{{ node_info_list }}"
+  loop_control:
+    loop_var: node_info
+    label: "{{ node_info.name }} -> {{ manage_agents_idle_agents_network }}"

--- a/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/remove_agents.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/manage_agents/tasks/remove_agents.yaml
@@ -1,0 +1,51 @@
+- name: Display node names that will be removed from being agents
+  ansible.builtin.debug:
+    var: manage_agents_node_names
+
+- name: Get agents
+  kubernetes.core.k8s_info:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ manage_agents_namespace }}"
+  register: agents_result
+
+- name: Extract agents
+  ansible.builtin.set_fact:
+    initial_agents: "{{ agents_result.resources }}"
+
+- name: Get node list for removal
+  ansible.builtin.include_role:
+    name: massopencloud.esi.node
+    tasks_from: get_nodes
+  vars:
+    node_filter_names: "{{ manage_agents_node_names }}"
+# set_fact: node_info_list
+
+- name: Delete agents for each node
+  kubernetes.core.k8s:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ manage_agents_namespace }}"
+    name: >-
+      {{
+        node_info.ports |
+        map(attribute='address') |
+        cloudkit.service.mac_to_agent_name(initial_agents)
+      }}
+    state: absent
+  loop: "{{ node_info_list }}"
+  loop_control:
+    loop_var: node_info
+    label: "{{ node_info.name }}"
+
+- name: Clean nodes
+  ansible.builtin.include_role:
+    name: massopencloud.esi.node
+    tasks_from: clean_node
+  vars:
+    node_name: "{{ node_info.name }}"
+    node_clean_wait: true
+  loop: "{{ node_info_list }}"
+  loop_control:
+    loop_var: node_info
+    label: "{{ node_info.name }}"

--- a/collections/ansible_collections/massopencloud/esi/plugins/filter/filters.py
+++ b/collections/ansible_collections/massopencloud/esi/plugins/filter/filters.py
@@ -1,0 +1,107 @@
+import re
+
+re_node_location = re.compile(
+        "moc-r([0-9]+)p([a-z])c([0-9]+)u([0-9]+)(-s(.*))?")
+
+
+def extract_esi_location(v: str) -> dict[str, str]:
+    mo = re_node_location.match(v.lower())
+    if not mo:
+        return {}
+
+    return {
+        "cabinet": mo.group(3),
+        "pod": mo.group(2),
+        "row": mo.group(1),
+        "slot": mo.group(6),
+        "u": mo.group(4),
+    }
+
+
+def mac_to_agent_name(v: list[str], agents) -> str | None:
+    try:
+        from ansible_collections.cloudkit.service.plugins.filter.agents \
+                import mac_to_agent_name as cloudkit_mac_to_agent_name
+
+        return cloudkit_mac_to_agent_name(v, agents)
+    except ImportError:
+        target_addresses = set(v)
+        for agent in agents:
+            # Use set intersection
+            interfaces = agent.get("status", {}) \
+                              .get("inventory", {}) \
+                              .get("interfaces", [])
+            agent_addresses = {iface["macAddress"] for iface in interfaces}
+
+            if target_addresses.intersection(agent_addresses):
+                return agent['metadata']['name']
+
+        return None
+
+
+def get_agent_metadata(node_info_list, agents):
+    agent_metadata = []
+
+    for node_info in node_info_list:
+        node_addresses = [port.get('address')
+                          for port in node_info.get('ports', [])
+                          if port.get('address')]
+        agent_name = mac_to_agent_name(node_addresses, agents)
+
+        annotations = {"esi.nerc.mghpcc.org/uuid": node_info['id']}
+
+        topology = extract_esi_location(node_info['name'])
+        topology_labels = {"topology.nerc.mghpcc.org/%s" % label: str(val)
+                           for label, val in topology.items()
+                           if val is not None}
+        resource_class_label = {
+            'esi.nerc.mghpcc.org/resource_class':
+                node_info.get('resource_class', '')
+        }
+        labels = {**topology_labels, **resource_class_label}
+
+        agent_metadata.append({
+            "name": agent_name,
+            "hostname": node_info['name'],
+            "annotations": annotations,
+            "labels": labels,
+        })
+
+    return agent_metadata
+
+
+class FilterModule:
+    def filters(self):
+        return {
+            "extract_esi_location": extract_esi_location,
+            "mac_to_agent_name": mac_to_agent_name,
+            "get_agent_metadata": get_agent_metadata,
+        }
+
+
+def test_extract_esi_location():
+    samples = {
+        "MOC-R4PAC24U35-S3A": {
+            "cabinet": "24",
+            "pod": "A",
+            "row": "4",
+            "slot": "3A",
+            "u": "35",
+        },
+        "MOC-R8PAC23U26": {
+            "cabinet": "23",
+            "pod": "A",
+            "row": "8",
+            "slot": None,
+            "u": "26",
+        },
+    }
+
+    for name, want in samples.items():
+        try:
+            have = extract_esi_location(name)
+            assert have == want
+        except AssertionError:
+            print(f"have = {have}")
+            print(f"want = {want}")
+            raise

--- a/collections/ansible_collections/massopencloud/esi/roles/node/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/node/meta/argument_specs.yaml
@@ -1,0 +1,31 @@
+argument_specs:
+  get_nodes:
+    options:
+      node_filter_names:
+        type: list
+        elements: str
+  provision_node:
+    options:
+      node_name:
+        required: true
+        type: str
+      node_provisioning_network_name:
+        required: true
+        type: str
+      node_discovery_url:
+        required: true
+        type: str
+      node_agent_namespace:
+        required: true
+        type: str
+      node_deploy_wait:
+        type: bool
+        default: true
+  clean_node:
+    options:
+      node_name:
+        required: true
+        type: str
+      node_clean_wait:
+        type: bool
+        default: true

--- a/collections/ansible_collections/massopencloud/esi/roles/node/tasks/clean_node.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/node/tasks/clean_node.yaml
@@ -1,0 +1,6 @@
+- name: Undeploy node
+  openstack.cloud.baremetal_node_action:
+    name: "{{ node_name }}"
+    state: absent
+    deploy: false
+    wait: false

--- a/collections/ansible_collections/massopencloud/esi/roles/node/tasks/get_nodes.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/node/tasks/get_nodes.yaml
@@ -1,0 +1,48 @@
+- name: Get node informations
+  openstack.cloud.baremetal_node_info:
+  register: node_info_result
+
+- name: Extract node info
+  when: >-
+    node_info_result.skipped is not defined or
+    not node_info_result.skipped
+  ansible.builtin.set_fact:
+    node_infos: "{{ node_info_result.baremetal_nodes }}"
+
+- name: Filter nodes by node_filter_names
+  ansible.builtin.set_fact:
+    node_infos: >-
+      {{
+        node_infos |
+        selectattr('name', 'in', node_filter_names)
+      }}
+
+- name: Get baremetal ports
+  openstack.cloud.baremetal_port_info:
+  register: port_info_result
+
+- name: Extract port info
+  when: >-
+    port_info_result.skipped is not defined or
+    not port_info_result.skipped
+  ansible.builtin.set_fact:
+    port_infos: "{{ port_info_result.ports }}"
+
+- name: Initialize node_info_list
+  ansible.builtin.set_fact:
+    node_info_list: []
+
+- name: Combine ports to each node info
+  ansible.builtin.set_fact:
+    node_info_list: >-
+      {{
+        node_info_list + [
+          node_info | combine({
+            'ports': port_infos | selectattr('node_id', 'equalto', node_info.id)
+          })
+        ]
+      }}
+  loop: "{{ node_infos }}"
+  loop_control:
+    loop_var: node_info
+    label: "{{ node_info.name }}"

--- a/collections/ansible_collections/massopencloud/esi/roles/node/tasks/provision_node.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/node/tasks/provision_node.yaml
@@ -1,0 +1,17 @@
+- name: Set node to provisioning network
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l2
+    tasks_from: set_networks_for_node
+  vars:
+    networks:
+      - "{{ node_provisioning_network_name }}"
+    node: "{{ node_name }}"
+
+- name: Set deploy interface, set boot image url, and deploy node
+  openstack.cloud.baremetal_node_action:
+    name: "{{ node_name }}"
+    instance_info:
+      deploy_interface: ramdisk
+      boot_iso: "{{ node_discovery_url }}"
+    deploy: true
+    wait: "{{ node_deploy_wait }}"


### PR DESCRIPTION
There is currently not an automated way to add/remove ESI nodes as agents to the hostpool. By adding these playbooks and the `massopencloud.esi.agent` role, a user can specify which ESI nodes they want to include and exclude in the hostpool.

Part of: https://github.com/innabox/issues/issues/195