### PR TITLE
Fix empty template lists caused by non-blocking stdin in AAP

### DIFF
--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -490,6 +490,7 @@ def find_template_roles(requested: list[str]) -> Generator[BaseTemplate | Networ
                     "--format",
                     "json",
                 ],
+                stdin=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 timeout=30,
             )


### PR DESCRIPTION
When running inside AAP, stdin is set to non-blocking mode. The ansible-galaxy subprocess in find_template_roles inherits this non-blocking stdin, causing it to exit with an error. The collection query failure is caught and skipped, resulting in empty template lists.

Pass stdin=subprocess.DEVNULL so ansible-galaxy gets a clean blocking file descriptor instead of inheriting the parent's non-blocking one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with the service collection filter that could cause unexpected behavior when processing template role information by preventing the ansible-galaxy command from attempting to read from standard input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->