### PR TITLE
Allocate Floating IP for VM

### DIFF
--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/defaults/main.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/defaults/main.yaml
@@ -6,17 +6,15 @@ default_vm_os_type: "linux"
 default_vm_image_source: "quay.io/containerdisks/fedora:latest"
 
 # Network Configuration Defaults
+default_vm_internal_network: "hypershift"
 default_vm_network_type: "pod"
-default_vm_expose_service: false
-default_vm_service_type: "ClusterIP"
 
 # Default service ports for common applications
 default_vm_service_ports:
-  ssh:
-    - name: "ssh"
-      port: 22
-      target_port: 22
-      protocol: "TCP"
+  - name: "ssh"
+    port: 22
+    targetPort: 22
+    protocol: "TCP"
 
 # Storage Defaults
 default_vm_storage_class: "nfs-client"  # NFS storage operator storage class

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/create.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/create.yaml
@@ -8,8 +8,7 @@
     vm_image_source: "{{ template_parameters.vm_image_source | default(default_vm_image_source) }}"
     vm_os_type: "{{ template_parameters.vm_os_type | default(default_vm_os_type) }}"
     storage_class: "{{ default_vm_storage_class }}"
-    vm_expose_service: "{{ default_vm_expose_service }}"
-    vm_service_type: "{{ default_vm_service_type }}"
+    vm_internal_network: "{{ default_vm_internal_network }}"
     vm_service_ports: "{{ default_vm_service_ports }}"
     vm_network_type: "{{ template_parameters.vm_network_type | default(default_vm_network_type) }}"
     ssh_public_key: "{{ template_parameters.ssh_public_key | default(default_ssh_public_key) }}"
@@ -127,21 +126,85 @@
       status: "True"
     wait_timeout: 600
 
-- name: Create VM service
+- name: Create a floating IP to attach to VM
+  ansible.builtin.include_role:
+    name: massopencloud.esi.floating_ip
+  vars:
+    floating_ip_state: present
+    floating_ip_name: "{{ vm_name }}-floating-ip"
+    floating_ip_properties:
+      vm: "{{ vm_name }}"
+      instance: "{{ vm_order.metadata.namespace }}"
+      purpose: "o-sac"
+
+- name: Create external LoadBalancer for VM
   kubernetes.core.k8s:
+    state: present
     definition:
       apiVersion: v1
       kind: Service
       metadata:
-        name: "{{ vm_name }}-service"
+        name: "{{ vm_name }}-load-balancer"
         namespace: "{{ vm_target_namespace }}"
         labels: "{{ default_vm_labels }}"
       spec:
-        type: "{{ vm_service_type }}"
+        type: LoadBalancer
         selector: "{{ default_vm_labels }}"
         ports: "{{ vm_service_ports }}"
+
+- name: Get LoadBalancer IP
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Service
+    name: "{{ vm_name }}-load-balancer"
+    namespace: "{{ vm_target_namespace }}"
+  register: load_balancer
+  until: load_balancer.resources[0].status.loadBalancer.ingress is defined
+  retries: 30
+  delay: 10
+
+- name: Get VirtualMachine Instance to find the node
+  kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachineInstance
+    name: "{{ vm_name }}"
+    namespace: "{{ vm_target_namespace }}"
+  register: vmi_info
+
+- name: Get Node information for the VM
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Node
+    name: "{{ vmi_info.resources[0].status.nodeName }}"
+  register: node_info
+
+- name: Build port mappings list
+  ansible.builtin.set_fact:
+    port_mappings: "{{ port_mappings | default([]) + [item.port | string + ':' + item.nodePort | string] }}"
+  loop: "{{ load_balancer.resources[0].spec.ports }}"
+
+- name: Create floating IP port forwarding to VM node NodePorts
+  ansible.builtin.include_role:
+    name: massopencloud.esi.floating_ip
+    tasks_from: create_port_forwarding
+  vars:
+    internal_ip: "{{ node_info.resources[0].status.addresses | selectattr('type', 'equalto', 'InternalIP') | map(attribute='address') | first }}"
+    floating_ip: "{{ allocate_floating_ip_result }}"
+    internal_network: "{{ vm_internal_network }}"
+    ports: "{{ port_mappings }}"
+    description: "{{ vm_name }}-nodeport"
+
+- name: Annotate VirtualMachine with floating IP address
+  kubernetes.core.k8s:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachine
+    name: "{{ vm_name }}"
+    namespace: "{{ vm_target_namespace }}"
     state: present
-  when: vm_expose_service and vm_service_ports | length > 0
+    definition:
+      metadata:
+        annotations:
+          cloudkit.openshift.io/floating-ip-address: "{{ allocate_floating_ip_result }}"
 
 - name: Get VM status
   kubernetes.core.k8s_info:

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/delete.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/delete.yaml
@@ -3,6 +3,21 @@
   ansible.builtin.set_fact:
     vm_name: "{{ template_parameters.vm_name }}"
 
+- name: Get VirtualMachine info for floating IP cleanup
+  kubernetes.core.k8s_info:
+    api_version: kubevirt.io/v1
+    kind: VirtualMachine
+    name: "{{ vm_name }}"
+    namespace: "{{ vm_target_namespace }}"
+  register: vm_info
+
+- name: Delete floating IP
+  ansible.builtin.include_role:
+    name: massopencloud.esi.floating_ip
+    tasks_from: destroy_floating_ip
+  vars:
+    floating_ip_name: "{{ vm_name }}-floating-ip"
+
 - name: Stop VirtualMachine
   kubernetes.core.k8s:
     api_version: kubevirt.io/v1
@@ -41,6 +56,14 @@
     api_version: v1
     kind: Service
     name: "{{ vm_name }}-service"
+    namespace: "{{ vm_target_namespace }}"
+    state: absent
+
+- name: Delete VM load balancer service
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Service
+    name: "{{ vm_name }}-load-balancer"
     namespace: "{{ vm_target_namespace }}"
     state: absent
 


### PR DESCRIPTION
This adds the ability to ssh a floating IP allocated by OpenStack into a VM. The floating IP is automatically allocated when the playbook to create a vm is ran, and automatically removed when the playbook to delete a vm is ran. Resolves [innabox/#241](https://github.com/orgs/innabox/projects/13/views/1?pane=issue&itemId=133810235&issue=innabox%7Cissues%7C241)