### PR TITLE
MGMT-23939: Read explicit ClusterOrder fields in cluster provisioning

### DIFF
--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/allocate_floating_ip.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/allocate_floating_ip.yaml
@@ -10,12 +10,12 @@
   register: fips
 
 - name: Set allocate_floating_ip_result to found ip
-  when: fips.floating_ips
+  when: (fips.floating_ips | length > 0)
   ansible.builtin.set_fact:
     allocate_floating_ip_result: "{{ fips.floating_ips[0].floating_ip_address }}"
 
 - name: Allocate a new floating ip
-  when: not fips.floating_ips
+  when: (fips.floating_ips | length == 0)
   block:
   - name: Allocate floating ip  # noqa:no-changed-when
     ansible.builtin.command: >-

--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/create_port_forwarding.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/create_port_forwarding.yaml
@@ -5,7 +5,7 @@
   changed_when: purge_port_fwd_result.stdout | from_json | length > 0
 
 - name: Create port forwarding  # noqa:no-changed-when
-  when: ports
+  when: (ports | length > 0)
   ansible.builtin.command: >-
     openstack esi port forwarding create {{ internal_ip }} {{ floating_ip }}
       --internal-ip-network "{{ internal_network }}"

--- a/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/destroy_floating_ip.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/floating_ip/tasks/destroy_floating_ip.yaml
@@ -4,7 +4,7 @@
   register: fips
 
 - name: Destroy floating floating_ip_address
-  when: fips.floating_ips
+  when: (fips.floating_ips | length > 0)
   block:
   - name: Extract ip address to destroy
     ansible.builtin.set_fact:

--- a/collections/ansible_collections/massopencloud/esi/roles/l2/tasks/create_network.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l2/tasks/create_network.yaml
@@ -4,12 +4,12 @@
   register: networks
 
 - name: Set create_network_result to found network
-  when: networks.networks
+  when: (networks.networks | length > 0)
   ansible.builtin.set_fact:
     create_network_result: "{{ networks.networks[0].id }}"
 
 - name: Create a new network
-  when: not networks.networks
+  when: (networks.networks | length == 0)
   block:
   - name: Create network  # noqa:no-changed-when
     ansible.builtin.command: >-

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/create_router.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/create_router.yaml
@@ -4,12 +4,12 @@
   register: routers
 
 - name: Set create_router_result to found router
-  when: routers.routers
+  when: (routers.routers | length > 0)
   ansible.builtin.set_fact:
     create_router_result: "{{ routers.routers[0].id }}"
 
 - name: Create a new router
-  when: not routers.routers
+  when: (routers.routers | length == 0)
   block:
   - name: Create router  # noqa:no-changed-when
     ansible.builtin.command: >-

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/create_subnet.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/create_subnet.yaml
@@ -4,12 +4,12 @@
   register: subnets
 
 - name: Set create_subnet_result to found subnet
-  when: subnets.subnets
+  when: (subnets.subnets | length > 0)
   ansible.builtin.set_fact:
     create_subnet_result: "{{ subnets.subnets[0].id }}"
 
 - name: Create a new subnet
-  when: not subnets.subnets
+  when: (subnets.subnets | length == 0)
   block:
   - name: Create subnet  # noqa:no-changed-when
     ansible.builtin.command: >-

--- a/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/get_subnet.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/l3/tasks/get_subnet.yaml
@@ -4,6 +4,6 @@
   register: subnets
 
 - name: Set subnet_info to found subnet
-  when: subnets.subnets
+  when: (subnets.subnets | length > 0)
   ansible.builtin.set_fact:
     subnet_info: "{{ subnets.subnets[0] }}"

--- a/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
+++ b/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
@@ -31,12 +31,12 @@
 
 # Resolve networking CIDRs: explicit CR field > role defaults
 - name: Resolve pod_cidr from explicit field
-  when: ((cluster_order.spec.network | default({})).podCIDR | default('') | length > 0)
+  when: ((cluster_order.spec.network | default({}, true)).podCIDR | default('') | length > 0)
   ansible.builtin.set_fact:
     cluster_settings_pod_cidr: "{{ cluster_order.spec.network.podCIDR }}"
 
 - name: Resolve service_cidr from explicit field
-  when: ((cluster_order.spec.network | default({})).serviceCIDR | default('') | length > 0)
+  when: ((cluster_order.spec.network | default({}, true)).serviceCIDR | default('') | length > 0)
   ansible.builtin.set_fact:
     cluster_settings_service_cidr: "{{ cluster_order.spec.network.serviceCIDR }}"
 

--- a/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
+++ b/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
@@ -1,12 +1,45 @@
 ---
 - name: Get template parameters from cluster order
   ansible.builtin.set_fact:
-    cluster_settings_template_parameters: "{{ cluster_order.spec.templateParameters | from_json }}"
+    cluster_settings_template_parameters: "{{ cluster_order.spec.templateParameters | default('{}') | from_json }}"
 
-- name: Get default pull-secret and ssh-key
+# Resolve pull_secret: explicit CR field > templateParameters > provider default Secret
+- name: Resolve pull_secret from explicit field or template parameters
+  ansible.builtin.set_fact:
+    cluster_settings_pull_secret: >-
+      {{ cluster_order.spec.pullSecret
+         | default(cluster_settings_template_parameters.pull_secret | default('')) }}
+  no_log: true
+
+# Resolve ssh_public_key: explicit CR field > templateParameters > provider default Secret
+- name: Resolve ssh_public_key from explicit field or template parameters
+  ansible.builtin.set_fact:
+    cluster_settings_ssh_public_key: >-
+      {{ cluster_order.spec.sshPublicKey
+         | default(cluster_settings_template_parameters.ssh_public_key | default('')) }}
+
+# Resolve release_image: explicit CR field > template default
+- name: Resolve release_image from explicit field
+  when: cluster_order.spec.releaseImage | default('')
+  ansible.builtin.set_fact:
+    ocp_release_image: "{{ cluster_order.spec.releaseImage }}"
+
+# Resolve networking CIDRs: explicit CR field > role defaults
+- name: Resolve pod_cidr from explicit field
+  when: (cluster_order.spec.network | default({})).podCIDR | default('')
+  ansible.builtin.set_fact:
+    cluster_settings_pod_cidr: "{{ cluster_order.spec.network.podCIDR }}"
+
+- name: Resolve service_cidr from explicit field
+  when: (cluster_order.spec.network | default({})).serviceCIDR | default('')
+  ansible.builtin.set_fact:
+    cluster_settings_service_cidr: "{{ cluster_order.spec.network.serviceCIDR }}"
+
+# Fall back to provider default Secret if pull_secret or ssh_public_key still empty
+- name: Get default pull-secret and ssh-key from provider Secret
   when: >-
-    "ssh_public_key" not in cluster_settings_template_parameters
-    or "pull_secret" not in cluster_settings_template_parameters
+    not cluster_settings_pull_secret
+    or not cluster_settings_ssh_public_key
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Secret
@@ -15,40 +48,41 @@
   failed_when: false
   register: default_cluster_credentials
 
-- name: Apply defaults if they exist
-  when: >-
-    default_cluster_credentials.resources|default(false)
+- name: Apply provider defaults for missing credentials
+  when: default_cluster_credentials.resources | default(false)
   block:
-    - name: Set default pull-secret and ssh-key as template default parameters
-      when: >-
-        cluster_settings_template_parameters.ssh_public_key is not defined
-        or cluster_settings_template_parameters.pull_secret is not defined
+    - name: Set pull_secret from provider default
+      when: not cluster_settings_pull_secret
       ansible.builtin.set_fact:
-        cluster_settings_template_defaults: >
-          {{ cluster_settings_template_defaults | combine({
-              'pull_secret': '{{ default_cluster_credentials.resources[0].data.pull_secret | b64decode }}',
-              'ssh_public_key': '{{ default_cluster_credentials.resources[0].data.ssh_public_key | b64decode }}'
-              })
-          }}
+        cluster_settings_pull_secret: "{{ default_cluster_credentials.resources[0].data.pull_secret | b64decode }}"
       no_log: true
 
-    - name: Merge default template parameters with user-provided template parameters
+    - name: Set ssh_public_key from provider default
+      when: not cluster_settings_ssh_public_key
       ansible.builtin.set_fact:
-        cluster_settings_template_defaults: >-
-          {{ cluster_settings_template_defaults | combine(cluster_settings_template_parameters) }}
-      no_log: true
+        cluster_settings_ssh_public_key: "{{ default_cluster_credentials.resources[0].data.ssh_public_key | b64decode }}"
 
-    - name: Merge update template parameters into cluster order
-      ansible.builtin.set_fact:
-        cluster_order: >-
-          {{
-          cluster_order | combine({
-            "spec": {
-              "templateParameters": cluster_settings_template_defaults|to_json,
-            }
-          }, recursive=true)
-          }}
-      no_log: true
+# Write resolved values back into template_parameters for backward compatibility
+- name: Merge resolved credentials into template parameters
+  ansible.builtin.set_fact:
+    cluster_settings_template_parameters: >-
+      {{ cluster_settings_template_parameters | combine({
+        'pull_secret': cluster_settings_pull_secret,
+        'ssh_public_key': cluster_settings_ssh_public_key
+      }) }}
+  no_log: true
+
+- name: Update template parameters in cluster order
+  ansible.builtin.set_fact:
+    cluster_order: >-
+      {{
+      cluster_order | combine({
+        "spec": {
+          "templateParameters": cluster_settings_template_parameters | to_json,
+        }
+      }, recursive=true)
+      }}
+  no_log: true
 
 - name: Set default nodeRequests
   when: >-

--- a/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
+++ b/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
@@ -54,7 +54,7 @@
   register: default_cluster_credentials
 
 - name: Apply provider defaults for missing credentials
-  when: default_cluster_credentials.resources | default(false)
+  when: (default_cluster_credentials.resources | default([]) | length > 0)
   block:
     - name: Set pull_secret from provider default
       when: not cluster_settings_pull_secret

--- a/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
+++ b/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
@@ -4,11 +4,12 @@
     cluster_settings_template_parameters: "{{ cluster_order.spec.templateParameters | default('{}') | from_json }}"
 
 # Resolve pull_secret: explicit CR field > templateParameters > provider default Secret
+# The second argument (true) ensures empty strings and nulls also fall through.
 - name: Resolve pull_secret from explicit field or template parameters
   ansible.builtin.set_fact:
     cluster_settings_pull_secret: >-
       {{ cluster_order.spec.pullSecret
-         | default(cluster_settings_template_parameters.pull_secret | default('')) }}
+         | default(cluster_settings_template_parameters.pull_secret | default('', true), true) }}
   no_log: true
 
 # Resolve ssh_public_key: explicit CR field > templateParameters > provider default Secret
@@ -16,13 +17,17 @@
   ansible.builtin.set_fact:
     cluster_settings_ssh_public_key: >-
       {{ cluster_order.spec.sshPublicKey
-         | default(cluster_settings_template_parameters.ssh_public_key | default('')) }}
+         | default(cluster_settings_template_parameters.ssh_public_key | default('', true), true) }}
 
-# Resolve release_image: explicit CR field > template default
-- name: Resolve release_image from explicit field
-  when: cluster_order.spec.releaseImage | default('')
+# Resolve release_image: explicit CR field > templateParameters > template default
+- name: Resolve release_image from explicit field or template parameters
+  when: >-
+    cluster_order.spec.releaseImage | default('', true)
+    or cluster_settings_template_parameters.release_image | default('', true)
   ansible.builtin.set_fact:
-    ocp_release_image: "{{ cluster_order.spec.releaseImage }}"
+    ocp_release_image: >-
+      {{ cluster_order.spec.releaseImage
+         | default(cluster_settings_template_parameters.release_image | default('', true), true) }}
 
 # Resolve networking CIDRs: explicit CR field > role defaults
 - name: Resolve pod_cidr from explicit field

--- a/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
+++ b/collections/ansible_collections/osac/service/roles/cluster_settings/tasks/main.yml
@@ -22,8 +22,8 @@
 # Resolve release_image: explicit CR field > templateParameters > template default
 - name: Resolve release_image from explicit field or template parameters
   when: >-
-    cluster_order.spec.releaseImage | default('', true)
-    or cluster_settings_template_parameters.release_image | default('', true)
+    (cluster_order.spec.releaseImage | default('', true) | length > 0)
+    or (cluster_settings_template_parameters.release_image | default('', true) | length > 0)
   ansible.builtin.set_fact:
     ocp_release_image: >-
       {{ cluster_order.spec.releaseImage
@@ -31,12 +31,12 @@
 
 # Resolve networking CIDRs: explicit CR field > role defaults
 - name: Resolve pod_cidr from explicit field
-  when: (cluster_order.spec.network | default({})).podCIDR | default('')
+  when: ((cluster_order.spec.network | default({})).podCIDR | default('') | length > 0)
   ansible.builtin.set_fact:
     cluster_settings_pod_cidr: "{{ cluster_order.spec.network.podCIDR }}"
 
 - name: Resolve service_cidr from explicit field
-  when: (cluster_order.spec.network | default({})).serviceCIDR | default('')
+  when: ((cluster_order.spec.network | default({})).serviceCIDR | default('') | length > 0)
   ansible.builtin.set_fact:
     cluster_settings_service_cidr: "{{ cluster_order.spec.network.serviceCIDR }}"
 

--- a/collections/ansible_collections/osac/service/roles/hosted_cluster/defaults/main.yml
+++ b/collections/ansible_collections/osac/service/roles/hosted_cluster/defaults/main.yml
@@ -5,3 +5,6 @@ hosted_cluster_default_cluster_order_label: "{{ {cluster_order_label: hosted_clu
 hosted_cluster_node_requests: []
 hosted_cluster_controller_availability_policy: HighlyAvailable
 hosted_cluster_infrastructure_availability_policy: HighlyAvailable
+# Default networking CIDRs - can be overridden via cluster_settings_pod_cidr / cluster_settings_service_cidr
+hosted_cluster_pod_cidr: "{{ cluster_settings_pod_cidr | default('10.128.0.0/14') }}"
+hosted_cluster_service_cidr: "{{ cluster_settings_service_cidr | default('172.30.0.0/16') }}"

--- a/collections/ansible_collections/osac/service/roles/hosted_cluster/defaults/main.yml
+++ b/collections/ansible_collections/osac/service/roles/hosted_cluster/defaults/main.yml
@@ -6,5 +6,5 @@ hosted_cluster_node_requests: []
 hosted_cluster_controller_availability_policy: HighlyAvailable
 hosted_cluster_infrastructure_availability_policy: HighlyAvailable
 # Default networking CIDRs - can be overridden via cluster_settings_pod_cidr / cluster_settings_service_cidr
-hosted_cluster_pod_cidr: "{{ cluster_settings_pod_cidr | default('10.128.0.0/14') }}"
-hosted_cluster_service_cidr: "{{ cluster_settings_service_cidr | default('172.30.0.0/16') }}"
+hosted_cluster_pod_cidr: "{{ cluster_settings_pod_cidr | default('10.132.0.0/14') }}"
+hosted_cluster_service_cidr: "{{ cluster_settings_service_cidr | default('172.31.0.0/16') }}"

--- a/collections/ansible_collections/osac/service/roles/hosted_cluster/tasks/create_hosted_cluster.yaml
+++ b/collections/ansible_collections/osac/service/roles/hosted_cluster/tasks/create_hosted_cluster.yaml
@@ -44,9 +44,9 @@
           name: "sshkey-cluster-{{ hosted_cluster_name }}"
         networking:
           clusterNetwork:
-            - cidr: 10.132.0.0/14
+            - cidr: "{{ hosted_cluster_pod_cidr }}"
           serviceNetwork:
-            - cidr: 172.31.0.0/16
+            - cidr: "{{ hosted_cluster_service_cidr }}"
         platform:
           type: Agent
           agent:

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_17_small/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_17_small/tasks/delete.yaml
@@ -31,8 +31,8 @@
     hosted_cluster_namespace: "{{ cluster_working_namespace }}"
     hosted_cluster_settings:
       ocp_release_image: "{{ ocp_release_image }}"
-      pull_secret: "{{ template_parameters.pull_secret }}"
-      ssh_public_key: "{{ template_parameters.ssh_public_key }}"
+      pull_secret: "{{ cluster_settings_pull_secret }}"
+      ssh_public_key: "{{ cluster_settings_ssh_public_key }}"
     hosted_cluster_node_count: >-
       {{ cluster_order.spec.nodeRequests | map(attribute="numberOfNodes") | sum }}
 

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_17_small/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_17_small/tasks/install.yaml
@@ -36,8 +36,8 @@
     hosted_cluster_namespace: "{{ cluster_working_namespace }}"
     hosted_cluster_settings:
       ocp_release_image: "{{ ocp_release_image }}"
-      pull_secret: "{{ template_parameters.pull_secret }}"
-      ssh_public_key: "{{ template_parameters.ssh_public_key }}"
+      pull_secret: "{{ cluster_settings_pull_secret }}"
+      ssh_public_key: "{{ cluster_settings_ssh_public_key }}"
     hosted_cluster_node_requests: "{{ cluster_order.spec.nodeRequests | unique(attribute='resourceClass') }}"
     hosted_cluster_state: present
 


### PR DESCRIPTION
## Summary
- Update `cluster_settings` role to resolve `pull_secret`, `ssh_public_key`, `release_image`, and network CIDRs from explicit CR fields
- Fallback chain: explicit CR field > templateParameters > provider default Secret
- Update `hosted_cluster` role to use configurable CIDRs instead of hardcoded values
- Backward compatible: existing ClusterOrders without explicit fields continue to work

## Jira
[MGMT-23939](https://redhat.atlassian.net/browse/MGMT-23939)

## Related
- fulfillment-service: [fulfillment-service#416](https://github.com/osac-project/fulfillment-service/pull/416)
- osac-operator CRD: [osac-operator#186](https://github.com/osac-project/osac-operator/pull/186)

## Test plan
- [x] pre-commit hooks pass (yamllint)
- [ ] E2E test with explicit fields on live environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pod and service CIDRs are now configurable for hosted clusters with sensible defaults and are applied when creating clusters.
  * Pull-secret handling updated to use resolved credentials consistently and preserve resolved settings for compatibility.

* **Bug Fixes**
  * More robust handling of missing or empty template parameters; provider defaults apply only when credentials are truly absent.
  * Network lookup logic now explicitly checks for returned results to avoid false-positive/negative conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->