### PR TITLE
Use the private API to publish templates

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/publish_templates/defaults/main.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/publish_templates/defaults/main.yaml
@@ -1,3 +1,3 @@
 ---
-publish_templates_cluster_api_endpoint: "{{ cloudkit_fulfillment_service_uri }}/api/fulfillment/v1/cluster_templates"
-publish_templates_vm_api_endpoint: "{{ cloudkit_fulfillment_service_uri }}/api/fulfillment/v1/virtual_machine_templates"
+publish_templates_cluster_api_endpoint: "{{ cloudkit_fulfillment_service_uri }}/api/private/v1/cluster_templates"
+publish_templates_vm_api_endpoint: "{{ cloudkit_fulfillment_service_uri }}/api/private/v1/virtual_machine_templates"

--- a/collections/ansible_collections/cloudkit/service/roles/publish_templates/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/service/roles/publish_templates/meta/argument_specs.yaml
@@ -16,8 +16,8 @@ argument_specs:
       publish_templates_cluster_api_endpoint:
         type: str
         description: API endpoint for cluster templates
-        default: "{{ cloudkit_fulfillment_service_uri }}/api/fulfillment/v1/cluster_templates"
+        default: "{{ cloudkit_fulfillment_service_uri }}/api/private/v1/cluster_templates"
       publish_templates_vm_api_endpoint:
         type: str
         description: API endpoint for VM templates
-        default: "{{ cloudkit_fulfillment_service_uri }}/api/fulfillment/v1/virtual_machine_templates"
+        default: "{{ cloudkit_fulfillment_service_uri }}/api/private/v1/virtual_machine_templates"


### PR DESCRIPTION
Now that the multi-tenancy logic is in place templates need to be published using the private API, as otherwise they will be assigned to the tenant of the user publishing them, and won't be usable by other users. Using the private API ensures that they are assigned to the `shared` tenant, which is visible for everyone.