### PR TITLE
Add stale ESI resources cleanup playbooks

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/cleanup_stale_network_resources/defaults/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/cleanup_stale_network_resources/defaults/main.yaml
@@ -1,0 +1,1 @@
+cleanup_stale_network_resources_namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"

--- a/collections/ansible_collections/cloudkit/service/roles/cleanup_stale_network_resources/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/cleanup_stale_network_resources/meta/argument_specs.yaml
@@ -1,0 +1,8 @@
+argument_specs:
+  main:
+    options:
+      cleanup_stale_network_resources_namespace:
+        description: |
+          Namespace to filter network resources
+        type: str
+        required: true

--- a/collections/ansible_collections/cloudkit/service/roles/cleanup_stale_network_resources/tasks/cleanup.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/cleanup_stale_network_resources/tasks/cleanup.yaml
@@ -1,0 +1,166 @@
+---
+- name: Get all existing ClusterOrders from specified namespace
+  kubernetes.core.k8s_info:
+    api_version: cloudkit.openshift.io/v1alpha1
+    kind: ClusterOrder
+    namespace: "{{ cleanup_stale_network_resources_namespace }}"
+  register: cluster_orders
+  failed_when: false
+
+- name: Set cluster order names
+  ansible.builtin.set_fact:
+    existing_cluster_order_names: "{{ [prefix] | product(cluster_names) | map('join') }}"
+  vars:
+    prefix: "clusterorder_"
+    cluster_names: "{{ cluster_orders.resources | map(attribute='metadata.name') }}"
+
+- name: Display existing cluster names
+  ansible.builtin.debug:
+    msg: |
+      Found existing ClusterOrders: {{ existing_cluster_order_names }}
+
+# Networks
+- name: Get all networks with purpose_o-sac and instance tags
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l2
+    tasks_from: list_networks
+  vars:
+    l2_network_properties:
+      purpose: "o-sac"
+      instance: "{{ cleanup_stale_network_resources_namespace }}"
+
+- name: Get stale networks
+  ansible.builtin.set_fact:
+    cleanup_stale_network_resources_stale_networks: "{{ cleanup_stale_network_resources_stale_networks + [item] }}"
+  loop: "{{ list_networks_result | default([]) }}"
+  when:
+    - item.Tags is defined
+    - ((item.Tags | default([])) | intersect(existing_cluster_order_names)) | length == 0
+
+# Floating IPs
+- name: Get all floating IPs with o-sac and instance tags
+  ansible.builtin.include_role:
+    name: massopencloud.esi.floating_ip
+    tasks_from: list_floating_ips
+  vars:
+    floating_ip_properties:
+      purpose: "o-sac"
+      instance: "{{ cleanup_stale_network_resources_namespace }}"
+
+- name: Get stale floating IPs
+  ansible.builtin.set_fact:
+    cleanup_stale_network_resources_stale_floating_ips: "{{ cleanup_stale_network_resources_stale_floating_ips + [item] }}"
+  loop: "{{ list_floating_ips_result | default([]) }}"
+  when:
+    - item.Tags is defined
+    - ((item.Tags | default([])) | intersect(existing_cluster_order_names)) | length == 0
+
+# Routers
+- name: Get all routers with o-sac and instance tags
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l3
+    tasks_from: list_routers
+  vars:
+    l3_network_properties:
+      purpose: "o-sac"
+      instance: "{{ cleanup_stale_network_resources_namespace }}"
+
+- name: Get stale routers
+  ansible.builtin.set_fact:
+    cleanup_stale_network_resources_stale_routers: "{{ cleanup_stale_network_resources_stale_routers + [item] }}"
+  loop: "{{ list_routers_result | default([]) }}"
+  when:
+    - item.Tags is defined
+    - ((item.Tags | default([])) | intersect(existing_cluster_order_names)) | length == 0
+
+# Subnets
+- name: Get all subnets with o-sac and instance tags
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l3
+    tasks_from: list_subnets
+  vars:
+    l3_network_properties:
+      purpose: "o-sac"
+      instance: "{{ cleanup_stale_network_resources_namespace }}"
+
+- name: Get stale subnets
+  ansible.builtin.set_fact:
+    cleanup_stale_network_resources_stale_subnets: "{{ cleanup_stale_network_resources_stale_subnets + [item] }}"
+  loop: "{{ list_subnets_result | default([]) }}"
+  when:
+    - item.Tags is defined
+    - ((item.Tags | default([])) | intersect(existing_cluster_order_names)) | length == 0
+
+# Display summary
+- name: Display stale resources found
+  ansible.builtin.debug:
+    msg: |
+      Found stale resources:
+      - Networks: {{ cleanup_stale_network_resources_stale_networks | length }}
+      - Floating IPs: {{ cleanup_stale_network_resources_stale_floating_ips | length }}
+      - Routers: {{ cleanup_stale_network_resources_stale_routers | length }}
+      - Subnets: {{ cleanup_stale_network_resources_stale_subnets | length }}
+
+- name: Display stale network names
+  ansible.builtin.debug:
+    msg: "Stale network: {{ item.Name }}"
+  loop: "{{ cleanup_stale_network_resources_stale_networks }}"
+  when: cleanup_stale_network_resources_stale_networks | length > 0
+
+- name: Display stale floating IP addresses
+  ansible.builtin.debug:
+    msg: "Stale floating IP: {{ item['Floating IP Address'] }}"
+  loop: "{{ cleanup_stale_network_resources_stale_floating_ips }}"
+  when: cleanup_stale_network_resources_stale_floating_ips | length > 0
+
+- name: Display stale router names
+  ansible.builtin.debug:
+    msg: "Stale router: {{ item.Name }}"
+  loop: "{{ cleanup_stale_network_resources_stale_routers }}"
+  when: cleanup_stale_network_resources_stale_routers | length > 0
+
+- name: Display stale subnet names
+  ansible.builtin.debug:
+    msg: "Stale subnet: {{ item.Name }}"
+  loop: "{{ cleanup_stale_network_resources_stale_subnets }}"
+  when: cleanup_stale_network_resources_stale_subnets | length > 0
+
+- name: Delete stale routers
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l3
+    tasks_from: destroy_router
+  vars:
+    router_name: "{{ item.Name }}"
+  loop: "{{ cleanup_stale_network_resources_stale_routers }}"
+  loop_control:
+    label: "Router {{ item.Name }}"
+
+- name: Delete stale subnets
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l3
+    tasks_from: destroy_subnet
+  vars:
+    subnet_name: "{{ item.Name }}"
+  loop: "{{ cleanup_stale_network_resources_stale_subnets }}"
+  loop_control:
+    label: "Subnet {{ item.Name }}"
+
+- name: Delete stale networks
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l2
+    tasks_from: destroy_network
+  vars:
+    network_name: "{{ item.Name }}"
+  loop: "{{ cleanup_stale_network_resources_stale_networks }}"
+  loop_control:
+    label: "Network {{ item.Name }}"
+
+- name: Delete stale floating IPs
+  ansible.builtin.include_role:
+    name: massopencloud.esi.floating_ip
+    tasks_from: destroy_floating_ip
+  vars:
+    floating_ip_name: "{{ item.Description }}"
+  loop: "{{ cleanup_stale_network_resources_stale_floating_ips }}"
+  loop_control:
+    label: "Floating IP {{ item.Description }}"

--- a/collections/ansible_collections/cloudkit/service/roles/cleanup_stale_network_resources/tasks/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/cleanup_stale_network_resources/tasks/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: Cleanup stale network resources
+  ansible.builtin.include_tasks: cleanup.yaml

--- a/collections/ansible_collections/cloudkit/service/roles/cleanup_stale_network_resources/vars/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/cleanup_stale_network_resources/vars/main.yaml
@@ -1,0 +1,4 @@
+cleanup_stale_network_resources_stale_networks: []
+cleanup_stale_network_resources_stale_floating_ips: []
+cleanup_stale_network_resources_stale_routers: []
+cleanup_stale_network_resources_stale_subnets: []

--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/list_floating_ips.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/list_floating_ips.yaml
@@ -1,0 +1,21 @@
+- name: Convert floating IP properties to tags
+  ansible.builtin.set_fact:
+    tags_to_filter: "{{ tags_to_filter | default([]) + [item.key + '_' + item.value] }}"
+  loop: "{{ floating_ip_properties | dict2items }}"
+  when: floating_ip_properties | length > 0
+
+- name: List floating IPs with tags
+  block:
+  - name: List floating IPs  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack floating ip list
+      {% for tag in tags_to_filter %}
+      --tag "{{ tag }}"
+      {% endfor %}
+      --long
+      -f json
+    register: list_floating_ips_cmd
+
+  - name: Set list_floating_ips_result to floating IPs list
+    ansible.builtin.set_fact:
+      list_floating_ips_result: "{{ list_floating_ips_cmd.stdout | from_json }}"

--- a/collections/ansible_collections/massopencloud/esi/roles/l2/defaults/main.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l2/defaults/main.yaml
@@ -1,2 +1,3 @@
 l2_network_mtu: 1500
 l2_network_tags: []
+l2_network_properties: {}

--- a/collections/ansible_collections/massopencloud/esi/roles/l2/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l2/meta/argument_specs.yaml
@@ -35,3 +35,10 @@ argument_specs:
           Name or UUID of node
         type: "str"
         required: true
+  list_networks:
+    options:
+      l2_network_properties:
+        description: |
+          Dictionary of properties to convert to tags for filtering networks
+        type: "dict"
+        required: false

--- a/collections/ansible_collections/massopencloud/esi/roles/l2/tasks/list_networks.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l2/tasks/list_networks.yaml
@@ -1,0 +1,21 @@
+- name: Convert network properties to tags
+  ansible.builtin.set_fact:
+    tags_to_filter: "{{ tags_to_filter | default([]) + [item.key + '_' + item.value] }}"
+  loop: "{{ l2_network_properties | dict2items }}"
+  when: l2_network_properties | length > 0
+
+- name: List networks with tags
+  block:
+  - name: List networks  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack network list
+      {% for tag in tags_to_filter %}
+      --tag "{{ tag }}"
+      {% endfor %}
+      --long
+      -f json
+    register: list_networks_cmd
+
+  - name: Set list_networks_result to networks list
+    ansible.builtin.set_fact:
+      list_networks_result: "{{ list_networks_cmd.stdout | from_json }}"

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/defaults/main.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/defaults/main.yaml
@@ -6,3 +6,4 @@ l3_subnet_allocation_pool_end: 192.168.50.200
 l3_subnet_dns_nameservers:
   - 8.8.8.8
 l3_network_tags: []
+l3_network_properties: {}

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/meta/argument_specs.yaml
@@ -49,3 +49,17 @@ argument_specs:
           Name or ID of the router to be destroyed
         type: "str"
         required: true
+  list_routers:
+    options:
+      l3_network_properties:
+        description: |
+          Dictionary of properties to convert to tags for filtering routers
+        type: "dict"
+        required: false
+  list_subnets:
+    options:
+      l3_network_properties:
+        description: |
+          Dictionary of properties to convert to tags for filtering subnets
+        type: "dict"
+        required: false

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/list_routers.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/list_routers.yaml
@@ -1,0 +1,21 @@
+- name: Convert router properties to tags
+  ansible.builtin.set_fact:
+    tags_to_filter: "{{ tags_to_filter | default([]) + [item.key + '_' + item.value] }}"
+  loop: "{{ l3_network_properties | dict2items }}"
+  when: l3_network_properties | length > 0
+
+- name: List routers with tags
+  block:
+  - name: List routers  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack router list
+      {% for tag in tags_to_filter %}
+      --tag "{{ tag }}"
+      {% endfor %}
+      --long
+      -f json
+    register: list_routers_cmd
+
+  - name: Set list_routers_result to routers list
+    ansible.builtin.set_fact:
+      list_routers_result: "{{ list_routers_cmd.stdout | from_json }}"

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/list_subnets.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/list_subnets.yaml
@@ -1,0 +1,21 @@
+- name: Convert subnet properties to tags
+  ansible.builtin.set_fact:
+    tags_to_filter: "{{ tags_to_filter | default([]) + [item.key + '_' + item.value] }}"
+  loop: "{{ l3_network_properties | dict2items }}"
+  when: l3_network_properties | length > 0
+
+- name: List subnets with tags
+  block:
+  - name: List subnets  # noqa:no-changed-when
+    ansible.builtin.command: >-
+      openstack subnet list
+      {% for tag in tags_to_filter %}
+      --tag "{{ tag }}"
+      {% endfor %}
+      --long
+      -f json
+    register: list_subnets_cmd
+
+  - name: Set list_subnets_result to subnets list
+    ansible.builtin.set_fact:
+      list_subnets_result: "{{ list_subnets_cmd.stdout | from_json }}"

--- a/playbook_cloudkit_cleanup_stale_network_resources.yml
+++ b/playbook_cloudkit_cleanup_stale_network_resources.yml
@@ -1,0 +1,11 @@
+---
+- name: Cleanup stale ESI network resources
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Cleanup stale network resources
+      ansible.builtin.include_role:
+        name: cloudkit.service.cleanup_stale_network_resources
+      vars:
+        cleanup_stale_network_resources_namespace: " {{ lookup('env', 'POD_NAMESPACE') }} "


### PR DESCRIPTION
This cleanup script runs per instance to identify and remove stale network resources (networks, floating IPs, routers, subnets) that are no longer associated with existing cluster orders

- The cleanup playbook filters resources by instance and purpose tags, then removes those that don't have a tag matching an existing ClusterOrder.

This PR closes [innabox #189](https://github.com/innabox/issues/issues/189)
