### PR TITLE
NO_ISSUE: fix bootstrap job auth upstream readiness check

### DIFF
--- a/config/base/job.yaml
+++ b/config/base/job.yaml
@@ -32,7 +32,14 @@ spec:
               CONTROLLER_GATEWAY=$?
               echo "CONTROLLER_GATEWAY exit code: $CONTROLLER_GATEWAY"
 
-              if [ $GATEWAY -eq 0 ] && [ $EDA_GATEWAY -eq 0 ] && [ $CONTROLLER_GATEWAY -eq 0 ];
+              auth_code=$(curl -sk -o /dev/null -w "%{http_code}" -X POST \
+                http://${AAP_GATEWAY_HOSTNAME}/api/gateway/v1/tokens/ \
+                -d "username=admin&password=dummy" 2>/dev/null)
+              [ "$auth_code" != "503" ] && [ "$auth_code" != "000" ];
+              AUTH_UPSTREAM=$?
+              echo "AUTH_UPSTREAM exit code: $AUTH_UPSTREAM (HTTP $auth_code)"
+
+              if [ $GATEWAY -eq 0 ] && [ $EDA_GATEWAY -eq 0 ] && [ $CONTROLLER_GATEWAY -eq 0 ] && [ $AUTH_UPSTREAM -eq 0 ];
               then
                 echo "AAP controller is ready!"
                 exit 0


### PR DESCRIPTION
The init container's ping-based health checks pass before the gateway auth backend
is fully ready. The bootstrap playbook then fails with `HTTP 503: no healthy upstream`
when trying to acquire a token. With Kubernetes exponential backoff, retries don't
complete within the oc wait timeout window in CI.

Adds a 4th readiness check that verifies the tokens endpoint returns a non-503 response
before proceeding to the bootstrap playbook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced initialization process with authentication verification during service startup
  * Service readiness now requires successful authentication validation before marking the instance as ready
  * Improved deployment reliability through comprehensive startup checks that verify authentication credentials
  * Ensures proper authentication is established and validated before the service becomes operational

<!-- end of auto-generated comment: release notes by coderabbit.ai -->