### PR TITLE
MGMT-23733/MGMT-23823: add unit tests for metallb_l2 role

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -62,6 +62,33 @@
     - name: Run create tests
       when: run_create | default(true) | bool
       block:
+        - name: Check IPAddressPool does not already exist
+          kubernetes.core.k8s_info:
+            api_version: metallb.io/v1beta1
+            kind: IPAddressPool
+            name: "{{ test_pool_name }}"
+            namespace: metallb-system
+          register: pre_create_pool
+
+        - name: Check L2Advertisement does not already exist
+          kubernetes.core.k8s_info:
+            api_version: metallb.io/v1beta1
+            kind: L2Advertisement
+            name: "{{ test_pool_name }}-l2adv"
+            namespace: metallb-system
+          register: pre_create_l2adv
+
+        - name: Assert clean state before create
+          ansible.builtin.assert:
+            that:
+              - pre_create_pool.resources | length == 0
+              - pre_create_l2adv.resources | length == 0
+            fail_msg: >-
+              Stale test resources exist from a previous run. Clean up with:
+              oc delete ipaddresspool {{ test_pool_name }} -n metallb-system --ignore-not-found &&
+              oc delete l2advertisement {{ test_pool_name }}-l2adv -n metallb-system --ignore-not-found
+            success_msg: "No stale resources, proceeding with create"
+
         - name: Create MetalLB resources via metallb_l2 role
           ansible.builtin.include_role:
             name: osac.templates.metallb_l2
@@ -115,6 +142,27 @@
               - l2advertisement_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
             fail_msg: "L2Advertisement labels incorrect"
             success_msg: "L2Advertisement labels correct"
+
+      always:
+        - name: Clean up IPAddressPool on failure
+          kubernetes.core.k8s:
+            api_version: metallb.io/v1beta1
+            kind: IPAddressPool
+            name: "{{ test_pool_name }}"
+            namespace: metallb-system
+            state: absent
+          when: ansible_failed_result is defined
+          ignore_errors: true
+
+        - name: Clean up L2Advertisement on failure
+          kubernetes.core.k8s:
+            api_version: metallb.io/v1beta1
+            kind: L2Advertisement
+            name: "{{ test_pool_name }}-l2adv"
+            namespace: metallb-system
+            state: absent
+          when: ansible_failed_result is defined
+          ignore_errors: true
 
 # ──────────────────────────────────────────────────────────────
 # Test: Delete IPAddressPool and L2Advertisement

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -1,0 +1,185 @@
+---
+# Test playbook for osac.templates.metallb_l2 role.
+#
+# Tests create and delete of MetalLB IPAddressPool and L2Advertisement
+# resources. Requires a cluster with MetalLB CRDs applied and the
+# metallb-system namespace present. No MetalLB operator is needed since
+# tests only verify CR creation and deletion, not controller behavior.
+#
+# Do NOT set OSAC_REMOTE_CLUSTER_KUBECONFIG when running these tests.
+# The role's get_remote_cluster_kubeconfig include is a no-op without it,
+# and kubernetes.core.k8s falls back to the default kubeconfig.
+#
+# Usage:
+#   # Run all tests in sequence (create, verify, delete, delete-not-found)
+#   ansible-playbook test.yml -v
+#
+#   # Run only create tests
+#   ansible-playbook test.yml -e run_create=true -v
+#
+#   # Run only delete tests (resources must already exist)
+#   ansible-playbook test.yml -e run_delete=true -v
+#
+#   # Run only delete-not-found test (resources must NOT exist)
+#   ansible-playbook test.yml -e run_delete_not_found=true -v
+
+# ──────────────────────────────────────────────────────────────
+# Test: Create IPAddressPool and L2Advertisement
+# Expected: Both resources created in metallb-system with correct
+#   spec, labels, and naming conventions.
+# ──────────────────────────────────────────────────────────────
+- name: Test metallb_l2 role -- create PublicIPPool resources
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    test_pool_name: "test-metallb-pool"
+    test_pool_cidrs:
+      - "192.168.100.0/28"
+      - "192.168.101.0/28"
+    public_ip_pool_name: "{{ test_pool_name }}"
+    public_ip_pool:
+      metadata:
+        name: "{{ test_pool_name }}"
+      spec:
+        cidrs: "{{ test_pool_cidrs }}"
+
+  tasks:
+    - name: Run create tests
+      when: run_create | default(true) | bool
+      block:
+        - name: Create MetalLB resources via metallb_l2 role
+          ansible.builtin.include_role:
+            name: osac.templates.metallb_l2
+            tasks_from: create_public_ip_pool
+
+        - name: Fetch IPAddressPool
+          kubernetes.core.k8s_info:
+            api_version: metallb.io/v1beta1
+            kind: IPAddressPool
+            name: "{{ test_pool_name }}"
+            namespace: metallb-system
+          register: ipaddresspool_result
+
+        - name: Verify IPAddressPool exists with correct spec
+          ansible.builtin.assert:
+            that:
+              - ipaddresspool_result.resources | length == 1
+              - ipaddresspool_result.resources[0].spec.autoAssign == false
+              - ipaddresspool_result.resources[0].spec.addresses == test_pool_cidrs
+            fail_msg: "IPAddressPool not created correctly"
+            success_msg: "IPAddressPool '{{ test_pool_name }}' created with correct spec"
+
+        - name: Verify IPAddressPool labels
+          ansible.builtin.assert:
+            that:
+              - ipaddresspool_result.resources[0].metadata.labels['osac.openshift.io/publicippool'] == test_pool_name
+              - ipaddresspool_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
+            fail_msg: "IPAddressPool labels incorrect"
+            success_msg: "IPAddressPool labels correct"
+
+        - name: Fetch L2Advertisement
+          kubernetes.core.k8s_info:
+            api_version: metallb.io/v1beta1
+            kind: L2Advertisement
+            name: "{{ test_pool_name }}-l2adv"
+            namespace: metallb-system
+          register: l2advertisement_result
+
+        - name: Verify L2Advertisement exists and references IPAddressPool
+          ansible.builtin.assert:
+            that:
+              - l2advertisement_result.resources | length == 1
+              - test_pool_name in l2advertisement_result.resources[0].spec.ipAddressPools
+            fail_msg: "L2Advertisement not created correctly"
+            success_msg: "L2Advertisement '{{ test_pool_name }}-l2adv' created referencing correct pool"
+
+        - name: Verify L2Advertisement labels
+          ansible.builtin.assert:
+            that:
+              - l2advertisement_result.resources[0].metadata.labels['osac.openshift.io/publicippool'] == test_pool_name
+              - l2advertisement_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
+            fail_msg: "L2Advertisement labels incorrect"
+            success_msg: "L2Advertisement labels correct"
+
+# ──────────────────────────────────────────────────────────────
+# Test: Delete IPAddressPool and L2Advertisement
+# Expected: Both resources deleted. L2Advertisement deleted first.
+# ──────────────────────────────────────────────────────────────
+- name: Test metallb_l2 role -- delete PublicIPPool resources
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    test_pool_name: "test-metallb-pool"
+    public_ip_pool_name: "{{ test_pool_name }}"
+    public_ip_pool:
+      metadata:
+        name: "{{ test_pool_name }}"
+
+  tasks:
+    - name: Run delete tests
+      when: run_delete | default(true) | bool
+      block:
+        - name: Delete MetalLB resources via metallb_l2 role
+          ansible.builtin.include_role:
+            name: osac.templates.metallb_l2
+            tasks_from: delete_public_ip_pool
+
+        - name: Verify IPAddressPool is gone
+          kubernetes.core.k8s_info:
+            api_version: metallb.io/v1beta1
+            kind: IPAddressPool
+            name: "{{ test_pool_name }}"
+            namespace: metallb-system
+          register: ipaddresspool_after_delete
+
+        - name: Assert IPAddressPool deleted
+          ansible.builtin.assert:
+            that:
+              - ipaddresspool_after_delete.resources | length == 0
+            fail_msg: "IPAddressPool still exists after delete"
+            success_msg: "IPAddressPool '{{ test_pool_name }}' successfully deleted"
+
+        - name: Verify L2Advertisement is gone
+          kubernetes.core.k8s_info:
+            api_version: metallb.io/v1beta1
+            kind: L2Advertisement
+            name: "{{ test_pool_name }}-l2adv"
+            namespace: metallb-system
+          register: l2adv_after_delete
+
+        - name: Assert L2Advertisement deleted
+          ansible.builtin.assert:
+            that:
+              - l2adv_after_delete.resources | length == 0
+            fail_msg: "L2Advertisement still exists after delete"
+            success_msg: "L2Advertisement '{{ test_pool_name }}-l2adv' successfully deleted"
+
+# ──────────────────────────────────────────────────────────────
+# Test: Delete when resources already gone (NotFound handling)
+# Expected: No failure. The role tolerates already-deleted resources.
+# ──────────────────────────────────────────────────────────────
+- name: Test metallb_l2 role -- delete tolerates NotFound
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    test_pool_name: "test-metallb-pool"
+    public_ip_pool_name: "{{ test_pool_name }}"
+    public_ip_pool:
+      metadata:
+        name: "{{ test_pool_name }}"
+
+  tasks:
+    - name: Run delete-not-found test
+      when: run_delete_not_found | default(true) | bool
+      block:
+        - name: Delete already-gone resources (should not fail)
+          ansible.builtin.include_role:
+            name: osac.templates.metallb_l2
+            tasks_from: delete_public_ip_pool
+
+        - name: Confirm no failure occurred
+          ansible.builtin.debug:
+            msg: "Delete-not-found test passed: role tolerated already-deleted resources"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -15,13 +15,27 @@
 #   ansible-playbook test.yml -v
 #
 #   # Run only create tests
-#   ansible-playbook test.yml -e run_create=true -v
+#   ansible-playbook test.yml -e run_create=true -e run_delete=false -e run_delete_not_found=false -v
 #
 #   # Run only delete tests (resources must already exist)
-#   ansible-playbook test.yml -e run_delete=true -v
+#   ansible-playbook test.yml -e run_delete=true -e run_create=false -e run_delete_not_found=false -v
 #
 #   # Run only delete-not-found test (resources must NOT exist)
-#   ansible-playbook test.yml -e run_delete_not_found=true -v
+#   ansible-playbook test.yml -e run_delete_not_found=true -e run_create=false -e run_delete=false -v
+
+# ──────────────────────────────────────────────────────────────
+# Pre-flight: fail fast if OSAC_REMOTE_CLUSTER_KUBECONFIG is set
+# ──────────────────────────────────────────────────────────────
+- name: Validate metallb_l2 test environment
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Fail if OSAC_REMOTE_CLUSTER_KUBECONFIG is set
+      ansible.builtin.fail:
+        msg: >-
+          OSAC_REMOTE_CLUSTER_KUBECONFIG is set. This test expects the role to
+          use the default kubeconfig. Unset the variable before running tests.
+      when: lookup('env', 'OSAC_REMOTE_CLUSTER_KUBECONFIG') | length > 0
 
 # ──────────────────────────────────────────────────────────────
 # Test: Create IPAddressPool and L2Advertisement
@@ -121,6 +135,30 @@
     - name: Run delete tests
       when: run_delete | default(true) | bool
       block:
+        - name: Verify IPAddressPool exists before delete
+          kubernetes.core.k8s_info:
+            api_version: metallb.io/v1beta1
+            kind: IPAddressPool
+            name: "{{ test_pool_name }}"
+            namespace: metallb-system
+          register: pre_delete_pool
+
+        - name: Verify L2Advertisement exists before delete
+          kubernetes.core.k8s_info:
+            api_version: metallb.io/v1beta1
+            kind: L2Advertisement
+            name: "{{ test_pool_name }}-l2adv"
+            namespace: metallb-system
+          register: pre_delete_l2adv
+
+        - name: Assert resources exist (otherwise delete test is meaningless)
+          ansible.builtin.assert:
+            that:
+              - pre_delete_pool.resources | length == 1
+              - pre_delete_l2adv.resources | length == 1
+            fail_msg: "Resources do not exist before delete. Run create tests first or run all tests together."
+            success_msg: "Both resources exist, proceeding with delete"
+
         - name: Delete MetalLB resources via metallb_l2 role
           ansible.builtin.include_role:
             name: osac.templates.metallb_l2
@@ -175,6 +213,30 @@
     - name: Run delete-not-found test
       when: run_delete_not_found | default(true) | bool
       block:
+        - name: Verify IPAddressPool is absent before NotFound test
+          kubernetes.core.k8s_info:
+            api_version: metallb.io/v1beta1
+            kind: IPAddressPool
+            name: "{{ test_pool_name }}"
+            namespace: metallb-system
+          register: pre_notfound_pool
+
+        - name: Verify L2Advertisement is absent before NotFound test
+          kubernetes.core.k8s_info:
+            api_version: metallb.io/v1beta1
+            kind: L2Advertisement
+            name: "{{ test_pool_name }}-l2adv"
+            namespace: metallb-system
+          register: pre_notfound_l2adv
+
+        - name: Assert resources are absent (otherwise this is not a NotFound test)
+          ansible.builtin.assert:
+            that:
+              - pre_notfound_pool.resources | length == 0
+              - pre_notfound_l2adv.resources | length == 0
+            fail_msg: "Resources still exist. Run delete tests first or clean up manually."
+            success_msg: "Both resources absent, proceeding with NotFound test"
+
         - name: Delete already-gone resources (should not fail)
           ansible.builtin.include_role:
             name: osac.templates.metallb_l2


### PR DESCRIPTION
## Summary

[MGMT-23823](https://redhat.atlassian.net/browse/MGMT-23823): Add role-level
unit tests for `osac.templates.metallb_l2`, the Ansible role that creates and
deletes MetalLB IPAddressPool and L2Advertisement resources for PublicIPPool
provisioning.

The test playbook calls the role directly via `include_role` with fixture
variables and verifies the Kubernetes resources are created with the correct
spec, labels, and naming conventions. It also verifies deletion and graceful
NotFound handling.

**Test robustness:**
- Pre-flight guard fails fast if `OSAC_REMOTE_CLUSTER_KUBECONFIG` is set
  (prevents role and verification tasks from targeting different clusters)
- Pre-create absence check fails fast if stale resources from a previous
  interrupted run exist (prevents silently testing an update instead of a create)
- Failure cleanup (`always` block) removes test resources if the create play
  fails, so the next run starts from a clean state
- Pre-delete existence check ensures the delete test actually deletes something
- Pre-NotFound absence check ensures the NotFound test exercises the right path
- Usage examples show how to run individual plays with explicit disable flags

## Test Scenarios

| # | Scenario | What is verified |
|---|----------|------------------|
| 1 | Create pool | IPAddressPool created in metallb-system with autoAssign=false, correct addresses |
| 2 | Create L2Advertisement | L2Advertisement created referencing the correct IPAddressPool |
| 3 | Labels | Both resources have `osac.openshift.io/publicippool` and `osac.io/managed-by` labels |
| 4 | Delete | Pre-check confirms resources exist, then both resources deleted and confirmed gone |
| 5 | Delete NotFound | Pre-check confirms resources absent, then delete tolerates already-gone resources without failure |

## Testing

Requires a cluster with MetalLB CRDs applied and `metallb-system` namespace.
No MetalLB operator needed (tests only verify CR creation/deletion).

### How to run

```bash
cd osac-aap

KUBECONFIG=/path/to/kubeconfig \
  .venv/bin/ansible-playbook \
    collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml \
    -e ansible_python_interpreter=$(pwd)/.venv/bin/python3 \
    -v
```

### Results on edge22 (2026-04-20)

All 5 scenarios pass. No retries needed. The playbook runs 4 plays: environment
validation, create + verify, delete + verify, delete-not-found.

**Play 1: Environment validation**
- OSAC_REMOTE_CLUSTER_KUBECONFIG not set: **PASS** (skipped, correct)

**Play 2: Create + Verify**
- Pre-create: no stale resources: **PASS**
- IPAddressPool created in metallb-system: **PASS** (autoAssign=false, addresses match CIDRs)
- L2Advertisement created referencing pool: **PASS** (ipAddressPools contains pool name)
- IPAddressPool labels correct: **PASS**
- L2Advertisement labels correct: **PASS**
- Failure cleanup: skipped (no failure, correct)

**Play 3: Delete + Verify**
- Pre-check: both resources exist: **PASS**
- Both resources deleted and confirmed gone: **PASS**

**Play 4: Delete NotFound**
- Pre-check: both resources absent: **PASS**
- Delete tolerates NotFound: **PASS** (changed=false, no failure)

```
PLAY RECAP *********************************************************************
localhost : ok=47   changed=4   unreachable=0   failed=0   skipped=6   rescued=0   ignored=0
```

- **failed=0** confirms all assertions passed
- **changed=4**: the 4 actual K8s mutations (create pool, create l2adv, delete l2adv, delete pool)
- **skipped=6**: environment guard + 3x get_remote_cluster_kubeconfig + 2x failure cleanup (all expected)

### ansible-lint

No lint violations on the test file.

## CI Note

Role-level tests are not yet wired into the CI pipeline. PR #239 ([MGMT-23822](https://redhat.atlassian.net/browse/MGMT-23822))
will add role test discovery to `make test`. Until then, these tests must be
run manually.

## Ticket

[MGMT-23823](https://redhat.atlassian.net/browse/MGMT-23823)
(subtask of [MGMT-23733](https://redhat.atlassian.net/browse/MGMT-23733))
<br>

<small>Assisted-by: Cursor/Claude</small>
