### PR TITLE
MGMT-24117: read implementationStrategy from spec in playbooks

### DIFF
--- a/playbook_osac_create_public_ip_pool.yml
+++ b/playbook_osac_create_public_ip_pool.yml
@@ -6,21 +6,13 @@
   vars:
     public_ip_pool: "{{ ansible_eda.event.payload }}"
     public_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
-    # Implementation strategy set by osac-operator from PublicIPPool spec
-    implementation_strategy: >-
-      {{ (ansible_eda.event.payload.metadata.annotations | default({}))
-         .get('osac.openshift.io/implementation-strategy', '') }}
+    implementation_strategy: "{{ ansible_eda.event.payload.spec.implementationStrategy }}"
     template_parameters: {}
 
   pre_tasks:
     - name: Show EDA Event
       ansible.builtin.debug:
         var: ansible_eda.event.payload
-
-    - name: Validate implementation strategy is set
-      ansible.builtin.fail:
-        msg: "Missing required annotation 'osac.openshift.io/implementation-strategy'"
-      when: implementation_strategy | length == 0
 
   tasks:
     - name: Display PublicIPPool information

--- a/playbook_osac_delete_public_ip_pool.yml
+++ b/playbook_osac_delete_public_ip_pool.yml
@@ -6,21 +6,13 @@
   vars:
     public_ip_pool: "{{ ansible_eda.event.payload }}"
     public_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
-    # Implementation strategy set by osac-operator from PublicIPPool spec
-    implementation_strategy: >-
-      {{ (ansible_eda.event.payload.metadata.annotations | default({}))
-         .get('osac.openshift.io/implementation-strategy', '') }}
+    implementation_strategy: "{{ ansible_eda.event.payload.spec.implementationStrategy }}"
     template_parameters: {}
 
   pre_tasks:
     - name: Show EDA Event
       ansible.builtin.debug:
         var: ansible_eda.event.payload
-
-    - name: Validate implementation strategy is set
-      ansible.builtin.fail:
-        msg: "Missing required annotation 'osac.openshift.io/implementation-strategy'"
-      when: implementation_strategy | length == 0
 
   tasks:
     - name: Display PublicIPPool information


### PR DESCRIPTION
## Summary

Switch the PublicIPPool create and delete playbooks to read `implementationStrategy` from
`spec` instead of the `osac.openshift.io/implementation-strategy` annotation. This matches
the pattern already used by VirtualNetwork playbooks and removes the dependency on the
osac-operator copying the value into an annotation.

Also removes the "Validate implementation strategy is set" tasks since the CRD Enum
validation rejects invalid values at admission time (VirtualNetwork playbooks don't have
this check either).

**Changes:**
- `playbook_osac_create_public_ip_pool.yml`: read from `spec.implementationStrategy`, remove validation task
- `playbook_osac_delete_public_ip_pool.yml`: same changes

## Testing

Both playbooks validated as correct YAML. Pattern matches VirtualNetwork playbooks exactly:
```
$ diff <(grep 'implementation_strategy:' playbook_osac_create_public_ip_pool.yml) \
       <(grep 'implementation_strategy:' playbook_osac_create_virtual_network.yml)
# no diff
```

**E2E on edge22 (2026-04-24, clean-slate test):**

AAP was pointed at this branch. Created a fresh PublicIPPool from clean slate. The AAP
playbook correctly read `implementationStrategy: metallb-l2` from the spec, selected the
`metallb_l2` role, and successfully provisioned MetalLB resources:

```
AAP job 11703: Succeeded

MetalLB resources created:
  IPAddressPool/publicippool-gtxgq: ["192.168.127.216/29"]
  L2Advertisement/publicippool-gtxgq-l2adv: ["publicippool-gtxgq"]

Pool reached Ready state.
```

## Related PRs

- fulfillment-service: [#447](https://github.com/osac-project/fulfillment-service/pull/447) (buildSpec fix + annotation removal)
- osac-operator: [#201](https://github.com/osac-project/osac-operator/pull/201) (annotation-copy block removal)

Merge order: fulfillment-service first, then osac-operator, then this PR.

## Ticket

[MGMT-24117](https://redhat.atlassian.net/browse/MGMT-24117)

<br>

<small>Assisted-by: Cursor/Claude</small>