### PR TITLE
MGMT-24013: Auto-configure OpenShift Virtualization for GPU passthrough

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/meta/argument_specs.yaml
@@ -5,31 +5,37 @@ argument_specs:
         type: dict
         required: true
         description: ComputeInstance configuration
-      gpu_device_name:
-        type: str
+      gpu_devices:
+        type: list
         required: false
-        default: ""
+        default: []
+        elements: dict
         description: |
-          The resource name of the GPU device to pass through to the virtual machine. When
-          set, the virtual machine will be configured with GPU passthrough support via the
-          `hostDevices` field in the KubeVirt domain devices spec.
-
-          This must match a `resourceName` defined in the KubeVirt CR under
-          `spec.configuration.permittedHostDevices.pciHostDevices`. For example, to pass
-          through an NVIDIA A100 PCIe 80GB (PCI ID `10DE:20B5`), the KubeVirt CR should
-          contain:
-
-              configuration:
-                permittedHostDevices:
-                  pciHostDevices:
-                    - pciVendorSelector: "10DE:20B5"
-                      resourceName: "nvidia.com/GA100"
-                      externalResourceProvider: false
-
-          And the value of this parameter would be `nvidia.com/GA100`.
+          List of GPU devices to pass through to the virtual machine. Each entry
+          specifies a PCI device selector and a resource name. When set, the role
+          will configure the VM with GPU passthrough via the `hostDevices` field
+          in the KubeVirt domain devices spec, and will also ensure that the
+          `HyperConverged` CR (`kubevirt-hyperconverged` in the `openshift-cnv`
+          namespace) permits these host devices under
+          `spec.permittedHostDevices.pciHostDevices`.
 
           The PCI vendor and product ID for a given GPU can be found by running
           `lspci -nn | grep -i nvidia` on a node that has the device.
+        options:
+          pci_device_selector:
+            type: str
+            required: true
+            description: >
+              PCI vendor and product ID in "VVVV:PPPP" format, for example
+              "10DE:1DB6" for an NVIDIA Tesla V100.
+          resource_name:
+            type: str
+            required: true
+            description: >
+              The resource name for this device, for example
+              "nvidia.com/GV100GL_Tesla_V100". Used both in the VM
+              `hostDevices` spec and in the `HyperConverged` CR
+              `permittedHostDevices` configuration.
       template_parameters:
         type: dict
         required: false

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/configure_permitted_host_devices.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/configure_permitted_host_devices.yaml
@@ -1,0 +1,49 @@
+---
+- name: Build desired pciHostDevices entries from gpu_devices
+  ansible.builtin.set_fact:
+    desired_pci_host_devices: >-
+      [{% for dev in gpu_devices %}
+        {"pciDeviceSelector": "{{ dev.pci_device_selector }}",
+         "resourceName": "{{ dev.resource_name }}"}
+        {{ "," if not loop.last }}
+      {% endfor %}]
+  when: gpu_devices | default([]) | length > 0
+
+- name: Read current HyperConverged CR
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: hco.kubevirt.io/v1beta1
+    kind: HyperConverged
+    name: kubevirt-hyperconverged
+    namespace: openshift-cnv
+  register: hyperconverged_cr
+  when: gpu_devices | default([]) | length > 0
+
+- name: Compute merged pciHostDevices preserving existing entries
+  ansible.builtin.set_fact:
+    merged_pci_host_devices: "{{ _existing + _new_only }}"
+  vars:
+    _existing: >-
+      {{ hyperconverged_cr.resources[0].spec.permittedHostDevices.pciHostDevices
+         | default([]) }}
+    _existing_selectors: >-
+      {{ _existing | map(attribute='pciDeviceSelector') | list }}
+    _new_only: >-
+      {{ desired_pci_host_devices
+         | rejectattr('pciDeviceSelector', 'in', _existing_selectors)
+         | list }}
+  when: gpu_devices | default([]) | length > 0
+
+- name: Patch HyperConverged CR with merged pciHostDevices
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: hco.kubevirt.io/v1beta1
+    kind: HyperConverged
+    name: kubevirt-hyperconverged
+    namespace: openshift-cnv
+    state: patched
+    definition:
+      spec:
+        permittedHostDevices:
+          pciHostDevices: "{{ merged_pci_host_devices }}"
+  when: gpu_devices | default([]) | length > 0

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create.yaml
@@ -48,6 +48,12 @@
     name: osac.templates.ocp_virt_vm
     tasks_from: create_build_spec.yaml
 
+- name: Configure CNV permitted host devices for GPU passthrough
+  ansible.builtin.include_role:
+    name: osac.templates.ocp_virt_vm
+    tasks_from: configure_permitted_host_devices.yaml
+  when: gpu_devices | default([]) | length > 0
+
 - name: Step - Create secrets (user-data, SSH) and add to spec
   ansible.builtin.include_role:
     name: "{{ (create_step_secrets_override | default(create_step_secrets_default)).name }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_build_spec.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_build_spec.yaml
@@ -34,7 +34,7 @@
           dataVolume:
             name: "{{ compute_instance_name }}-root-disk"
 
-- name: Add GPU passthrough device to template spec if required
+- name: Add GPU passthrough devices to template spec
   ansible.builtin.set_fact:
     vm_template_spec: "{{ vm_template_spec | combine(gpu_patch, recursive=True, list_merge='append') }}"
   vars:
@@ -42,6 +42,9 @@
       domain:
         devices:
           hostDevices:
-            - name: gpu
-              deviceName: "{{ gpu_device_name }}"
-  when: (gpu_device_name | default('')) | length > 0
+            - name: "gpu-{{ idx }}"
+              deviceName: "{{ item.resource_name }}"
+  loop: "{{ gpu_devices | default([]) }}"
+  loop_control:
+    index_var: idx
+  when: gpu_devices | default([]) | length > 0

--- a/collections/ansible_collections/osac/test_overrides/roles/ocp_virt_vm_with_gpu/tasks/create.yaml
+++ b/collections/ansible_collections/osac/test_overrides/roles/ocp_virt_vm_with_gpu/tasks/create.yaml
@@ -4,4 +4,6 @@
     name: osac.templates.ocp_virt_vm
     tasks_from: create
   vars:
-    gpu_device_name: "nvidia.com/GB100"
+    gpu_devices:
+      - pci_device_selector: "10DE:2901"
+        resource_name: "nvidia.com/GB100"

--- a/tests/integration/setup_test_env.sh
+++ b/tests/integration/setup_test_env.sh
@@ -76,14 +76,33 @@ kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manage
 echo "Installing RHACM CRDs (ManagedCluster)..."
 kubectl apply -f https://raw.githubusercontent.com/stolostron/managedcluster-import-controller/main/deploy/crds/cluster.open-cluster-management.io_managedclusters.yaml 2>/dev/null || echo "RHACM CRDs may already exist or URL changed"
 
+echo "Installing HyperConverged CRD (OpenShift Virtualization / CNV)..."
+kubectl apply --server-side -f https://raw.githubusercontent.com/kubevirt/hyperconverged-cluster-operator/main/deploy/crds/hco00.crd.yaml 2>/dev/null || echo "HyperConverged CRD may already exist or URL changed"
+
+echo "Waiting for HyperConverged CRD to be established..."
+kubectl wait --for=condition=Established crd/hyperconvergeds.hco.kubevirt.io --timeout=60s || echo "Timeout waiting for HyperConverged CRD"
+
 # 4. Create test namespaces
 echo "Creating test namespaces..."
 kubectl create namespace osac-system || true
 kubectl create namespace osac-workflows-test || true
 kubectl create namespace cluster-test-cluster-work || true
 kubectl create namespace computeinstance-test-vm-work || true
+kubectl create namespace computeinstance-test-vm-gpu-work || true
+kubectl create namespace openshift-cnv || true
 
-# 5. Apply test fixtures
+# 5. Create minimal HyperConverged CR for GPU passthrough tests
+echo "Creating HyperConverged CR for GPU passthrough tests..."
+kubectl apply -f - <<HCEOF
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec: {}
+HCEOF
+
+# 6. Apply test fixtures
 # Note: computeinstance-defaults-test.yaml is intentionally omitted — it has no required
 # spec fields (tests defaults merging) and is read from file by tests via lookup().
 echo "Applying test fixtures..."

--- a/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
+++ b/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
@@ -33,11 +33,30 @@
     - ../../../common_vars.yml
 
   tasks:
-    - name: Verify GPU host device is present in VM template spec
+    - name: Verify GPU host devices are present in VM template spec
       ansible.builtin.assert:
         that:
           - vm_template_spec is defined
           - vm_template_spec.domain.devices.hostDevices is defined
-          - vm_template_spec.domain.devices.hostDevices | length > 0
-          - vm_template_spec.domain.devices.hostDevices | selectattr('deviceName', 'equalto', 'nvidia.com/GB100') | list | length > 0
-        fail_msg: "GPU device not found in VM template spec: {{ vm_template_spec }}"
+          - vm_template_spec.domain.devices.hostDevices | length == 1
+          - vm_template_spec.domain.devices.hostDevices[0].name == 'gpu-0'
+          - vm_template_spec.domain.devices.hostDevices[0].deviceName == 'nvidia.com/GB100'
+        fail_msg: "GPU devices not found in VM template spec: {{ vm_template_spec }}"
+
+    - name: Read HyperConverged CR
+      kubernetes.core.k8s_info:
+        api_version: hco.kubevirt.io/v1beta1
+        kind: HyperConverged
+        name: kubevirt-hyperconverged
+        namespace: openshift-cnv
+      register: hc_cr
+
+    - name: Verify GPU device was registered in HyperConverged CR
+      ansible.builtin.assert:
+        that:
+          - hc_cr.resources | length == 1
+          - hc_cr.resources[0].spec.permittedHostDevices.pciHostDevices is defined
+          - hc_cr.resources[0].spec.permittedHostDevices.pciHostDevices | length == 1
+          - hc_cr.resources[0].spec.permittedHostDevices.pciHostDevices[0].pciDeviceSelector == '10DE:2901'
+          - hc_cr.resources[0].spec.permittedHostDevices.pciHostDevices[0].resourceName == 'nvidia.com/GB100'
+        fail_msg: "GPU device not registered in HyperConverged CR: {{ hc_cr.resources }}"


### PR DESCRIPTION
## Summary

- Adds a `configure_permitted_host_devices.yaml` task to the base `ocp_virt_vm` role
  that automatically patches the `HyperConverged` CR with the declared GPU devices,
  removing the need for manual cluster administrator intervention.
- Replaces the single `gpu_device_name` string parameter with a `gpu_devices` list
  (each entry has a `pci_device_selector` and `resource_name`), supporting multiple
  GPU passthrough devices per VM.
- Extends the test environment with the HyperConverged CRD and a minimal CR so the
  integration test exercises the full configuration flow end-to-end.

## Test plan

- [x] All 13 integration tests pass (including the GPU baseline test that now verifies
  both the VM `hostDevices` spec and the patched `HyperConverged` CR).

Related: https://issues.redhat.com/browse/MGMT-24013

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU passthrough now supports multiple devices via a per-device list and adds a conditional cluster registration step when devices are provided.

* **Tests**
  * Integration tests updated to assert exact per-device VM hostDevice entries and that cluster permitted host-device registration matches the provided devices.

* **Chores**
  * Test environment setup ensures the virtualization CRD and required namespaces/resources exist for GPU tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->