### PR TITLE
Tidy-up simple VM template

### DIFF
--- a/collections/ansible_collections/cloudkit/service/roles/vm_settings/tasks/main.yml
+++ b/collections/ansible_collections/cloudkit/service/roles/vm_settings/tasks/main.yml
@@ -1,9 +1,15 @@
 ---
+- name: Assert template_parameters is defined
+  ansible.builtin.assert:
+    that:
+      - template_parameters is defined
+    fail_msg: "template_parameters must be defined"
+
 - name: Display template parameters
   ansible.builtin.debug:
-    msg: "{{ vm_order.spec.templateParameters | to_nice_yaml }}"
+    var: template_parameters
 
 - name: Update template parameters in VM order
   ansible.builtin.set_fact:
-    vm_order: "{{ vm_order | combine({'spec': {'templateParameters': vm_settings_template_default | to_json}}, recursive=true) }}"
-  when: (vm_order.spec.templateParameters.cloud_init_config | default({})) | length == 0
+    template_parameters: "{{ template_parameters | combine(vm_settings_template_default, recursive=true) }}"
+  when: (template_parameters.cloud_init_config is not defined) or (template_parameters.cloud_init_config | length == 0)

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/defaults/main.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/defaults/main.yaml
@@ -1,13 +1,6 @@
 ---
-# Default VM configuration values
-
-# Default OS and Image Configuration
-default_vm_os_type: "linux"
-default_vm_image_source: "quay.io/containerdisks/fedora:latest"
-
 # Network Configuration Defaults
 default_vm_internal_network: "hypershift"
-default_vm_network_type: "pod"
 
 # Default service ports for common applications
 default_vm_service_ports:
@@ -18,8 +11,6 @@ default_vm_service_ports:
 
 # Storage Defaults
 default_vm_storage_class: "nfs-client"  # NFS storage operator storage class
-default_additional_disks: []
-default_ssh_public_key: ""
 
 # Labels applied to all VM resources
 default_vm_labels: "{{ {vm_order_label: vm_order_name} }}"

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/meta/argument_specs.yaml
@@ -9,43 +9,34 @@ argument_specs:
         type: dict
         description: VM configuration parameters
         options:
-          vm_name:
-            description: >
-              Name of the virtual machine to create. If not specified,
-              will generate a random name using adjective-noun pairs.
+          cpu_cores:
+            description: Number of CPU cores for the VM.
+            type: int
+            required: false
+            default: 2
+          memory:
+            description: Amount of memory for the VM.
             type: str
             required: false
-          vm_image_source:
+            default: 2Gi
+          disk_size:
+            description: Size of the VM root disk.
+            type: str
+            required: false
+            default: 10Gi
+          image_source:
             description: >
               Container disk image or data source for the VM root disk.
               Can be a container image URL or PVC reference.
             type: str
             required: false
             default: "quay.io/containerdisks/fedora:latest"
-          vm_os_type:
-            description: >
-              Operating system type for VM optimization and features.
-            type: str
-            required: false
-            default: "linux"
-            choices:
-              - linux
-              - windows
           cloud_init_config:
             description: >
               Cloud-init configuration for VM initialization.
               Can include user data, network config, etc.
             type: dict
             required: false
-          vm_network_type:
-            description: >
-              Network attachment type for the VM.
-            type: str
-            required: false
-            default: "pod"
-            choices:
-              - pod
-              - multus
           ssh_public_key:
             description: >
               SSH public key to inject into the VM for remote access.

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/create.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/create.yaml
@@ -2,16 +2,14 @@
 - name: Set VM facts
   ansible.builtin.set_fact:
     vm_name: "{{ vm_order.metadata.name }}"
-    vm_cpu_cores: "2"
-    vm_memory: "2Gi"
-    vm_disk_size: "10Gi"
-    vm_image_source: "{{ template_parameters.vm_image_source | default(default_vm_image_source) }}"
-    vm_os_type: "{{ template_parameters.vm_os_type | default(default_vm_os_type) }}"
+    vm_cpu_cores: "{{ template_parameters.cpu_cores }}"
+    vm_memory: "{{ template_parameters.memory }}"
+    vm_disk_size: "{{ template_parameters.disk_size }}"
+    vm_image_source: "{{ template_parameters.image_source }}"
     storage_class: "{{ default_vm_storage_class }}"
     vm_internal_network: "{{ default_vm_internal_network }}"
     vm_service_ports: "{{ default_vm_service_ports }}"
-    vm_network_type: "{{ template_parameters.vm_network_type | default(default_vm_network_type) }}"
-    ssh_public_key: "{{ template_parameters.ssh_public_key | default(default_ssh_public_key) }}"
+    ssh_public_key: "{{ template_parameters.ssh_public_key }}"
 
 - name: Create cloud-init secret
   kubernetes.core.k8s:
@@ -21,15 +19,11 @@
       metadata:
         name: "{{ vm_name }}-cloud-init"
         namespace: "{{ vm_target_namespace }}"
+        labels: "{{ default_vm_labels }}"
       type: Opaque
       data:
         userData: "{{ (template_parameters.cloud_init_config | to_nice_yaml) | b64encode }}"
     state: present
-
-- name: Append 'docker://' if needed
-  ansible.builtin.set_fact:
-    vm_os_type: "docker://{{ vm_os_type }}"
-  when: not vm_os_type.startswith('docker://')
 
 - name: Create DataVolume for VM root disk
   kubernetes.core.k8s:
@@ -39,6 +33,7 @@
       metadata:
         name: "{{ vm_name }}-root-disk"
         namespace: "{{ vm_target_namespace }}"
+        labels: "{{ default_vm_labels }}"
       spec:
         source:
           registry:

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/delete.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/delete.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Set VM facts
   ansible.builtin.set_fact:
-    vm_name: "{{ template_parameters.vm_name }}"
+    vm_name: "{{ vm_order.metadata.name }}"
 
 - name: Get VirtualMachine info for floating IP cleanup
   kubernetes.core.k8s_info:

--- a/playbook_cloudkit_create_vm.yml
+++ b/playbook_cloudkit_create_vm.yml
@@ -11,14 +11,13 @@
       ansible.builtin.set_fact:
         vm_order_name: "{{ vm_order.metadata.name }}"
 
-    - name: Apply default VM settings
-      ansible.builtin.include_role:
-        name: cloudkit.service.vm_settings
-
     - name: Extract VM template info
       ansible.builtin.include_role:
         name: cloudkit.service.extract_vm_template_info
 
+    - name: Apply default VM settings
+      ansible.builtin.include_role:
+        name: cloudkit.service.vm_settings
   tasks:
     - name: Determine working namespace
       ansible.builtin.include_role:
@@ -30,6 +29,7 @@
           - "VM order: {{ vm_order_name }}"
           - "VM target namespace: {{ vm_target_namespace }}"
           - "Template ID: {{ template_id }}"
+          - "Template parameters: {{ template_parameters }}"
 
     - name: "Set the finalizer on the Cloudkit VM  {{ vm_order.metadata.name }}"
       ansible.builtin.include_role:

--- a/playbook_cloudkit_delete_vm.yml
+++ b/playbook_cloudkit_delete_vm.yml
@@ -15,13 +15,13 @@
       ansible.builtin.debug:
         var: vm_order
 
-    - name: Apply default VM settings
-      ansible.builtin.include_role:
-        name: cloudkit.service.vm_settings
-
     - name: Extract VM template info
       ansible.builtin.include_role:
         name: cloudkit.service.extract_vm_template_info
+
+    - name: Apply default VM settings
+      ansible.builtin.include_role:
+        name: cloudkit.service.vm_settings
 
     - name: Determine target namespace
       ansible.builtin.include_role:
@@ -39,10 +39,6 @@
       ansible.builtin.include_role:
         name: "{{ template_id }}"
         tasks_from: "delete"
-      vars:
-        template_parameters:
-          vm_name: "{{ vm_order_name }}"
-          vm_namespace: "{{ vm_target_namespace }}"
 
     - name: "Remove the finalizer on the Cloudkit VM  {{ vm_order.metadata.name }}"
       ansible.builtin.include_role:


### PR DESCRIPTION
- Remove unused and not relevant variables from template parameters
- Dropped `vm_` prefix in template parameters
- Intoduce cpu cores, memory and disk size parameters
