### PR TITLE
MGMT-23465: Add GPU passthrough support to the `ocp_virt_vm` template

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/meta/argument_specs.yaml
@@ -5,6 +5,31 @@ argument_specs:
         type: dict
         required: true
         description: ComputeInstance configuration
+      gpu_device_name:
+        type: str
+        required: false
+        default: ""
+        description: |
+          The resource name of the GPU device to pass through to the virtual machine. When
+          set, the virtual machine will be configured with GPU passthrough support via the
+          `hostDevices` field in the KubeVirt domain devices spec.
+
+          This must match a `resourceName` defined in the KubeVirt CR under
+          `spec.configuration.permittedHostDevices.pciHostDevices`. For example, to pass
+          through an NVIDIA A100 PCIe 80GB (PCI ID `10DE:20B5`), the KubeVirt CR should
+          contain:
+
+              configuration:
+                permittedHostDevices:
+                  pciHostDevices:
+                    - pciVendorSelector: "10DE:20B5"
+                      resourceName: "nvidia.com/GA100"
+                      externalResourceProvider: false
+
+          And the value of this parameter would be `nvidia.com/GA100`.
+
+          The PCI vendor and product ID for a given GPU can be found by running
+          `lspci -nn | grep -i nvidia` on a node that has the device.
       template_parameters:
         type: dict
         description: VM configuration parameters

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_build_spec.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_build_spec.yaml
@@ -33,3 +33,15 @@
         - name: root-disk
           dataVolume:
             name: "{{ compute_instance_name }}-root-disk"
+
+- name: Add GPU passthrough device to template spec if required
+  ansible.builtin.set_fact:
+    vm_template_spec: "{{ vm_template_spec | combine(gpu_patch, recursive=True, list_merge='append') }}"
+  vars:
+    gpu_patch:
+      domain:
+        devices:
+          hostDevices:
+            - name: gpu
+              deviceName: "{{ gpu_device_name }}"
+  when: (gpu_device_name | default('')) | length > 0

--- a/collections/ansible_collections/osac/test_overrides/roles/ocp_virt_vm_with_gpu/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/test_overrides/roles/ocp_virt_vm_with_gpu/meta/argument_specs.yaml
@@ -1,0 +1,19 @@
+argument_specs:
+  main:
+    options:
+      compute_instance:
+        type: dict
+        required: true
+        description: ComputeInstance configuration
+      template_parameters:
+        type: dict
+        description: VM configuration parameters
+        options:
+          exposed_ports:
+            description: >
+              Ports to expose on the VM for ingress traffic.
+              The syntax is a comma-separated list of `<port>/<protocol>` pairs, where `<protocol>` is either `tcp` or `udp`.
+              For example, `22/tcp,80/tcp` will expose tcp ports 22 and 80 on the VM.
+            type: str
+            required: false
+            default: "22/tcp"

--- a/collections/ansible_collections/osac/test_overrides/roles/ocp_virt_vm_with_gpu/meta/osac.yaml
+++ b/collections/ansible_collections/osac/test_overrides/roles/ocp_virt_vm_with_gpu/meta/osac.yaml
@@ -1,0 +1,7 @@
+title: ComputeInstance with NVIDIA GB100 GPU
+description: >
+  ComputeInstance template with NVIDIA GB100 GPU passthrough. Extends the
+  base ocp_virt_vm template by configuring host-device passthrough for the
+  GB100 accelerator.
+
+template_type: compute_instance

--- a/collections/ansible_collections/osac/test_overrides/roles/ocp_virt_vm_with_gpu/tasks/create.yaml
+++ b/collections/ansible_collections/osac/test_overrides/roles/ocp_virt_vm_with_gpu/tasks/create.yaml
@@ -1,0 +1,7 @@
+---
+- name: Delegate to base VM template
+  ansible.builtin.include_role:
+    name: osac.templates.ocp_virt_vm
+    tasks_from: create
+  vars:
+    gpu_device_name: "nvidia.com/GB100"

--- a/collections/ansible_collections/osac/test_overrides/roles/ocp_virt_vm_with_gpu/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/test_overrides/roles/ocp_virt_vm_with_gpu/tasks/delete.yaml
@@ -1,0 +1,5 @@
+---
+- name: Delegate to base VM template
+  ansible.builtin.include_role:
+    name: osac.templates.ocp_virt_vm
+    tasks_from: delete

--- a/tests/integration/fixtures/computeinstance-with-gpu-test.yaml
+++ b/tests/integration/fixtures/computeinstance-with-gpu-test.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: osac.openshift.io/v1alpha1
+kind: ComputeInstance
+metadata:
+  name: test-vm-gpu
+  namespace: osac-system
+spec:
+  templateID: osac.test_overrides.ocp_virt_vm_with_gpu
+  cores: 2
+  memoryGiB: 4
+  bootDisk:
+    sizeGiB: 20
+  image:
+    sourceType: registry
+    sourceRef: "quay.io/containerdisks/fedora:latest"
+  runStrategy: "Always"
+status:
+  desiredConfigVersion: "1"

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -25,6 +25,7 @@ WORKFLOWS=(
   "cluster_delete"
   "cluster_post_install"
   "compute_instance_create"
+  "compute_instance_with_gpu_create"
   "compute_instance_delete"
   "hostpool_create"
   "hostpool_delete"
@@ -50,23 +51,27 @@ for workflow in "${WORKFLOWS[@]}"; do
     FAILED+=("$workflow:baseline")
   fi
 
-  # Override test
-  echo "  [2/2] Running override test..."
-  # Clear override log
-  > /tmp/osac_test_overrides.log
+  # Override test (skip if no overrides playbook exists)
+  if [ -f "targets/${workflow}/tasks/overrides.yml" ]; then
+    echo "  [2/2] Running override test..."
+    # Clear override log
+    > /tmp/osac_test_overrides.log
 
-  if ansible-playbook "targets/${workflow}/tasks/overrides.yml" -e "@common_vars.yml" -v; then
-    # Verify override log has entries
-    if [ -s /tmp/osac_test_overrides.log ]; then
-      echo "  ✓ Override test passed"
-      PASSED+=("$workflow:overrides")
+    if ansible-playbook "targets/${workflow}/tasks/overrides.yml" -e "@common_vars.yml" -v; then
+      # Verify override log has entries
+      if [ -s /tmp/osac_test_overrides.log ]; then
+        echo "  ✓ Override test passed"
+        PASSED+=("$workflow:overrides")
+      else
+        echo "  ✗ Override test failed (no override log entries)"
+        FAILED+=("$workflow:overrides-no-log")
+      fi
     else
-      echo "  ✗ Override test failed (no override log entries)"
-      FAILED+=("$workflow:overrides-no-log")
+      echo "  ✗ Override test failed"
+      FAILED+=("$workflow:overrides")
     fi
   else
-    echo "  ✗ Override test failed"
-    FAILED+=("$workflow:overrides")
+    echo "  [2/2] No override test (skipped)"
   fi
 
   echo ""

--- a/tests/integration/targets/compute_instance_with_gpu_create/meta/main.yml
+++ b/tests/integration/targets/compute_instance_with_gpu_create/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
+++ b/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
@@ -1,0 +1,43 @@
+---
+- name: Compute Instance Create GPU - Baseline Test
+  hosts: localhost
+  gather_facts: true
+  vars_files:
+    - ../../../common_vars.yml
+
+  tasks:
+    - name: Read ComputeInstance GPU fixture
+      ansible.builtin.set_fact:
+        test_compute_instance: "{{ lookup('file', '../../../fixtures/computeinstance-with-gpu-test.yaml') | from_yaml }}"
+
+    - name: Set test variables for baseline workflow
+      ansible.builtin.set_fact:
+        ansible_eda:
+          event:
+            payload: "{{ test_compute_instance }}"
+        compute_instance_working_namespace: "computeinstance-test-vm-gpu-work"
+        create_step_resources_override:
+          name: osac.workflows.workflow_helpers
+          tasks_from: noop.yml
+        create_step_wait_annotate_override:
+          name: osac.workflows.workflow_helpers
+          tasks_from: noop.yml
+
+- name: Import compute instance create workflow (baseline with GPU)
+  ansible.builtin.import_playbook: osac.workflows.compute_instance.create
+
+- name: Verify baseline results with GPU
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - ../../../common_vars.yml
+
+  tasks:
+    - name: Verify GPU host device is present in VM template spec
+      ansible.builtin.assert:
+        that:
+          - vm_template_spec is defined
+          - vm_template_spec.domain.devices.hostDevices is defined
+          - vm_template_spec.domain.devices.hostDevices | length > 0
+          - vm_template_spec.domain.devices.hostDevices | selectattr('deviceName', 'equalto', 'nvidia.com/GB100') | list | length > 0
+        fail_msg: "GPU device not found in VM template spec: {{ vm_template_spec }}"


### PR DESCRIPTION
The `ocp_virt_vm` role now accepts an optional `gpu_device_name` parameter. When set, the VM template spec is extended with a `hostDevices` entry that configures PCI passthrough for the specified GPU device. The parameter defaults to empty, so existing templates are unaffected.

The `when` condition in `create_build_spec.yaml` uses the `default` filter to handle the case where `gpu_device_name` is undefined, which occurs when the role is invoked via `tasks_from` rather than through its `main` entry point (where `argument_specs` would set the default).

A test-only template `ocp_virt_vm_with_gpu` is added to the `osac.test_overrides` collection. It sets `gpu_device_name` to `nvidia.com/GB100` and delegates to the base `ocp_virt_vm` template, demonstrating how GPU-enabled templates can be built as thin wrappers.

An integration test `compute_instance_with_gpu_create` exercises the full workflow with this template and asserts that the resulting `vm_template_spec` contains the expected GPU `hostDevices` entry. The test runner is also updated to skip the override test when no `overrides.yml` playbook exists for a workflow.

In order for this to work, the KubeVirt CR must be configured in advance by the cluster administrator with the list of permitted host devices. This is not done automatically by the role. For example, to allow passthrough of an NVIDIA A100 PCIe 80GB (PCI ID `10DE:20B5`), the administrator should add the following to the KubeVirt CR:

```yaml
configuration:
  permittedHostDevices:
    pciHostDevices:
      - pciVendorSelector: "10DE:20B5"
        resourceName: "nvidia.com/GA100"
        externalResourceProvider: false
```

Related: https://issues.redhat.com/browse/MGMT-23465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional GPU device passthrough capability for virtual machines with customizable device name configuration
  * Introduced NVIDIA GB100 GPU accelerator template for compute instances with full passthrough support

* **Tests**
  * Added comprehensive integration test coverage for GPU-enabled virtual machine creation and lifecycle management
  * Enhanced test framework to intelligently handle optional override test scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->