### PR TITLE
Annotate cloudkit's VM with floating IP information

### DIFF
--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/create.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/create.yaml
@@ -191,10 +191,10 @@
 
 - name: Annotate VirtualMachine with floating IP address
   kubernetes.core.k8s:
-    api_version: kubevirt.io/v1
+    api_version: cloudkit.openshift.io/v1alpha1
     kind: VirtualMachine
     name: "{{ vm_name }}"
-    namespace: "{{ vm_target_namespace }}"
+    namespace: "{{ vm_order.metadata.namespace }}"
     state: present
     definition:
       metadata:

--- a/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/delete.yaml
+++ b/collections/ansible_collections/cloudkit/templates/roles/ocp_virt_vm/tasks/delete.yaml
@@ -3,14 +3,6 @@
   ansible.builtin.set_fact:
     vm_name: "{{ vm_order.metadata.name }}"
 
-- name: Get VirtualMachine info for floating IP cleanup
-  kubernetes.core.k8s_info:
-    api_version: kubevirt.io/v1
-    kind: VirtualMachine
-    name: "{{ vm_name }}"
-    namespace: "{{ vm_target_namespace }}"
-  register: vm_info
-
 - name: Delete floating IP
   ansible.builtin.include_role:
     name: massopencloud.esi.floating_ip


### PR DESCRIPTION
This change centralizes floating ip information in cloudkit's VM
definition instead of the kubevirt one. That way, the information is not
tied to the lifecycle of kubevirt's VM, but to the global lifecycle of
creating a VM (including networking setup).

Also, the operator expect the annotation to be set on cloudkit's VM in
order to report the information to the fulfillment service.

Depends on https://github.com/innabox/cloudkit-aap/pull/163
Follow-up of https://github.com/innabox/issues/issues/241
