### PR TITLE
MGMT-23733: add PublicIPPool AAP playbooks and MetalLB L2 role

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -171,6 +171,30 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-create-public-ip-pool"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_create_public_ip_pool.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+  - name: "{{ aap_prefix }}-delete-public-ip-pool"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_delete_public_ip_pool.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
 
 controller_job_template_surveys: # noqa: var-naming[no-role-prefix]
   - name: "{{ aap_prefix }}-create-hosted-cluster-post-install"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/defaults/main.yaml
@@ -1,4 +1,3 @@
 ---
-# Default labels for MetalLB PublicIPPool resources
-default_publicippool_labels:
-  osac.io/managed-by: osac-fulfillment
+# Defaults for metallb_l2 role
+# Labels are defined inline in the task files alongside resource definitions.

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/defaults/main.yaml
@@ -1,0 +1,4 @@
+---
+# Default labels for MetalLB PublicIPPool resources
+default_publicippool_labels:
+  osac.io/managed-by: osac-fulfillment

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
@@ -1,0 +1,28 @@
+---
+argument_specs:
+  create_public_ip_pool:
+    options:
+      public_ip_pool:
+        type: dict
+        required: true
+        description: PublicIPPool CR from fulfillment-api via EDA payload
+      public_ip_pool_name:
+        type: str
+        required: true
+        description: Name of the PublicIPPool resource
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}
+
+  delete_public_ip_pool:
+    options:
+      public_ip_pool:
+        type: dict
+        required: true
+        description: PublicIPPool CR from fulfillment-api via EDA payload
+      public_ip_pool_name:
+        type: str
+        required: true
+        description: Name of the PublicIPPool resource

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/osac.yaml
@@ -1,0 +1,14 @@
+---
+title: MetalLB L2 Implementation
+description: >
+  Provisions MetalLB IPAddressPool and L2Advertisement resources for PublicIPPool.
+  Handles L2-based IP address advertisement on bare-metal clusters.
+
+template_type: network
+
+# PublicIPPool registration fields
+implementation_strategy: metallb-l2
+capabilities:
+  supports_ipv4: true
+  supports_ipv6: true
+  supports_dual_stack: false

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip_pool.yaml
@@ -1,0 +1,74 @@
+---
+# Create MetalLB IPAddressPool and L2Advertisement for PublicIPPool
+# 1. Creates IPAddressPool with autoAssign: false and addresses from CR spec.cidrs
+# 2. Creates L2Advertisement referencing the IPAddressPool by name
+
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Extract PublicIPPool configuration
+  ansible.builtin.set_fact:
+    pool_name: "{{ public_ip_pool.metadata.name }}"
+    pool_cidrs: "{{ public_ip_pool.spec.cidrs }}"
+
+- name: Display PublicIPPool information
+  ansible.builtin.debug:
+    msg:
+      - "Creating MetalLB resources for PublicIPPool '{{ pool_name }}'"
+      - "CIDRs: {{ pool_cidrs }}"
+
+- name: Create IPAddressPool
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: present
+    definition:
+      apiVersion: metallb.io/v1beta1
+      kind: IPAddressPool
+      metadata:
+        name: "{{ pool_name }}"
+        namespace: metallb-system
+        labels:
+          osac.openshift.io/publicippool: "{{ pool_name }}"
+          osac.io/managed-by: osac-fulfillment
+      spec:
+        autoAssign: false
+        addresses: "{{ pool_cidrs }}"
+  register: ipaddresspool_result
+
+  # MetalLB webhook may not be ready yet after operator install
+  # Retry once every 10 seconds for 10 minutes
+  retries: 60
+  delay: 10
+  until: ipaddresspool_result is successful
+
+- name: Display IPAddressPool creation result
+  ansible.builtin.debug:
+    msg:
+      - "IPAddressPool '{{ pool_name }}' created successfully"
+      - "Changed: {{ ipaddresspool_result.changed | default(false) }}"
+
+- name: Create L2Advertisement
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: present
+    definition:
+      apiVersion: metallb.io/v1beta1
+      kind: L2Advertisement
+      metadata:
+        name: "{{ pool_name }}-l2adv"
+        namespace: metallb-system
+        labels:
+          osac.openshift.io/publicippool: "{{ pool_name }}"
+          osac.io/managed-by: osac-fulfillment
+      spec:
+        ipAddressPools:
+          - "{{ pool_name }}"
+  register: l2advertisement_result
+
+- name: Display L2Advertisement creation result
+  ansible.builtin.debug:
+    msg:
+      - "L2Advertisement '{{ pool_name }}-l2adv' created successfully"
+      - "Changed: {{ l2advertisement_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip_pool.yaml
@@ -67,6 +67,11 @@
           - "{{ pool_name }}"
   register: l2advertisement_result
 
+  # MetalLB webhook may not be ready yet after operator install
+  retries: 60
+  delay: 10
+  until: l2advertisement_result is successful
+
 - name: Display L2Advertisement creation result
   ansible.builtin.debug:
     msg:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip_pool.yaml
@@ -1,0 +1,61 @@
+---
+# Delete MetalLB L2Advertisement and IPAddressPool for PublicIPPool
+# 1. Deletes L2Advertisement first (must be removed before pool)
+# 2. Deletes IPAddressPool
+# Handles "not found" errors gracefully for both resources
+
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Extract PublicIPPool configuration
+  ansible.builtin.set_fact:
+    pool_name: "{{ public_ip_pool.metadata.name }}"
+
+- name: Display deletion information
+  ansible.builtin.debug:
+    msg:
+      - "Deleting MetalLB resources for PublicIPPool '{{ pool_name }}'"
+
+- name: Delete L2Advertisement
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: absent
+    api_version: metallb.io/v1beta1
+    kind: L2Advertisement
+    name: "{{ pool_name }}-l2adv"
+    namespace: metallb-system
+    wait: true
+    wait_timeout: 300
+  register: l2adv_delete_result
+  failed_when:
+    - l2adv_delete_result.failed | default(false)
+    - "'NotFound' not in (l2adv_delete_result.msg | default(''))"
+
+- name: Display L2Advertisement deletion result
+  ansible.builtin.debug:
+    msg:
+      - "L2Advertisement '{{ pool_name }}-l2adv' deletion completed"
+      - "Changed: {{ l2adv_delete_result.changed | default(false) }}"
+
+- name: Delete IPAddressPool
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: absent
+    api_version: metallb.io/v1beta1
+    kind: IPAddressPool
+    name: "{{ pool_name }}"
+    namespace: metallb-system
+    wait: true
+    wait_timeout: 300
+  register: ipaddresspool_delete_result
+  failed_when:
+    - ipaddresspool_delete_result.failed | default(false)
+    - "'NotFound' not in (ipaddresspool_delete_result.msg | default(''))"
+
+- name: Display IPAddressPool deletion result
+  ansible.builtin.debug:
+    msg:
+      - "IPAddressPool '{{ pool_name }}' deletion completed"
+      - "Changed: {{ ipaddresspool_delete_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip_pool.yaml
@@ -29,6 +29,11 @@
     wait: true
     wait_timeout: 300
   register: l2adv_delete_result
+  retries: 3
+  delay: 10
+  until: >-
+    l2adv_delete_result is successful
+    or ('NotFound' in (l2adv_delete_result.msg | default('')))
   failed_when:
     - l2adv_delete_result.failed | default(false)
     - "'NotFound' not in (l2adv_delete_result.msg | default(''))"
@@ -50,6 +55,11 @@
     wait: true
     wait_timeout: 300
   register: ipaddresspool_delete_result
+  retries: 3
+  delay: 10
+  until: >-
+    ipaddresspool_delete_result is successful
+    or ('NotFound' in (ipaddresspool_delete_result.msg | default('')))
   failed_when:
     - ipaddresspool_delete_result.failed | default(false)
     - "'NotFound' not in (ipaddresspool_delete_result.msg | default(''))"

--- a/playbook_osac_create_public_ip_pool.yml
+++ b/playbook_osac_create_public_ip_pool.yml
@@ -8,14 +8,19 @@
     public_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
     # Implementation strategy set by osac-operator from PublicIPPool spec
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
-         ['osac.openshift.io/implementation-strategy'] }}
+      {{ (ansible_eda.event.payload.metadata.annotations | default({}))
+         .get('osac.openshift.io/implementation-strategy', '') }}
     template_parameters: {}
 
   pre_tasks:
     - name: Show EDA Event
       ansible.builtin.debug:
         var: ansible_eda.event.payload
+
+    - name: Validate implementation strategy is set
+      ansible.builtin.fail:
+        msg: "Missing required annotation 'osac.openshift.io/implementation-strategy'"
+      when: implementation_strategy | length == 0
 
   tasks:
     - name: Display PublicIPPool information

--- a/playbook_osac_create_public_ip_pool.yml
+++ b/playbook_osac_create_public_ip_pool.yml
@@ -1,0 +1,31 @@
+---
+- name: Create a PublicIPPool resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    public_ip_pool: "{{ ansible_eda.event.payload }}"
+    public_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    # Implementation strategy set by osac-operator from PublicIPPool spec
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations
+         ['osac.openshift.io/implementation-strategy'] }}
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display PublicIPPool information
+      ansible.builtin.debug:
+        msg:
+          - "PublicIPPool name: {{ public_ip_pool_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+          - "Template parameters: {{ template_parameters }}"
+
+    - name: Call the selected PublicIPPool role
+      ansible.builtin.include_role:
+        name: "osac.templates.{{ implementation_strategy | replace('-', '_') }}"
+        tasks_from: create_public_ip_pool

--- a/playbook_osac_delete_public_ip_pool.yml
+++ b/playbook_osac_delete_public_ip_pool.yml
@@ -8,14 +8,19 @@
     public_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
     # Implementation strategy set by osac-operator from PublicIPPool spec
     implementation_strategy: >-
-      {{ ansible_eda.event.payload.metadata.annotations
-         ['osac.openshift.io/implementation-strategy'] }}
+      {{ (ansible_eda.event.payload.metadata.annotations | default({}))
+         .get('osac.openshift.io/implementation-strategy', '') }}
     template_parameters: {}
 
   pre_tasks:
     - name: Show EDA Event
       ansible.builtin.debug:
         var: ansible_eda.event.payload
+
+    - name: Validate implementation strategy is set
+      ansible.builtin.fail:
+        msg: "Missing required annotation 'osac.openshift.io/implementation-strategy'"
+      when: implementation_strategy | length == 0
 
   tasks:
     - name: Display PublicIPPool information

--- a/playbook_osac_delete_public_ip_pool.yml
+++ b/playbook_osac_delete_public_ip_pool.yml
@@ -1,0 +1,30 @@
+---
+- name: Delete a PublicIPPool resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    public_ip_pool: "{{ ansible_eda.event.payload }}"
+    public_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    # Implementation strategy set by osac-operator from PublicIPPool spec
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations
+         ['osac.openshift.io/implementation-strategy'] }}
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display PublicIPPool information
+      ansible.builtin.debug:
+        msg:
+          - "Deleting PublicIPPool: {{ public_ip_pool_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected PublicIPPool role
+      ansible.builtin.include_role:
+        name: "osac.templates.{{ implementation_strategy | replace('-', '_') }}"
+        tasks_from: delete_public_ip_pool

--- a/rulebooks/cluster_fulfillment.yml
+++ b/rulebooks/cluster_fulfillment.yml
@@ -62,3 +62,17 @@
         run_job_template:
           name: "{{ job_template_prefix }}-delete-subnet"
           organization: "{{ job_template_organization }}"
+
+    - name: Create public IP pool
+      condition: event.meta.endpoint == "create-public-ip-pool"
+      action:
+        run_job_template:
+          name: "{{ job_template_prefix }}-create-public-ip-pool"
+          organization: "{{ job_template_organization }}"
+
+    - name: Delete public IP pool
+      condition: event.meta.endpoint == "delete-public-ip-pool"
+      action:
+        run_job_template:
+          name: "{{ job_template_prefix }}-delete-public-ip-pool"
+          organization: "{{ job_template_organization }}"


### PR DESCRIPTION
## Summary

[MGMT-23733](https://redhat.atlassian.net/browse/MGMT-23733): Add AAP playbooks and MetalLB L2 Ansible role for PublicIPPool
provisioning. When the osac-operator triggers an AAP job for a PublicIPPool CR,
these playbooks dispatch to the `metallb_l2` role, which creates an
IPAddressPool (`autoAssign: false`) and L2Advertisement on the target cluster.

**New files:**
- `playbook_osac_create_public_ip_pool.yml` / `playbook_osac_delete_public_ip_pool.yml`: EDA-dispatched playbooks
- `osac.templates.metallb_l2` role: create/delete tasks for MetalLB resources
- EDA rulebook rules for `create-public-ip-pool` / `delete-public-ip-pool` endpoints
- Config-as-code job templates using `networking-operations` inventory/IG

**Key design decisions:**
- Role lives under `osac.templates` (not `osac.service`) to match the `include_role` dispatch pattern
- Playbooks apply `replace('-', '_')` filter on `implementation_strategy` annotation since Ansible role names cannot contain hyphens
- Uses `get_remote_cluster_kubeconfig` (same as `cudn_net`) because MetalLB resources must be on the target cluster
- Delete order: L2Advertisement first, then IPAddressPool, both tolerating NotFound

## Testing

### ansible-lint

```
cd osac-aap && ANSIBLE_LOCAL_TEMP=$TMPDIR ansible-lint \
  playbook_osac_create_public_ip_pool.yml \
  playbook_osac_delete_public_ip_pool.yml \
  collections/ansible_collections/osac/templates/roles/metallb_l2/
```

Result: `Passed: 0 failure(s), 0 warning(s) in 8 files processed`

### E2E on edge22 (2026-04-09)

Full end-to-end test on edge22 (SNO, OCP 4.20, AAP Direct provider):

| Test | Description | AAP Job | Result |
|------|-------------|---------|--------|
| Create | Apply PublicIPPool CR -> operator triggers AAP -> IPAddressPool + L2Advertisement created in metallb-system | 10186 (Succeeded) | PASS |
| Delete | Delete PublicIPPool CR -> operator triggers AAP -> L2Advertisement then IPAddressPool removed | 10188 (Succeeded) | PASS |

Verified:
- IPAddressPool created with `autoAssign: false` and correct addresses from `spec.cidrs`
- L2Advertisement references the IPAddressPool by name
- Both resources have `osac.openshift.io/publicippool` and `osac.io/managed-by` labels
- Delete tolerates already-removed resources (NotFound handling)
- CR phase transitions: Progressing -> Ready (create), Deleting -> removed (delete)

Full E2E results document attached to [MGMT-23733](https://redhat.atlassian.net/browse/MGMT-23733).

### Unit tests

Role-level unit tests for `metallb_l2` tracked as follow-up: [MGMT-23823](https://redhat.atlassian.net/browse/MGMT-23823) (depends on PR #239 merging first to establish test conventions).

## Related PRs

- osac-project/osac-operator#176 (operator-side: CRD, controller, registration)

## Ticket

[MGMT-23733](https://redhat.atlassian.net/browse/MGMT-23733)

<br>

<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public IP pool creation and deletion capabilities with automated triggering via event-driven rules.
  * Introduced MetalLB L2 network implementation template supporting IPv4 and IPv6 addressing with automated resource provisioning and cleanup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->