### PR TITLE
NO_ISSUE: fix restart check failing on AnsibleTaggedDateTime

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_resources.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_resources.yaml
@@ -109,12 +109,12 @@
   ansible.builtin.set_fact:
     restart_requested: >-
       {{
-        (compute_instance.spec.restartRequestedAt | default('') | length > 0)
+        (compute_instance.spec.restartRequestedAt | default('') | string | length > 0)
         and
         (
-          (compute_instance.status.lastRestartedAt | default('') | length == 0)
+          (compute_instance.status.lastRestartedAt | default('') | string | length == 0)
           or
-          (compute_instance.spec.restartRequestedAt | to_datetime > compute_instance.status.lastRestartedAt | default('1970-01-01T00:00:00Z') | to_datetime)
+          (compute_instance.spec.restartRequestedAt | string > compute_instance.status.lastRestartedAt | default('1970-01-01T00:00:00Z') | string)
         )
       }}
 
@@ -138,7 +138,7 @@
   register: vmi_info
   until:
     - vmi_info.resources | length > 0
-    - vmi_info.resources[0].metadata.creationTimestamp > compute_instance.spec.restartRequestedAt
+    - vmi_info.resources[0].metadata.creationTimestamp | string > compute_instance.spec.restartRequestedAt | string
   retries: 60
   delay: 5
   when: restart_requested | bool


### PR DESCRIPTION
## Summary
- Add `| string` before `| length` in the restart check in `ocp_virt_vm/tasks/create_resources.yaml`

## Problem
ansible-core 2.20 returns `_AnsibleTaggedDateTime` for datetime fields like `restartRequestedAt`. The `length` filter calls `len()` on this object, which fails:

```
The filter plugin 'ansible.builtin.length' failed: object of type '_AnsibleTaggedDateTime' has no len()
```

This causes every restart AAP job to fail, leaving `lastRestartedAt` empty.

## Fix
Convert to string before checking length: `| default('') | string | length > 0`