### PR TITLE
Make cert-manager + http-01 issuer part of standard install

### DIFF
--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/tasks/post_install.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/tasks/post_install.yaml
@@ -1,4 +1,13 @@
 ---
+- name: Ensure openshift-operators namespace exists
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-operators
+
 - name: Create cert-manager subscription
   kubernetes.core.k8s:
     state: present
@@ -6,13 +15,14 @@
       apiVersion: operators.coreos.com/v1alpha1
       kind: Subscription
       metadata:
-          name: cert-manager
+        name: cert-manager
+        namespace: openshift-operators
       spec:
-          channel: stable
-          installPlanApproval: Automatic
-          name: cert-manager
-          source: community-operators
-          sourceNamespace: openshift-marketplace
+        channel: stable
+        installPlanApproval: Automatic
+        name: cert-manager
+        source: community-operators
+        sourceNamespace: openshift-marketplace
 
 - name: Create production issuer
   kubernetes.core.k8s:
@@ -21,28 +31,20 @@
       apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
       metadata:
-        name: letsencrypt-production-dns01
+        name: letsencrypt-production-http01
       spec:
         acme:
-          email: help@nerc.mghpcc.org
           privateKeySecretRef:
-            name: letsencrypt-production-key
-          server: https://acme-v02.api.letsencrypt.org/directory
+            name: letsencrypt-production-http01
+          server: 'https://acme-v02.api.letsencrypt.org/directory'
           solvers:
-          - dns01:
-              cnameStrategy: Follow
-              route53:
-                region: us-east-1
-                accessKeyIDSecretRef:
-                  key: AWS_ACCESS_KEY_ID
-                  name: aws-route53-credentials
-                secretAccessKeySecretRef:
-                  key: AWS_SECRET_ACCESS_KEY
-                  name: aws-route53-credentials
+            - http01:
+                ingress:
+                  class: openshift-default
   register: production_issuer_result
   until: production_issuer_result is succeeded
   retries: 30
-  delay: 10
+  delay: 30
 
 - name: Create staging issuer
   kubernetes.core.k8s:
@@ -51,25 +53,17 @@
       apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
       metadata:
-        name: letsencrypt-staging-dns01
+        name: letsencrypt-staging-http01
       spec:
         acme:
-          email: help@nerc.mghpcc.org
           privateKeySecretRef:
-            name: letsencrypt-staging-key
-          server: https://acme-staging-v02.api.letsencrypt.org/directory
+            name: letsencrypt-staging-http01
+          server: 'https://acme-staging-v02.api.letsencrypt.org/directory'
           solvers:
-          - dns01:
-              cnameStrategy: Follow
-              route53:
-                region: us-east-1
-                accessKeyIDSecretRef:
-                  key: AWS_ACCESS_KEY_ID
-                  name: aws-route53-credentials
-                secretAccessKeySecretRef:
-                  key: AWS_SECRET_ACCESS_KEY
-                  name: aws-route53-credentials
+            - http01:
+                ingress:
+                  class: openshift-default
   register: staging_issuer_result
   until: staging_issuer_result is succeeded
   retries: 30
-  delay: 10
+  delay: 30


### PR DESCRIPTION
This PR adds cert-manager,  standard and staging issuer as part of the standard ocp_4_17_small install. It is installed as part of the post_install task. 

It was tested by doing the following: 
- Deployed https://github.com/traefik/whoami application and verified that the endpoint was unreachable without an Ingress, as expected.
- Created a whoami Ingress, waited for cert-manager to issue the TLS certificates, and confirmed the endpoint became reachable as expected.
- Uninstalled the cert-manager operator and verified that the endpoint remained reachable afterward.

Closes: https://github.com/innabox/issues/issues/231