### PR TITLE
MGMT-24122: use subnet-namespace annotation for VM working namespace

### DIFF
--- a/collections/ansible_collections/osac/service/roles/compute_instance_working_namespace/tasks/main.yml
+++ b/collections/ansible_collections/osac/service/roles/compute_instance_working_namespace/tasks/main.yml
@@ -2,19 +2,30 @@
 - name: Retrieve working compute instance namespace unless it is already set
   when: compute_instance_working_namespace is not defined
   block:
-  - name: Retrieve tenant
-    kubernetes.core.k8s_info:
-      api_version: osac.openshift.io/v1alpha1
-      kind: Tenant
-      name: "{{ compute_instance.status.tenantReference.name }}"
-      namespace: "{{ compute_instance.status.tenantReference.namespace }}"
-    register: compute_instance_working_namespace_tenant
-
-  - name: Check if the tenant is found
-    ansible.builtin.fail:
-      msg: "Tenant namespace was not found. ({{ compute_instance_working_namespace_tenant.resources | length }} were found.)"
-    when: compute_instance_working_namespace_tenant.resources | length != 1
-
-  - name: Set working compute instance namespace as result
+  - name: Use subnet namespace from annotation when available
     ansible.builtin.set_fact:
-      compute_instance_working_namespace: "{{ compute_instance_working_namespace_tenant.resources[0].status.namespace }}"
+      compute_instance_working_namespace: "{{ compute_instance.metadata.annotations['osac.openshift.io/subnet-namespace'] }}"
+    when: >-
+      compute_instance.metadata.annotations is defined and
+      'osac.openshift.io/subnet-namespace' in compute_instance.metadata.annotations and
+      compute_instance.metadata.annotations['osac.openshift.io/subnet-namespace'] | length > 0
+
+  - name: Fall back to tenant namespace when subnet namespace annotation is absent
+    when: compute_instance_working_namespace is not defined
+    block:
+    - name: Retrieve tenant
+      kubernetes.core.k8s_info:
+        api_version: osac.openshift.io/v1alpha1
+        kind: Tenant
+        name: "{{ compute_instance.status.tenantReference.name }}"
+        namespace: "{{ compute_instance.status.tenantReference.namespace }}"
+      register: compute_instance_working_namespace_tenant
+
+    - name: Check if the tenant is found
+      ansible.builtin.fail:
+        msg: "Tenant namespace was not found. ({{ compute_instance_working_namespace_tenant.resources | length }} were found.)"
+      when: compute_instance_working_namespace_tenant.resources | length != 1
+
+    - name: Set working compute instance namespace as result
+      ansible.builtin.set_fact:
+        compute_instance_working_namespace: "{{ compute_instance_working_namespace_tenant.resources[0].status.namespace }}"


### PR DESCRIPTION
## Summary

- The `compute_instance_working_namespace` role now checks for the `osac.openshift.io/subnet-namespace` annotation on the ComputeInstance CR before falling back to the tenant namespace lookup
- When a VM has a `subnetRef`, the fulfillment-controller sets this annotation (see osac-project/fulfillment-service#453) and the AAP playbook now uses it to create the VM in the correct subnet namespace
- This fixes VMs being created in the tenant namespace (`guest`) instead of the subnet namespace, which caused the osac-operator to never find the VM and the ComputeInstance to remain stuck in `STARTING`

## Test plan

- [x] VM with subnet annotation → created in subnet namespace, operator finds it → RUNNING
- [x] VM without annotation → falls back to tenant namespace (backwards compatible)

Fixes: https://redhat.atlassian.net/browse/MGMT-24122
Depends on: osac-project/fulfillment-service#453

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>