### PR TITLE
MGMT-23556: Create the centralized interface and move current AWS implementation to be first backend

### DIFF
--- a/collections/ansible_collections/dns/api/roles/dns/defaults/main.yaml
+++ b/collections/ansible_collections/dns/api/roles/dns/defaults/main.yaml
@@ -1,0 +1,1 @@
+dns_class: dns.route53.dns

--- a/collections/ansible_collections/dns/api/roles/dns/meta/argument_specs.yaml
+++ b/collections/ansible_collections/dns/api/roles/dns/meta/argument_specs.yaml
@@ -1,0 +1,70 @@
+---
+argument_specs:
+  create:
+    short_description: Create a DNS record
+    options:
+      dns_class:
+        type: str
+        required: false
+        default: dns.route53.dns
+        description: >
+          Fully-qualified Ansible role name of the DNS driver to use
+          (e.g., dns.route53.dns, dns.cloudflare.dns,
+          or a third-party role like myorg.mycollection.custom_dns).
+      dns_zone:
+        type: str
+        required: true
+        description: >
+          The DNS zone to operate in (e.g., "example.com").
+          Passed through to the backend driver.
+      dns_record_name:
+        type: str
+        required: true
+        description: Fully qualified domain name for the record.
+      dns_record_type:
+        type: str
+        required: false
+        default: A
+        choices: [A, AAAA]
+        description: DNS record type.
+      dns_record_value:
+        type: str
+        required: true
+        description: >
+          The value for the record (e.g., an IPv4 address for A records,
+          an IPv6 address for AAAA records).
+      dns_record_ttl:
+        type: int
+        required: false
+        default: 1800
+        description: TTL in seconds.
+      dns_record_overwrite:
+        type: bool
+        required: false
+        default: true
+        description: Whether to overwrite an existing record.
+  delete:
+    short_description: Delete a DNS record
+    options:
+      dns_class:
+        type: str
+        required: false
+        default: dns.route53.dns
+        description: >
+          Fully-qualified Ansible role name of the DNS driver to use.
+      dns_zone:
+        type: str
+        required: true
+        description: >
+          The DNS zone to operate in (e.g., "example.com").
+          Passed through to the backend driver.
+      dns_record_name:
+        type: str
+        required: true
+        description: Fully qualified domain name for the record.
+      dns_record_type:
+        type: str
+        required: false
+        default: A
+        choices: [A, AAAA]
+        description: DNS record type.

--- a/collections/ansible_collections/dns/api/roles/dns/tasks/create.yaml
+++ b/collections/ansible_collections/dns/api/roles/dns/tasks/create.yaml
@@ -1,0 +1,5 @@
+---
+- name: "Create DNS record - {{ dns_class }}"
+  ansible.builtin.include_role:
+    name: "{{ dns_class }}"
+    tasks_from: create

--- a/collections/ansible_collections/dns/api/roles/dns/tasks/delete.yaml
+++ b/collections/ansible_collections/dns/api/roles/dns/tasks/delete.yaml
@@ -1,0 +1,5 @@
+---
+- name: "Delete DNS record - {{ dns_class }}"
+  ansible.builtin.include_role:
+    name: "{{ dns_class }}"
+    tasks_from: delete

--- a/collections/ansible_collections/dns/route53/roles/dns/meta/argument_specs.yaml
+++ b/collections/ansible_collections/dns/route53/roles/dns/meta/argument_specs.yaml
@@ -1,0 +1,50 @@
+---
+argument_specs:
+  create:
+    short_description: Create a DNS record via AWS Route 53
+    options:
+      dns_zone:
+        type: str
+        required: true
+        description: The Route 53 hosted zone name (e.g., "example.com").
+      dns_record_name:
+        type: str
+        required: true
+        description: Fully qualified domain name for the record.
+      dns_record_type:
+        type: str
+        required: false
+        default: A
+        choices: [A, AAAA]
+        description: DNS record type.
+      dns_record_value:
+        type: str
+        required: true
+        description: The value for the record.
+      dns_record_ttl:
+        type: int
+        required: false
+        default: 1800
+        description: TTL in seconds.
+      dns_record_overwrite:
+        type: bool
+        required: false
+        default: true
+        description: Whether to overwrite an existing record.
+  delete:
+    short_description: Delete a DNS record via AWS Route 53
+    options:
+      dns_zone:
+        type: str
+        required: true
+        description: The Route 53 hosted zone name (e.g., "example.com").
+      dns_record_name:
+        type: str
+        required: true
+        description: Fully qualified domain name for the record.
+      dns_record_type:
+        type: str
+        required: false
+        default: A
+        choices: [A, AAAA]
+        description: DNS record type.

--- a/collections/ansible_collections/dns/route53/roles/dns/tasks/create.yaml
+++ b/collections/ansible_collections/dns/route53/roles/dns/tasks/create.yaml
@@ -1,0 +1,14 @@
+---
+- name: "Create DNS record via Route 53 - {{ dns_record_name }}"
+  amazon.aws.route53:
+    state: present
+    zone: "{{ dns_zone }}"
+    record: "{{ dns_record_name }}"
+    type: "{{ dns_record_type }}"
+    ttl: "{{ dns_record_ttl }}"
+    value: "{{ dns_record_value }}"
+    wait: true
+    overwrite: "{{ dns_record_overwrite }}"
+    access_key: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | trim }}"
+    secret_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | trim }}"
+  no_log: true

--- a/collections/ansible_collections/dns/route53/roles/dns/tasks/delete.yaml
+++ b/collections/ansible_collections/dns/route53/roles/dns/tasks/delete.yaml
@@ -1,0 +1,25 @@
+---
+- name: "Look up existing DNS record via Route 53 - {{ dns_record_name }}"
+  amazon.aws.route53:
+    state: get
+    zone: "{{ dns_zone }}"
+    record: "{{ dns_record_name }}"
+    type: "{{ dns_record_type }}"
+    access_key: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | trim }}"
+    secret_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | trim }}"
+  register: __dns_route53_existing
+  no_log: true
+
+- name: "Delete DNS record via Route 53 - {{ dns_record_name }}"
+  amazon.aws.route53:
+    state: absent
+    zone: "{{ dns_zone }}"
+    record: "{{ dns_record_name }}"
+    type: "{{ dns_record_type }}"
+    ttl: "{{ __dns_route53_existing.set.ttl }}"
+    value: "{{ __dns_route53_existing.set.value }}"
+    wait: true
+    access_key: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | trim }}"
+    secret_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | trim }}"
+  when: __dns_route53_existing.set is defined and (__dns_route53_existing.set | length > 0)
+  no_log: true

--- a/collections/ansible_collections/massopencloud/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/massopencloud/steps/roles/external_access/tasks/create.yaml
@@ -14,8 +14,8 @@
 
   # wait until the service exists and has a loadbalancer ip
   until: >-
-    kube_apiserver_service.resources and
-    kube_apiserver_service.resources[0].status.loadBalancer.ingress | default(false)
+    (kube_apiserver_service.resources | length > 0) and
+    (kube_apiserver_service.resources[0].status.loadBalancer.ingress | default([]) | length > 0)
   retries: "{{ external_access_resource_wait_retries }}"
   delay: "{{ external_access_resource_wait_delay }}"
 
@@ -69,18 +69,16 @@
 - name: Create dns records
   when: >-
     external_access_base_domain in external_access_supported_base_domains|default([])
-  amazon.aws.route53:
-    state: present
-    zone: "{{ external_access_base_domain }}"
-    record: "{{ item.name }}"
-    type: A
-    ttl: "{{ external_access_dns_ttl }}"
-    value: "{{ item.addr }}"
-    wait: true
-    overwrite: true
-  environment:
-    AWS_ACCESS_KEY_ID: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | trim }}"
-    AWS_SECRET_ACCESS_KEY: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | trim }}"
+  ansible.builtin.include_role:
+    name: dns.api.dns
+    tasks_from: create
+  vars:
+    dns_zone: "{{ external_access_base_domain }}"
+    dns_record_name: "{{ item.name }}"
+    dns_record_type: A
+    dns_record_ttl: "{{ external_access_dns_ttl }}"
+    dns_record_value: "{{ item.addr }}"
+    dns_record_overwrite: true
   loop:
     - name: "{{ external_access_api_domain }}"
       addr: "{{ external_access_api_floating_ip }}"

--- a/collections/ansible_collections/massopencloud/steps/roles/external_access/tasks/delete.yaml
+++ b/collections/ansible_collections/massopencloud/steps/roles/external_access/tasks/delete.yaml
@@ -9,16 +9,14 @@
     - "{{ external_access_name }}-ingress"
 
 - name: Delete dns records
-  amazon.aws.route53:
-    state: absent
-    zone: "{{ external_access_base_domain }}"
-    record: "{{ item }}"
-    type: A
-    wait: true
-  environment:
-    AWS_ACCESS_KEY_ID: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | trim }}"
-    AWS_SECRET_ACCESS_KEY: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | trim }}"
+  ansible.builtin.include_role:
+    name: dns.api.dns
+    tasks_from: delete
+  vars:
+    dns_zone: "{{ external_access_base_domain }}"
+    dns_record_name: "{{ item }}"
+    dns_record_type: A
   loop:
-  - "api.{{ external_access_name }}.{{ external_access_base_domain }}"
-  - "api-int.{{ external_access_name }}.{{ external_access_base_domain }}"
-  - "*.apps.{{ external_access_name }}.{{ external_access_base_domain }}"
+    - "api.{{ external_access_name }}.{{ external_access_base_domain }}"
+    - "api-int.{{ external_access_name }}.{{ external_access_base_domain }}"
+    - "*.apps.{{ external_access_name }}.{{ external_access_base_domain }}"

--- a/collections/ansible_collections/netris/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/netris/steps/roles/external_access/tasks/create.yaml
@@ -13,8 +13,8 @@
     name: kube-apiserver
   register: kube_apiserver_service
   until: >-
-    kube_apiserver_service.resources and
-    kube_apiserver_service.resources[0].status.loadBalancer.ingress | default(false)
+    (kube_apiserver_service.resources | length > 0) and
+    (kube_apiserver_service.resources[0].status.loadBalancer.ingress | default([]) | length > 0)
   retries: "{{ external_access_resource_wait_retries }}"
   delay: "{{ external_access_resource_wait_delay }}"
 
@@ -68,18 +68,16 @@
 - name: Create dns records
   when: >-
     external_access_base_domain in external_access_supported_base_domains | default([])
-  amazon.aws.route53:
-    state: present
-    zone: "{{ external_access_base_domain }}"
-    record: "{{ item.name }}"
-    type: A
-    ttl: "{{ external_access_dns_ttl }}"
-    value: "{{ item.addr | ansible.utils.ipaddr('address') }}"
-    wait: true
-    overwrite: true
-  environment:
-    AWS_ACCESS_KEY_ID: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | trim }}"
-    AWS_SECRET_ACCESS_KEY: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | trim }}"
+  ansible.builtin.include_role:
+    name: dns.api.dns
+    tasks_from: create
+  vars:
+    dns_zone: "{{ external_access_base_domain }}"
+    dns_record_name: "{{ item.name }}"
+    dns_record_type: A
+    dns_record_ttl: "{{ external_access_dns_ttl }}"
+    dns_record_value: "{{ item.addr | ansible.utils.ipaddr('address') }}"
+    dns_record_overwrite: true
   loop:
     - name: "{{ external_access_api_domain }}"
       addr: "{{ external_access_api_floating_ip }}"

--- a/collections/ansible_collections/netris/steps/roles/external_access/tasks/delete.yaml
+++ b/collections/ansible_collections/netris/steps/roles/external_access/tasks/delete.yaml
@@ -49,15 +49,13 @@
 
 - name: Delete dns records
   when: external_access_base_domain is defined
-  amazon.aws.route53:
-    state: absent
-    zone: "{{ external_access_base_domain }}"
-    record: "{{ item }}"
-    type: A
-    wait: true
-  environment:
-    AWS_ACCESS_KEY_ID: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | trim }}"
-    AWS_SECRET_ACCESS_KEY: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | trim }}"
+  ansible.builtin.include_role:
+    name: dns.api.dns
+    tasks_from: delete
+  vars:
+    dns_zone: "{{ external_access_base_domain }}"
+    dns_record_name: "{{ item }}"
+    dns_record_type: A
   loop:
     - "api.{{ external_access_name }}.{{ external_access_base_domain }}"
     - "api-int.{{ external_access_name }}.{{ external_access_base_domain }}"

--- a/collections/ansible_collections/osac/service/roles/hosted_cluster/tasks/create_hosted_cluster.yaml
+++ b/collections/ansible_collections/osac/service/roles/hosted_cluster/tasks/create_hosted_cluster.yaml
@@ -9,7 +9,7 @@
         namespace: "{{ hosted_cluster_namespace }}"
         labels: "{{ hosted_cluster_default_cluster_order_label }}"
       data:
-        .dockerconfigjson: "{{ hosted_cluster_settings.pull_secret | to_json | b64encode }}"
+        .dockerconfigjson: "{{ hosted_cluster_settings.pull_secret | b64encode }}"
       type: kubernetes.io/dockerconfigjson
   no_log: true
 

--- a/collections/ansible_collections/osac/service/roles/hosted_cluster/tasks/delete_hosted_cluster.yaml
+++ b/collections/ansible_collections/osac/service/roles/hosted_cluster/tasks/delete_hosted_cluster.yaml
@@ -52,6 +52,6 @@
     namespace: "{{ hosted_cluster_namespace }}"
     name: "{{ hosted_cluster_name }}"
   register: hosted_cluster_status
-  until: not hosted_cluster_status.resources
+  until: (hosted_cluster_status.resources | length == 0)
   retries: 720
   delay: 10

--- a/collections/ansible_collections/osac/service/roles/wait_for/tasks/wait_for_cluster_operators.yaml
+++ b/collections/ansible_collections/osac/service/roles/wait_for/tasks/wait_for_cluster_operators.yaml
@@ -12,10 +12,10 @@
     kubeconfig: "{{ wait_for_kubeconfig }}"
   register: _wait_co_results
   until: >-
-    _wait_co_results.resources | default([]) | length > 0
-    and _wait_co_results.resources
+    (_wait_co_results.resources | default([]) | length > 0)
+    and (_wait_co_results.resources
         | json_query("[?!(status.conditions[?type=='Available' && status=='True'])]")
-        | length == 0
+        | length == 0)
   retries: "{{ wait_for_clusteroperators_retries }}"
   delay: "{{ wait_for_clusteroperators_delay }}"
 

--- a/collections/ansible_collections/osac/service/roles/wait_for/tasks/wait_for_dns.yaml
+++ b/collections/ansible_collections/osac/service/roles/wait_for/tasks/wait_for_dns.yaml
@@ -3,6 +3,6 @@
       dig +noall +answer {{ wait_for_dns_record }}
   register: wait_for_dns_info
   changed_when: false
-  until: wait_for_dns_info.stdout
+  until: (wait_for_dns_info.stdout | length > 0)
   retries: "{{ wait_for_dns_retries }}"
   delay: "{{ wait_for_dns_delay }}"

--- a/group_vars/all/configuration.yaml
+++ b/group_vars/all/configuration.yaml
@@ -64,3 +64,7 @@ server_mgmt_route_gateway: "{{ lookup('env', 'SERVER_MGMT_ROUTE_GATEWAY') }}"
 # SSH key content is written to files by the osac.service.write_ssh_keys role.
 server_ssh_bastion_host: "{{ lookup('env', 'SERVER_SSH_BASTION_HOST') }}"
 server_ssh_bastion_user: "{{ lookup('env', 'SERVER_SSH_BASTION_USER') }}"
+
+# DNS configuration
+dns_class: "{{ lookup('env', 'DNS_CLASS', default='dns.route53.dns') }}"
+dns_zone: "{{ lookup('env', 'DNS_ZONE', default=external_access_base_domain) }}"


### PR DESCRIPTION
## Summary                                                                                                                                                                 
                                         
  Implements the [DNS API enhancement proposal](https://github.com/osac-project/enhancement-proposals/blob/main/enhancements/dns-api/README.md), introducing a pluggable DNS 
  abstraction layer that replaces hardcoded AWS Route 53 calls with a class-agnostic interface.
                                                                                                                                                                             
  - Add `dns.api` collection with a dispatcher role (`dns.api.dns`) that delegates DNS record create/delete to a configurable backend driver via `dns_class` variable
  - Add `dns.route53` collection with the first driver role (`dns.route53.dns`) implementing the interface using `amazon.aws.route53`
  - Refactor `netris.steps` and `massopencloud.steps` external_access roles to use the new DNS dispatcher instead of calling Route 53 directly                               
  - Default `dns_class` to `dns.route53.dns` for backward compatibility — existing deployments require no configuration changes                                              
                                                                                                                                                                             
  ### Adding a new DNS backend                                                                                                                                               
                                                            
  To add support for a new provider (e.g., Cloudflare), create a new collection at `collections/ansible_collections/dns/cloudflare/roles/dns/` with `tasks/create.yaml` and  
  `tasks/delete.yaml` implementing the standard interface (`dns_record_name`, `dns_record_type`, `dns_record_value`, `dns_record_ttl`, `dns_record_overwrite`). Then set
  `dns_class: dns.cloudflare.dns`. No changes to `dns.api` or any existing code required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable DNS backend with a Route53 implementation; create/delete support for record type, TTL, overwrite, and input validation. External workflows now delegate DNS create/delete to the DNS role and include wildcard app records.

* **Bug Fixes**
  * Corrected pull-secret base64 encoding for hosted clusters.
  * Readiness, deletion, and DNS-wait polling conditions made more explicit and reliable.

* **Chores**
  * DNS backend and Route53 zone made configurable via environment-defaulted settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->