### PR TITLE
Refactor VM template parameters and namespace handling

### DIFF
--- a/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
+++ b/collections/ansible_collections/cloudkit/service/playbooks/publish_templates.yaml
@@ -29,6 +29,14 @@
       ansible.builtin.include_role:
         name: cloudkit.service.enumerate_templates
 
+    - name: Print cluster templates found.
+      ansible.builtin.debug:
+        var: cloudkit_cluster_templates
+
+    - name: Print vm templates found.
+      ansible.builtin.debug:
+        var: cloudkit_vm_templates
+
     - name: Publish templates
       ansible.builtin.include_role:
         name: cloudkit.service.publish_templates

--- a/collections/ansible_collections/cloudkit/service/roles/vm_working_namespace/tasks/main.yml
+++ b/collections/ansible_collections/cloudkit/service/roles/vm_working_namespace/tasks/main.yml
@@ -16,4 +16,6 @@
 
   - name: Set working vm namespace as result
     ansible.builtin.set_fact:
+      vm_working_namespace: "{{ vm_working_namespace_list.resources[0].metadata.name }}"
+      # Temporary: will be removed with template PR
       vm_target_namespace: "{{ vm_working_namespace_list.resources[0].metadata.name }}"

--- a/group_vars/all/cloudkit_common_labels.yaml
+++ b/group_vars/all/cloudkit_common_labels.yaml
@@ -1,2 +1,5 @@
 cluster_order_label: "cloudkit.openshift.io/clusterorder"
 cluster_order_infrastructure_finalizer: "cloudkit.openshift.io/infrastructure"
+
+vm_order_label: "cloudkit.openshift.io/virtualmachine"
+vm_cloudkit_finalizer: "cloudkit-aap.openshift.io/finalizer"

--- a/group_vars/all/vmaas_common_labels.yaml
+++ b/group_vars/all/vmaas_common_labels.yaml
@@ -1,2 +1,0 @@
-vm_order_label: "cloudkit.openshift.io/virtualmachine"
-vm_settings_cloudkit_finalizer: "cloudkit-aap.openshift.io/finalizer"

--- a/playbook_cloudkit_create_vm.yml
+++ b/playbook_cloudkit_create_vm.yml
@@ -5,40 +5,46 @@
 
   vars:
     vm_order: "{{ ansible_eda.event.payload }}"
+    vm_order_name: "{{ ansible_eda.event.payload.metadata.name }}"
 
   pre_tasks:
-    - name: Set VM order name
-      ansible.builtin.set_fact:
-        vm_order_name: "{{ vm_order.metadata.name }}"
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
 
+    # Brings in variables:
+    # template_id, template_parameters
     - name: Extract VM template info
       ansible.builtin.include_role:
         name: cloudkit.service.extract_vm_template_info
 
-  tasks:
+    # Brings in variables:
+    # vm_working_namespace
     - name: Determine working namespace
       ansible.builtin.include_role:
         name: cloudkit.service.vm_working_namespace
 
+  tasks:
+
     - name: Display VM order information
       ansible.builtin.debug:
         msg:
-          - "VM order: {{ vm_order_name }}"
-          - "VM target namespace: {{ vm_target_namespace }}"
+          - "VM order name: {{ vm_order_name }}"
+          - "VM working namespace: {{ vm_working_namespace }}"
           - "Template ID: {{ template_id }}"
           - "Template parameters: {{ template_parameters }}"
 
-    - name: "Set the finalizer on the Cloudkit VM  {{ vm_order.metadata.name }}"
+    - name: "Set the finalizer on the Cloudkit VM {{ vm_order_name }}"
       ansible.builtin.include_role:
         name: cloudkit.service.finalizer
       vars:
         finalizer_state: present
-        finalizer_name: "{{ vm_settings_cloudkit_finalizer }}"
+        finalizer_name: "{{ vm_cloudkit_finalizer }}"
         finalizer_target:
           api_version: cloudkit.openshift.io/v1alpha1
           kind: VirtualMachine
           namespace: "{{ vm_order.metadata.namespace }}"
-          name: "{{ vm_order.metadata.name }}"
+          name: "{{ vm_order_name }}"
 
     - name: Call the selected VM template
       ansible.builtin.include_role:

--- a/playbook_cloudkit_delete_vm.yml
+++ b/playbook_cloudkit_delete_vm.yml
@@ -5,21 +5,14 @@
 
   vars:
     vm_order: "{{ ansible_eda.event.payload }}"
+    vm_order_name: "{{ ansible_eda.event.payload.metadata.name }}"
 
   pre_tasks:
-    - name: Set VM order name
-      ansible.builtin.set_fact:
-        vm_order_name: "{{ vm_order.metadata.name }}"
-
-    - name: VM order for deletion
-      ansible.builtin.debug:
-        var: vm_order
-
     - name: Extract VM template info
       ansible.builtin.include_role:
         name: cloudkit.service.extract_vm_template_info
 
-    - name: Determine target namespace
+    - name: Determine working namespace
       ansible.builtin.include_role:
         name: cloudkit.service.vm_working_namespace
 
@@ -28,7 +21,7 @@
       ansible.builtin.debug:
         msg:
           - "Deleting VM order: {{ vm_order_name }}"
-          - "VM target namespace: {{ vm_target_namespace }}"
+          - "VM working namespace: {{ vm_working_namespace }}"
           - "Template ID: {{ template_id }}"
 
     - name: Call the selected VM template for deletion
@@ -41,9 +34,9 @@
         name: cloudkit.service.finalizer
       vars:
         finalizer_state: absent
-        finalizer_name: "{{ vm_settings_cloudkit_finalizer }}"
+        finalizer_name: "{{ vm_cloudkit_finalizer }}"
         finalizer_target:
           api_version: cloudkit.openshift.io/v1alpha1
           kind: VirtualMachine
           namespace: "{{ vm_order.metadata.namespace }}"
-          name: "{{ vm_order.metadata.name }}"
+          name: "{{ vm_order_name }}"


### PR DESCRIPTION
- Add vm_storage_class field to template metadata schema
- Rename vm_target_namespace to vm_working_namespace for consistency
- Consolidate VM order labels across cloudkit and vmaas configs
- Rename vm_settings_cloudkit_finalizer to vm_cloudkit_finalizer
- Add debug output for template enumeration in publish_templates
- Simplify VM order name handling in create/delete playbooks
