### PR TITLE
Fix template enumeration to honor the 'required' parameter

### DIFF
--- a/collections/ansible_collections/cloudkit/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/cloudkit/service/plugins/filter/find_template_roles.py
@@ -115,6 +115,7 @@ class TemplateParameter(Base):
             name=name,
             title=spec.get("short_description"),
             description=spec.get("description"),
+            required=spec.get("required", False),
             default=spec.get("default"),
             type=TypeMapping[spec.get("type", "str")],
         )


### PR DESCRIPTION
This is related to [innabox #257](https://github.com/innabox/issues/issues/257). Tested the change with the following playbook:
```
- hosts: localhost
  gather_facts: false
  vars:
    cloudkit_template_collections: ['cloudkit.templates']
  tasks:
    - name: Enumerate cluster templates
      ansible.builtin.include_role:
        name: cloudkit.service.enumerate_templates

    - name: Display ocp_4_17_small template
      ansible.builtin.debug:
        msg: |
          Template: {{ item.id }}
      loop: "{{ cloudkit_cluster_templates }}"
      when: item.id == 'cloudkit.templates.ocp_4_17_small'
```
The output shows that pull_secret required is True:
```
{
    "msg": "Template: {'title': 'Simple OpenShift 4.17 Cluster', 'description': 'This template will build a minimally configured OpenShift 4.17 cluster.\\n', 'parameters': [{'name': 'pull_secret', 'description': 'The pull secret contains credentials for authenticating to image repositories.\\n', 'required': True, 'type': <ProtobufType.STRING: 'type.googleapis.com/google.protobuf.StringValue'>}, {'name': 'ssh_public_key', 'description': 'A public ssh key that will be installed into the `authorized_keys` file of the `core` user on cluster worker nodes.\\n', 'required': False, 'type': <ProtobufType.STRING: 'type.googleapis.com/google.protobuf.StringValue'>}], 'id': 'cloudkit.templates.ocp_4_17_small', 'node_sets': {'fc430': {'host_class': 'fc430', 'size': 2}}}\n"
}
```
