### PR TITLE
NO-ISSUE: Manage test dependencies with `uv` instead of `pip`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,10 +48,7 @@ jobs:
           python-version-file: "pyproject.toml"
 
       - name: Install the project
-        run: uv sync --locked --all-extras --group development
-
-      - name: Install Python dependencies for tests
-        run: pip install kubernetes openstacksdk
+        run: uv sync --locked --all-extras --all-groups
 
       - name: Install kind
         uses: helm/kind-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = [
 
 [dependency-groups]
 development = ["ansible-lint>=25.2.1", "antsibull-changelog>=0.33.0"]
+test = [
+    "openstacksdk>=4.5.0",
+]
 
 [tool.uv.sources]
 python-esiclient = { git = "https://github.com/cci-moc/python-esiclient.git", rev = "1.4" }

--- a/tests/integration/setup_test_env.sh
+++ b/tests/integration/setup_test_env.sh
@@ -10,10 +10,6 @@ echo "=== Setting up test environment ==="
 echo "Cleaning up any existing test cluster..."
 kind delete cluster --name osac-test 2>/dev/null || true
 
-# 0.5. Install required Python libraries
-echo "Installing required Python libraries..."
-pip install --user kubernetes openstacksdk 2>/dev/null || pip3 install --user kubernetes openstacksdk
-
 # 1. Create kind cluster
 echo "Creating kind cluster..."
 kind create cluster --name osac-test --wait 5m

--- a/uv.lock
+++ b/uv.lock
@@ -404,57 +404,6 @@ wheels = [
 ]
 
 [[package]]
-name = "osac-aap"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "aiobotocore" },
-    { name = "ansible" },
-    { name = "boto3" },
-    { name = "botocore" },
-    { name = "dnspython" },
-    { name = "esisdk" },
-    { name = "jmespath" },
-    { name = "kubernetes" },
-    { name = "pydantic" },
-    { name = "python-esiclient" },
-    { name = "python-esileapclient" },
-    { name = "python-ironicclient" },
-    { name = "python-openstackclient" },
-    { name = "urllib3" },
-]
-
-[package.dev-dependencies]
-development = [
-    { name = "ansible-lint" },
-    { name = "antsibull-changelog" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiobotocore", specifier = ">=2.21.1" },
-    { name = "ansible", specifier = ">=11.4.0" },
-    { name = "boto3", specifier = ">=1.37.0" },
-    { name = "botocore", specifier = ">=1.37.0" },
-    { name = "dnspython", specifier = ">=2.7.0" },
-    { name = "esisdk", specifier = ">=1.5.0" },
-    { name = "jmespath", specifier = ">=1.0.1" },
-    { name = "kubernetes", specifier = ">=32.0.1" },
-    { name = "pydantic", specifier = ">=2.11.3" },
-    { name = "python-esiclient", git = "https://github.com/cci-moc/python-esiclient.git?rev=1.4" },
-    { name = "python-esileapclient", specifier = ">=1.0.0" },
-    { name = "python-ironicclient", specifier = ">=5.10.0" },
-    { name = "python-openstackclient", specifier = ">=7.4.0" },
-    { name = "urllib3", specifier = ">=2.4.0" },
-]
-
-[package.metadata.requires-dev]
-development = [
-    { name = "ansible-lint", specifier = ">=25.2.1" },
-    { name = "antsibull-changelog", specifier = ">=0.33.0" },
-]
-
-[[package]]
 name = "cmd2"
 version = "2.5.11"
 source = { registry = "https://pypi.org/simple" }
@@ -999,6 +948,61 @@ sdist = { url = "https://files.pythonhosted.org/packages/58/3f/09e93eb484b69d2a0
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/2d/318b2b631f68e0fc221ba8f45d163bf810cdb795cf242fe85ad3e5d45639/os_service_types-1.7.0-py2.py3-none-any.whl", hash = "sha256:0505c72205690910077fb72b88f2a1f07533c8d39f2fe75b29583481764965d6", size = 24020, upload-time = "2019-05-12T12:05:46.328Z" },
 ]
+
+[[package]]
+name = "osac-aap"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "aiobotocore" },
+    { name = "ansible" },
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "dnspython" },
+    { name = "esisdk" },
+    { name = "jmespath" },
+    { name = "kubernetes" },
+    { name = "pydantic" },
+    { name = "python-esiclient" },
+    { name = "python-esileapclient" },
+    { name = "python-ironicclient" },
+    { name = "python-openstackclient" },
+    { name = "urllib3" },
+]
+
+[package.dev-dependencies]
+development = [
+    { name = "ansible-lint" },
+    { name = "antsibull-changelog" },
+]
+test = [
+    { name = "openstacksdk" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiobotocore", specifier = ">=2.21.1" },
+    { name = "ansible", specifier = ">=11.4.0" },
+    { name = "boto3", specifier = ">=1.37.0" },
+    { name = "botocore", specifier = ">=1.37.0" },
+    { name = "dnspython", specifier = ">=2.7.0" },
+    { name = "esisdk", specifier = ">=1.5.0" },
+    { name = "jmespath", specifier = ">=1.0.1" },
+    { name = "kubernetes", specifier = ">=32.0.1" },
+    { name = "pydantic", specifier = ">=2.11.3" },
+    { name = "python-esiclient", git = "https://github.com/cci-moc/python-esiclient.git?rev=1.4" },
+    { name = "python-esileapclient", specifier = ">=1.0.0" },
+    { name = "python-ironicclient", specifier = ">=5.10.0" },
+    { name = "python-openstackclient", specifier = ">=7.4.0" },
+    { name = "urllib3", specifier = ">=2.4.0" },
+]
+
+[package.metadata.requires-dev]
+development = [
+    { name = "ansible-lint", specifier = ">=25.2.1" },
+    { name = "antsibull-changelog", specifier = ">=0.33.0" },
+]
+test = [{ name = "openstacksdk", specifier = ">=4.5.0" }]
 
 [[package]]
 name = "osc-lib"


### PR DESCRIPTION
The README explains that dependencies are managed with `uv`, but test dependencies (`kubernetes`, `openstacksdk`) were installed ad-hoc via `pip install` in `setup_test_env.sh` and in the GitHub Actions workflow. This was inconsistent and confusing.

Move those packages into a `test` dependency group in `pyproject.toml` so they are tracked in `uv.lock` like everything else. Update the GitHub Actions workflow to use `uv sync --all-groups` and remove the separate `pip install` steps from both the workflow and the test setup script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated test dependency management by centralizing test-related dependencies through a unified dependency group resolution system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->