### PR TITLE
MGMT-23659: Stop sending id for NetworkClass, match by implementation_strategy

### DIFF
--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -280,10 +280,6 @@ class NetworkClassTemplate(Base):
     def serialize_path(self, value: Path):
         return str(value)
 
-    @pydantic.computed_field
-    def id(self) -> str:
-        return f"{self.collection}.{self.name}"
-
 
 def _validate_collection_name(name: str) -> None:
     """Validate that collection name follows namespace.collection format.

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tasks/network_classes.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tasks/network_classes.yaml
@@ -4,24 +4,27 @@
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
-  register: network_class_check
+  register: publish_templates_network_class_check
 
-- name: Create list of existing NetworkClass IDs
+- name: Build map of existing NetworkClass implementation_strategy to IDs
   ansible.builtin.set_fact:
-    network_class_ids: >-
+    publish_templates_network_class_strategy_to_id: >-
       {{
-      network_class_check | json_query("json.items[].id")
+      publish_templates_network_class_strategy_to_id | default({}) | combine({item.implementation_strategy: item.id})
       }}
-  when: network_class_check is success and network_class_check.json.get('items', []) | length > 0
+  loop: "{{ publish_templates_network_class_check.json.get('items', []) }}"
+  when: publish_templates_network_class_check is success and item.implementation_strategy is defined
 
 - name: Update existing NetworkClass
   loop: "{{ osac_network_classes }}"
   loop_control:
-    label: "{{ network_class.id }}"
+    label: "{{ network_class.implementation_strategy }}"
     loop_var: network_class
-  when: network_class_ids is defined and network_class.id in network_class_ids
+  when: >-
+    publish_templates_network_class_strategy_to_id is defined and
+    network_class.implementation_strategy in publish_templates_network_class_strategy_to_id
   ansible.builtin.uri:
-    url: "{{ publish_templates_network_class_api_endpoint }}/{{ network_class.id }}"
+    url: "{{ publish_templates_network_class_api_endpoint }}/{{ publish_templates_network_class_strategy_to_id[network_class.implementation_strategy] }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
     method: PATCH
     headers:
@@ -32,9 +35,11 @@
 - name: Create new NetworkClass
   loop: "{{ osac_network_classes }}"
   loop_control:
-    label: "{{ network_class.id }}"
+    label: "{{ network_class.implementation_strategy }}"
     loop_var: network_class
-  when: network_class_ids is not defined or network_class.id not in network_class_ids
+  when: >-
+    publish_templates_network_class_strategy_to_id is not defined or
+    network_class.implementation_strategy not in publish_templates_network_class_strategy_to_id
   ansible.builtin.uri:
     url: "{{ publish_templates_network_class_api_endpoint }}"
     validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tests/mock_api_server.py
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tests/mock_api_server.py
@@ -34,7 +34,7 @@ POPULATED_RESPONSES = {
     "/api/private/v1/network_classes": {
         "size": 1,
         "total": 1,
-        "items": [{"id": "existing-network-class", "title": "Test NC"}],
+        "items": [{"id": "existing-network-class", "implementation_strategy": "cudn_net", "title": "Test NC"}],
     },
 }
 

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tests/test.yml
@@ -74,7 +74,7 @@
           - id: "new-ci-template"
             title: "Test CI"
         osac_network_classes:
-          - id: "new-network-class"
+          - implementation_strategy: "new-network-class"
             title: "Test NC"
       when: test_empty | default(false) | bool
 
@@ -149,9 +149,9 @@
           - id: "existing-ci-template"
             title: "Updated CI"
         osac_network_classes:
-          - id: "existing-network-class"
+          - implementation_strategy: "cudn_net"
             title: "Updated NC"
-          - id: "brand-new-nc"
+          - implementation_strategy: "brand-new-nc"
             title: "New NC"
       when: test_populated | default(false) | bool
 
@@ -227,7 +227,7 @@
           - id: "edge-case-ci"
             title: "Edge CI"
         osac_network_classes:
-          - id: "edge-case-nc"
+          - implementation_strategy: "edge-case-nc"
             title: "Edge NC"
       when: test_no_items_key | default(false) | bool
 


### PR DESCRIPTION
## Summary
- Remove `id` computed field from `NetworkClassTemplate` — no id sent to API, server generates UUIDs
- Update `publish_templates` role to match existing NetworkClasses by `implementation_strategy` for upsert
- Updated mock server and test playbook

## Jira
[MGMT-23659](https://redhat.atlassian.net/browse/MGMT-23659)

## Related
- Depends on fulfillment-service PR (server generates UUID for NetworkClass id)
- Supersedes #242 (dropped `fqn` field per review feedback — `implementation_strategy` is sufficient as upsert key)

## Test plan
- [x] ansible-lint passes (production profile)
- [x] Empty scenario test passes
- [x] No-items-key edge case test passes