### PR TITLE
Remove resource class restriction for ocp_4_17 templates

### DIFF
--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/meta/argument_specs.yaml
@@ -17,8 +17,6 @@ argument_specs:
           resourceClass:
             type: str
             required: true
-            choices:
-            - fc430
       template_parameters:
         type: dict
         options:

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/meta/cloudkit.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small/meta/cloudkit.yaml
@@ -13,5 +13,4 @@ default_node_request:
 # classes listed here may be used when requesting additional nodes. If this
 # list is empty or unspecified, a ClusterOrder may request nodes from any
 # available resource class.
-allowed_resource_classes:
-- fc430
+allowed_resource_classes: []

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small_github/meta/argument_specs.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small_github/meta/argument_specs.yaml
@@ -17,8 +17,6 @@ argument_specs:
           resourceClass:
             type: str
             required: true
-            choices:
-            - fc430
       template_parameters:
         type: dict
         options:

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small_github/meta/cloudkit.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_4_17_small_github/meta/cloudkit.yaml
@@ -14,5 +14,4 @@ default_node_request:
 # classes listed here may be used when requesting additional nodes. If this
 # list is empty or unspecified, a ClusterOrder may request nodes from any
 # available resource class.
-allowed_resource_classes:
-- fc430
+allowed_resource_classes: []


### PR DESCRIPTION
These templates are often used for testing; as such, it would be convenient to be able to test multiple resource classes.

The `allowed_resource_classes` parameter is set to an empty list (rather than removed) so the explanatory text above it still has a reference.