### PR TITLE
Moving from StorageClass to StorageClasses

### DIFF
--- a/collections/ansible_collections/osac/service/roles/tenant_storage_class/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/tenant_storage_class/tasks/main.yaml
@@ -1,5 +1,5 @@
 ---
-# Discover the StorageClass to use for a tenant by reading tenant.status.storageClass.
+# Discover the StorageClass to use for a tenant by reading tenant.status.storageClasses.
 # The osac-operator Tenant controller is the single source of truth for StorageClass
 # validation (duplicate detection, fallback to Default). This role reads the already-
 # resolved result instead of re-implementing the same logic independently.
@@ -26,13 +26,13 @@
       Check Tenant conditions for details.
   when: tenant_storage_class_tenant_result.resources[0].status.phase | default('') != "Ready"
 
-- name: Fail if tenant storageClass is empty
+- name: Fail if tenant storageClasses is empty
   ansible.builtin.fail:
     msg: >-
-      Tenant '{{ tenant_storage_class_tenant_name }}' is ready but status.storageClass is empty.
+      Tenant '{{ tenant_storage_class_tenant_name }}' is ready but status.storageClasses is empty.
       This is unexpected; check the Tenant StorageClassReady condition.
-  when: tenant_storage_class_tenant_result.resources[0].status.storageClass | default('') | length == 0
+  when: tenant_storage_class_tenant_result.resources[0].status.storageClasses | default([]) | length == 0
 
 - name: Set StorageClass name from tenant status
   ansible.builtin.set_fact:
-    tenant_storage_class_name: "{{ tenant_storage_class_tenant_result.resources[0].status.storageClass }}"
+    tenant_storage_class_name: "{{ tenant_storage_class_tenant_result.resources[0].status.storageClasses[0].name }}"

--- a/collections/ansible_collections/osac/service/roles/tenant_storage_class/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/tenant_storage_class/tests/test.yml
@@ -11,8 +11,8 @@
 #   test_tenant_name|test_tenant_name_*:  The Tenant name to look up.
 #   test_tenant_namespace:                The namespace of the Tenant CR.
 #
-#   Test 1 (tenant Ready with storageClass set):
-#     Prerequisites: Tenant exists, phase=Ready, status.storageClass is set
+#   Test 1 (tenant Ready with storageClasses set):
+#     Prerequisites: Tenant exists, phase=Ready, status.storageClasses is set
 #     ansible-playbook ... -e test_tenant_name=tenant-akshay -e test_tenant_namespace=osac
 #
 #   Test 2 (tenant not ready -- Progressing phase):
@@ -23,15 +23,15 @@
 #     Prerequisites: Tenant with the given name does not exist in the namespace
 #     ansible-playbook ... -e test_tenant_name_missing=tenant-nonexistent -e test_tenant_namespace=osac
 #
-#   Test 4 (tenant ready but storageClass empty -- unexpected edge case):
-#     Prerequisites: Tenant phase=Ready but status.storageClass is empty (misconfigured)
+#   Test 4 (tenant ready but storageClasses empty -- unexpected edge case):
+#     Prerequisites: Tenant phase=Ready but status.storageClasses is empty (misconfigured)
 #     ansible-playbook ... -e test_tenant_name_no_sc=tenant-akshay -e test_tenant_namespace=osac
 
 # ──────────────────────────────────────────────────────────────
-# Test 1: Tenant ready with storageClass set (happy path)
+# Test 1: Tenant ready with storageClasses set (happy path)
 # Expected: role succeeds, tenant_storage_class_name set to the SC name from tenant status
 # ──────────────────────────────────────────────────────────────
-- name: Test tenant_storage_class role -- tenant ready with storageClass
+- name: Test tenant_storage_class role -- tenant ready with storageClasses
   hosts: localhost
   gather_facts: false
 
@@ -124,15 +124,15 @@
             success_msg: "Role failed as expected: {{ ansible_failed_result.msg }}"
 
 # ──────────────────────────────────────────────────────────────
-# Test 4: Tenant ready but storageClass empty -- error path
-# Expected: role fails with "storageClass is empty" message
+# Test 4: Tenant ready but storageClasses empty -- error path
+# Expected: role fails with "storageClasses is empty" message
 # ──────────────────────────────────────────────────────────────
-- name: Test tenant_storage_class role -- tenant ready but storageClass empty (should fail)
+- name: Test tenant_storage_class role -- tenant ready but storageClasses empty (should fail)
   hosts: localhost
   gather_facts: false
 
   tasks:
-    - name: Run empty-storageClass failure test
+    - name: Run empty-storageClasses failure test
       when:
         - test_tenant_name_no_sc is defined
         - test_tenant_namespace is defined
@@ -146,12 +146,12 @@
 
         - name: This task should not be reached -- role should have failed
           ansible.builtin.fail:
-            msg: "Role did not fail as expected when tenant storageClass is empty"
+            msg: "Role did not fail as expected when tenant storageClasses is empty"
 
       rescue:
-        - name: Verify role failed with expected empty-storageClass message
+        - name: Verify role failed with expected empty-storageClasses message
           ansible.builtin.assert:
             that:
-              - "'storageClass is empty' in ansible_failed_result.msg"
+              - "'storageClasses is empty' in ansible_failed_result.msg"
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg }}"
             success_msg: "Role failed as expected: {{ ansible_failed_result.msg }}"


### PR DESCRIPTION
This addresses the following commit in osac-operator https://github.com/osac-project/osac-operator/commit/6867ffe1aa21454072dca45242132b3e8a4b2cd7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tenant storage class validation to correctly handle multiple storage class entries and derive the tenant storage class from the first available entry, preventing false negatives when no single-string value is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->