### PR TITLE
Rename host_class to host_type in Ansible collections

### DIFF
--- a/collections/ansible_collections/massopencloud/esi/plugins/filter/ironic_node_to_osac_host.py
+++ b/collections/ansible_collections/massopencloud/esi/plugins/filter/ironic_node_to_osac_host.py
@@ -3,7 +3,7 @@
 def ironic_node_to_osac_host(ironic_node):
     host = {
         "name": ironic_node["name"],
-        "host_class": ironic_node["resource_class"],
+        "host_type": ironic_node["resource_class"],
         "power_state": ironic_node["power_state"],
         "target_power_state": ironic_node["target_power_state"],
     }

--- a/collections/ansible_collections/massopencloud/esi/roles/host/meta/argument_specs.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/host/meta/argument_specs.yaml
@@ -17,7 +17,7 @@ argument_specs:
         required: true
   list_hosts:
     options:
-      host_class:
-        description: Host class to filter hosts by
+      host_type:
+        description: Host type to filter hosts by
         type: "str"
         required: false

--- a/collections/ansible_collections/massopencloud/esi/roles/host/tasks/list_hosts.yaml
+++ b/collections/ansible_collections/massopencloud/esi/roles/host/tasks/list_hosts.yaml
@@ -7,9 +7,9 @@
     node_list: "{{ baremetal_node_info_result.baremetal_nodes | selectattr('extra.purpose', 'defined') | selectattr('extra.purpose', 'equalto', 'host') | list }}"
 
 - name: Filter by resource class
-  when: host_class is defined
+  when: host_type is defined
   ansible.builtin.set_fact:
-    node_list: "{{ node_list | selectattr('resource_class', 'equalto', host_class) | list }}"
+    node_list: "{{ node_list | selectattr('resource_class', 'equalto', host_type) | list }}"
 
 - name: Filter by available hosts
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -176,7 +176,7 @@ class NodeRequest(Base):
 class NodeSet(Base):
     """NodeSet represents the template's default bare metal resources"""
 
-    host_class: str
+    host_type: str
     size: int
 
 
@@ -242,7 +242,7 @@ class ClusterTemplate(BaseTemplate):
     def node_sets(self) -> dict[str, NodeSet] | None:
         ret = {
             nr.resource_class: NodeSet(
-                host_class=nr.resource_class, size=nr.number_of_nodes
+                host_type=nr.resource_class, size=nr.number_of_nodes
             )
             for nr in self.default_node_request
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated host filtering parameter name from `host_class` to `host_type` across filters and role configuration specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->