### PR TITLE
MGMT-23834: fix cudn_net implementation_strategy to match Ansible role name

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/cudn_net/README.md
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/README.md
@@ -11,7 +11,7 @@ VirtualNetworks define the top-level network isolation boundary with CIDR alloca
 **Key behaviors:**
 - Creates ClusterUserDefinedNetwork CR in the cluster
 - Supports IPv4-only, IPv6-only, and dual-stack configurations
-- NetworkClass determines the implementation strategy (cudn-net)
+- NetworkClass determines the implementation strategy (cudn_net)
 - One VirtualNetwork maps to one ClusterUserDefinedNetwork
 
 **Implementation:**
@@ -74,7 +74,7 @@ Each SecurityGroup creates its own NetworkPolicy, and Kubernetes applies them ad
 
 ## Implementation Strategy
 
-This role implements the `cudn-net` NetworkClass strategy using OpenShift's ClusterUserDefinedNetwork (CUDN) feature. The implementation follows these patterns:
+This role implements the `cudn_net` NetworkClass strategy using OpenShift's ClusterUserDefinedNetwork (CUDN) feature. The implementation follows these patterns:
 
 **For VirtualNetworks:**
 - Create ClusterUserDefinedNetwork CR with Layer2 topology

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/meta/osac.yaml
@@ -7,7 +7,7 @@ description: >
 template_type: network
 
 # NetworkClass registration fields
-implementation_strategy: cudn-net
+implementation_strategy: cudn_net
 capabilities:
   supports_ipv4: true
   supports_ipv6: true


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-23834

The implementation_strategy in osac.yaml was set to "cudn-net" (hyphen) but the Ansible role name is "cudn_net" (underscore). The VirtualNetwork provisioning playbook constructs the role name as 
`osac.templates.{{ implementation_strategy }}`, so it tried to find osac.templates.cudn-net which doesn't exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated network strategy identifier naming convention from hyphenated to underscore format for consistency across documented references.

* **Chores**
  * Updated configuration implementation strategy identifier to align with new naming standard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->