### PR TITLE
Update network resources tags

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/cluster_infra/tasks/create_cluster_infra.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/cluster_infra/tasks/create_cluster_infra.yaml
@@ -8,7 +8,10 @@
   vars:
     network_suffix: "{{ cluster_infra_name }}"
     network_state: present
-    network_tags: ['o-sac', '{{ cluster_infra_name }}']
+    network_properties:
+      instance: "{{ cluster_order.metadata.namespace }}"
+      clusterorder: "{{ cluster_infra_name }}"
+      purpose: "o-sac"
 
 - name: Set cluster_infra_network_name
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/cloudkit/service/roles/external_access/tasks/create_external_access.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/external_access/tasks/create_external_access.yaml
@@ -30,7 +30,10 @@
   vars:
     floating_ip_state: present
     floating_ip_name: "{{ external_access_name }}-api"  # noqa:var-naming[no-role-prefix]
-    floating_ip_tags: ['o-sac', '{{ external_access_name }}']
+    floating_ip_properties:
+      instance: "{{ cluster_order.metadata.namespace }}"
+      clusterorder: "{{ external_access_name }}"
+      purpose: "o-sac"
 
 - name: Set api_floating_ip
   ansible.builtin.set_fact:
@@ -54,7 +57,10 @@
   vars:
     floating_ip_state: present
     floating_ip_name: "{{ external_access_name }}-ingress"  # noqa:var-naming[no-role-prefix]
-    floating_ip_tags: ['o-sac', '{{ external_access_name }}']
+    floating_ip_properties:
+      instance: "{{ cluster_order.metadata.namespace }}"
+      clusterorder: "{{ external_access_name }}"
+      purpose: "o-sac"
 
 - name: Set external_access_ingress_floating_ip
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/defaults/main.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/defaults/main.yaml
@@ -1,2 +1,3 @@
 floating_ip_network: external
 floating_ip_tags: []
+floating_ip_properties: {}

--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/meta/argument_specs.yaml
@@ -15,6 +15,11 @@ argument_specs:
           List of tags to apply to the floating IP
         type: "list"
         required: false
+      floating_ip_properties:
+        description: |
+          Dictionary of properties to convert to tags for the floating IP
+        type: "dict"
+        required: false
   create_port_forwarding:
     options:
       internal_ip:

--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/allocate_floating_ip.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/allocate_floating_ip.yaml
@@ -1,3 +1,9 @@
+- name: Convert floating IP attributes to tags
+  ansible.builtin.set_fact:
+    floating_ip_tags: "{{ floating_ip_tags + [item.key + '_' + item.value] }}"
+  loop: "{{ floating_ip_properties | dict2items }}"
+  when: floating_ip_properties | length > 0
+
 - name: Check if floating ip exists
   openstack.cloud.floating_ip_info:
     description: "{{ floating_ip_name }}"

--- a/collections/ansible_collections/massopencloud/esi/roles/network/defaults/main.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/defaults/main.yaml
@@ -7,3 +7,4 @@ network_l3_subnet_allocation_pool_end: 192.168.50.200
 network_l3_subnet_dns_nameservers:
   - 8.8.8.8
 network_tags: []
+network_properties: {}

--- a/collections/ansible_collections/massopencloud/esi/roles/network/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/meta/argument_specs.yaml
@@ -52,6 +52,11 @@ argument_specs:
           List of tags to apply to all network resources (network, subnet, router).
         type: "list"
         required: false
+      network_properties:
+        description: |
+          Dictionary of properties to convert to tags for network resources
+        type: "dict"
+        required: false
   get_node_network_info:
     options:
       node:

--- a/collections/ansible_collections/massopencloud/esi/roles/network/tasks/create_network.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/network/tasks/create_network.yaml
@@ -1,3 +1,9 @@
+- name: Convert network properties to tags
+  ansible.builtin.set_fact:
+    network_tags: "{{ network_tags + [item.key + '_' + item.value] }}"
+  loop: "{{ network_properties | dict2items }}"
+  when: network_properties | length > 0
+
 - name: Create network
   ansible.builtin.include_role:
     name: massopencloud.esi.l2


### PR DESCRIPTION
This is part of [innabox #189](https://github.com/innabox/issues/issues/189)

- CloudKit playbooks create network/floating IP resources with key-value pairs in the format:
```
{"purpose": "o-sac",
 "instance": "<instance_name>,
 "clusteroder": <cluster_order_name>}
```
- ESI playbooks convert the key value pairs to tag list `['purpose_o-sac', 'instance_<name>', 'clusterorder_<cluster order name>']` and apply to network resources