### PR TITLE
NO_ISSUE: fix vendored aap_configuration regex_replace corrupting omit sentinel

### DIFF
--- a/vendor/ansible_collections/infra/aap_configuration/roles/controller_credential_types/tasks/main.yml
+++ b/vendor/ansible_collections/infra/aap_configuration/roles/controller_credential_types/tasks/main.yml
@@ -4,7 +4,7 @@
     name: "{{ __controller_credential_type_item.name | mandatory }}"
     new_name: "{{ __controller_credential_type_item.new_name | default(omit, true) }}"
     description: "{{ __controller_credential_type_item.description | default(('' if controller_configuration_credential_types_enforce_defaults else omit), true) }}"
-    injectors: "{{ __controller_credential_type_item.injectors | default(({} if controller_configuration_credential_types_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+    injectors: "{{ __controller_credential_type_item.injectors | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_credential_type_item.injectors is defined and __controller_credential_type_item.injectors) else ({} if controller_configuration_credential_types_enforce_defaults else omit) }}"
     inputs: "{{ __controller_credential_type_item.inputs | default(({} if controller_configuration_credential_types_enforce_defaults else omit), true) }}"
     kind: "{{ __controller_credential_type_item.kind | default('cloud') }}"
     state: "{{ __controller_credential_type_item.state | default(platform_state | default('present')) }}"

--- a/vendor/ansible_collections/infra/aap_configuration/roles/controller_host_groups/tasks/main.yml
+++ b/vendor/ansible_collections/infra/aap_configuration/roles/controller_host_groups/tasks/main.yml
@@ -7,7 +7,7 @@
     new_name: "{{ __controller_groups_item.new_name | default(omit, true) }}"
     description: "{{ __controller_groups_item.description | default(('' if controller_configuration_groups_enforce_defaults else omit), true) }}"
     inventory: "{{ __controller_groups_item.inventory | mandatory }}"
-    variables: "{{ __controller_groups_item.variables | default(({} if controller_configuration_groups_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+    variables: "{{ __controller_groups_item.variables | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_groups_item.variables is defined and __controller_groups_item.variables) else ({} if controller_configuration_groups_enforce_defaults else omit) }}"
     hosts: "{{ __controller_groups_item.hosts | default(([] if controller_configuration_groups_enforce_defaults else omit), true) }}"
     children: "{{ __controller_groups_item.children | default(([] if controller_configuration_groups_enforce_defaults else omit), true) }}"
     preserve_existing_hosts: "{{ __controller_groups_item.preserve_existing_hosts | default((false if controller_configuration_groups_enforce_defaults else omit)) }}"

--- a/vendor/ansible_collections/infra/aap_configuration/roles/controller_hosts/tasks/main.yml
+++ b/vendor/ansible_collections/infra/aap_configuration/roles/controller_hosts/tasks/main.yml
@@ -7,7 +7,7 @@
     inventory: "{{ __controller_host_item.inventory | mandatory }}"
     enabled: "{{ __controller_host_item.enabled | default((false if controller_configuration_host_enforce_defaults else omit), true) }}"
     state: "{{ __controller_host_item.state | default(platform_state | default('present')) }}"
-    variables: "{{ __controller_host_item.variables | default(({} if controller_configuration_host_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+    variables: "{{ __controller_host_item.variables | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_host_item.variables is defined and __controller_host_item.variables) else ({} if controller_configuration_host_enforce_defaults else omit) }}"
 
     # Role Standard Options
     controller_host: "{{ aap_hostname | default(omit, true) }}"

--- a/vendor/ansible_collections/infra/aap_configuration/roles/controller_inventories/tasks/main.yml
+++ b/vendor/ansible_collections/infra/aap_configuration/roles/controller_inventories/tasks/main.yml
@@ -8,7 +8,7 @@
     organization: "{{ __controller_inventory_item.organization.name | default(__controller_inventory_item.organization) | mandatory }}"
     instance_groups: "{{ __controller_inventory_item.instance_groups | default(([] if controller_configuration_inventories_enforce_defaults else omit), true) }}"
     input_inventories: "{{ __controller_inventory_item.input_inventories | default(([] if controller_configuration_inventories_enforce_defaults else omit), true) }}"
-    variables: "{{ __controller_inventory_item.variables | default(({} if controller_configuration_inventories_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+    variables: "{{ __controller_inventory_item.variables | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_inventory_item.variables is defined and __controller_inventory_item.variables) else ({} if controller_configuration_inventories_enforce_defaults else omit) }}"
     kind: "{{ __controller_inventory_item.kind | default(('' if controller_configuration_inventories_enforce_defaults else omit), true) }}"
     host_filter: "{{ __controller_inventory_item.host_filter | default(('' if controller_configuration_inventories_enforce_defaults else omit), true) }}"
     prevent_instance_group_fallback: "{{ __controller_inventory_item.prevent_instance_group_fallback | default((false if controller_configuration_inventories_enforce_defaults else omit), true) }}"

--- a/vendor/ansible_collections/infra/aap_configuration/roles/controller_inventory_sources/tasks/main.yml
+++ b/vendor/ansible_collections/infra/aap_configuration/roles/controller_inventory_sources/tasks/main.yml
@@ -8,7 +8,7 @@
     organization: "{{ __controller_source_item.inventory.organization.name | default(__controller_source_item.organization | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true)) }}"
     source: "{{ __controller_source_item.source | default(('scm' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
     source_path: "{{ __controller_source_item.source_path | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
-    source_vars: "{{ __controller_source_item.source_vars | default(({} if controller_configuration_inventory_sources_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+    source_vars: "{{ __controller_source_item.source_vars | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_source_item.source_vars is defined and __controller_source_item.source_vars) else ({} if controller_configuration_inventory_sources_enforce_defaults else omit) }}"
     enabled_var: "{{ __controller_source_item.enabled_var | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
     enabled_value: "{{ __controller_source_item.enabled_value | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"
     host_filter: "{{ __controller_source_item.host_filter | default(('' if controller_configuration_inventory_sources_enforce_defaults else omit), true) }}"

--- a/vendor/ansible_collections/infra/aap_configuration/roles/controller_notification_templates/tasks/main.yml
+++ b/vendor/ansible_collections/infra/aap_configuration/roles/controller_notification_templates/tasks/main.yml
@@ -8,7 +8,7 @@
     organization: "{{ __controller_notification_item.organization.name | default(__controller_notification_item.organization) | default(omit, true) }}"
     notification_type: "{{ __controller_notification_item.notification_type | default(omit, true) }}"
     notification_configuration: "{{ __controller_notification_item.notification_configuration | default(({} if controller_configuration_notifications_enforce_defaults else omit), true) }}"
-    messages: "{{ __controller_notification_item.messages | default(({} if controller_configuration_notifications_enforce_defaults else omit), true) | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') }}"
+    messages: "{{ __controller_notification_item.messages | regex_replace('{  {', '{_~~remove~~_{') | regex_replace('_~~remove~~_', '') if (__controller_notification_item.messages is defined and __controller_notification_item.messages) else ({} if controller_configuration_notifications_enforce_defaults else omit) }}"
     state: "{{ __controller_notification_item.state | default(platform_state | default('present')) }}"
 
     # Role Standard Options


### PR DESCRIPTION
Backport of the upstream fix from `infra.aap_configuration` (fixed between v3.4.1 and v4.x).

## Problem

When `variables`, `source_vars`, `injectors`, or `messages` are not defined in the
inventory/host/credential_type/notification config, the vendored v3.4.1 code pipes
the Ansible `omit` sentinel through `regex_replace`:

```yaml
variables: "{{ ... | default(omit) | regex_replace(...) }}"
```

This corrupts the `omit` sentinel, causing the `ansible.controller` module to receive
it as a literal string. Since the module declares `variables=dict(type='dict')`, it
fails with:

```
argument 'variables' is of type str and we were unable to convert to dict
```

This breaks the AAP bootstrap job — all 5 controller inventories fail to create.

## Fix

Apply the upstream pattern: only call `regex_replace` when the variable is actually
defined, keeping `omit` on a separate code path:

```yaml
variables: "{{ ... | regex_replace(...) if (var is defined and var) else (... omit) }}"
```

## Affected roles (all 6 fixed)

- `controller_inventories` — `variables`
- `controller_inventory_sources` — `source_vars`
- `controller_credential_types` — `injectors`
- `controller_host_groups` — `variables`
- `controller_hosts` — `variables`
- `controller_notification_templates` — `messages`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or undefined configuration variables in deployments: placeholder-cleanup transformations are now skipped when values are missing, preventing unnecessary processing and reducing unexpected side-effects.

* **Chores**
  * Updated approvers and reviewers list to include an additional team member.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->