### PR TITLE
NO_ISSUE: fix ansible-galaxy subprocess inheriting non-blocking stdin

### DIFF
--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -490,6 +490,7 @@ def find_template_roles(requested: list[str]) -> Generator[BaseTemplate | Networ
                     "--format",
                     "json",
                 ],
+                stdin=subprocess.DEVNULL,
                 stderr=subprocess.PIPE,
                 timeout=30,
             )


### PR DESCRIPTION
## Summary
- Add `stdin=subprocess.DEVNULL` to the `ansible-galaxy collection list` subprocess call in `find_template_roles.py`
- Fixes template enumeration silently returning empty results when running inside AAP

## Problem
AAP's receptor/runner sets stdin to non-blocking mode. When `find_template_roles.py` spawns `ansible-galaxy collection list` as a subprocess, it inherits this non-blocking stdin. Since ansible-core 2.14 ([ansible/ansible#77668](https://github.com/ansible/ansible/pull/77668)), `ansible-galaxy` checks for blocking IO at startup and exits if stdin is non-blocking:

```
[WARNING]: Failed to query collection 'osac.templates': ERROR: Ansible requires blocking IO on stdin/stdout/stderr. Non-blocking file handles detected: <stdin>
```

The error is caught as a `CalledProcessError` and logged as a warning, causing the publish-templates job to succeed but publish nothing (`osac_compute_instance_templates: []`).

## Fix
`ansible-galaxy collection list` never reads from stdin. Passing `stdin=subprocess.DEVNULL` prevents it from inheriting the parent's non-blocking stdin.

## Ref
https://redhat.atlassian.net/browse/MGMT-22635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess handling stability in template role discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->