### PR TITLE
MGMT-23659: Use fqn instead of id for NetworkClass publishing

### DIFF
--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -281,7 +281,7 @@ class NetworkClassTemplate(Base):
         return str(value)
 
     @pydantic.computed_field
-    def id(self) -> str:
+    def fqn(self) -> str:
         return f"{self.collection}.{self.name}"
 
 

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tasks/network_classes.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tasks/network_classes.yaml
@@ -6,22 +6,23 @@
       authorization: Bearer {{ osac_fulfillment_service_token }}
   register: network_class_check
 
-- name: Create list of existing NetworkClass IDs
+- name: Build map of existing NetworkClass FQNs to IDs
   ansible.builtin.set_fact:
-    network_class_ids: >-
+    network_class_fqn_to_id: >-
       {{
-      network_class_check | json_query("json.items[].id")
+      network_class_fqn_to_id | default({}) | combine({item.fqn: item.id})
       }}
-  when: network_class_check is success and network_class_check.json.get('items', []) | length > 0
+  loop: "{{ network_class_check.json.get('items', []) }}"
+  when: network_class_check is success and item.fqn is defined
 
 - name: Update existing NetworkClass
   loop: "{{ osac_network_classes }}"
   loop_control:
-    label: "{{ network_class.id }}"
+    label: "{{ network_class.fqn }}"
     loop_var: network_class
-  when: network_class_ids is defined and network_class.id in network_class_ids
+  when: network_class_fqn_to_id is defined and network_class.fqn in network_class_fqn_to_id
   ansible.builtin.uri:
-    url: "{{ publish_templates_network_class_api_endpoint }}/{{ network_class.id }}"
+    url: "{{ publish_templates_network_class_api_endpoint }}/{{ network_class_fqn_to_id[network_class.fqn] }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
     method: PATCH
     headers:
@@ -32,9 +33,9 @@
 - name: Create new NetworkClass
   loop: "{{ osac_network_classes }}"
   loop_control:
-    label: "{{ network_class.id }}"
+    label: "{{ network_class.fqn }}"
     loop_var: network_class
-  when: network_class_ids is not defined or network_class.id not in network_class_ids
+  when: network_class_fqn_to_id is not defined or network_class.fqn not in network_class_fqn_to_id
   ansible.builtin.uri:
     url: "{{ publish_templates_network_class_api_endpoint }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tasks/network_classes.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tasks/network_classes.yaml
@@ -4,25 +4,25 @@
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
-  register: network_class_check
+  register: publish_templates_network_class_check
 
 - name: Build map of existing NetworkClass FQNs to IDs
   ansible.builtin.set_fact:
-    network_class_fqn_to_id: >-
+    publish_templates_network_class_fqn_to_id: >-
       {{
-      network_class_fqn_to_id | default({}) | combine({item.fqn: item.id})
+      publish_templates_network_class_fqn_to_id | default({}) | combine({item.fqn: item.id})
       }}
-  loop: "{{ network_class_check.json.get('items', []) }}"
-  when: network_class_check is success and item.fqn is defined
+  loop: "{{ publish_templates_network_class_check.json.get('items', []) }}"
+  when: publish_templates_network_class_check is success and item.fqn is defined
 
 - name: Update existing NetworkClass
   loop: "{{ osac_network_classes }}"
   loop_control:
     label: "{{ network_class.fqn }}"
     loop_var: network_class
-  when: network_class_fqn_to_id is defined and network_class.fqn in network_class_fqn_to_id
+  when: publish_templates_network_class_fqn_to_id is defined and network_class.fqn in publish_templates_network_class_fqn_to_id
   ansible.builtin.uri:
-    url: "{{ publish_templates_network_class_api_endpoint }}/{{ network_class_fqn_to_id[network_class.fqn] }}"
+    url: "{{ publish_templates_network_class_api_endpoint }}/{{ publish_templates_network_class_fqn_to_id[network_class.fqn] }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
     method: PATCH
     headers:
@@ -35,7 +35,7 @@
   loop_control:
     label: "{{ network_class.fqn }}"
     loop_var: network_class
-  when: network_class_fqn_to_id is not defined or network_class.fqn not in network_class_fqn_to_id
+  when: publish_templates_network_class_fqn_to_id is not defined or network_class.fqn not in publish_templates_network_class_fqn_to_id
   ansible.builtin.uri:
     url: "{{ publish_templates_network_class_api_endpoint }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tests/mock_api_server.py
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tests/mock_api_server.py
@@ -34,7 +34,7 @@ POPULATED_RESPONSES = {
     "/api/private/v1/network_classes": {
         "size": 1,
         "total": 1,
-        "items": [{"id": "existing-network-class", "title": "Test NC"}],
+        "items": [{"id": "existing-network-class", "fqn": "osac.templates.cudn_net", "title": "Test NC"}],
     },
 }
 

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tests/test.yml
@@ -74,7 +74,7 @@
           - id: "new-ci-template"
             title: "Test CI"
         osac_network_classes:
-          - id: "new-network-class"
+          - fqn: "new-network-class"
             title: "Test NC"
       when: test_empty | default(false) | bool
 
@@ -149,9 +149,9 @@
           - id: "existing-ci-template"
             title: "Updated CI"
         osac_network_classes:
-          - id: "existing-network-class"
+          - fqn: "osac.templates.cudn_net"
             title: "Updated NC"
-          - id: "brand-new-nc"
+          - fqn: "brand-new-nc"
             title: "New NC"
       when: test_populated | default(false) | bool
 
@@ -227,7 +227,7 @@
           - id: "edge-case-ci"
             title: "Edge CI"
         osac_network_classes:
-          - id: "edge-case-nc"
+          - fqn: "edge-case-nc"
             title: "Edge NC"
       when: test_no_items_key | default(false) | bool
 


### PR DESCRIPTION
## Summary
- Change `NetworkClassTemplate` to emit `fqn` field instead of `id`
- Update `publish_templates` role to match existing NetworkClasses by `fqn`-to-`id` mapping
- Update mock server and test playbook for new field name

## Jira
[MGMT-23659](https://redhat.atlassian.net/browse/MGMT-23659)

## Related
- Depends on fulfillment-service PR (adds `fqn` field to NetworkClass proto and generates UUID for `id`)

## Test plan
- [x] Empty scenario test passes
- [x] No-items-key edge case test passes
- [ ] Populated scenario test (pre-existing `json_query` issue in cluster templates path, unrelated)