### PR TITLE
MGMT-24178, MGMT-24196: Netris CaaS fixes / improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ tests/integration/kubeconfig-*
 
 # CLAUDE.md
 CLAUDE.md
+.claude/

--- a/collections/ansible_collections/netris/controller/roles/nat/tasks/create.yaml
+++ b/collections/ansible_collections/netris/controller/roles/nat/tasks/create.yaml
@@ -42,9 +42,30 @@
       }) }}
   when: nat_action == 'snat'
 
-- name: Reset existing NAT check (avoid stale state from prior delete call)
+- name: Get existing NAT rules
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/nat"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _nat_list_resp
+  no_log: true
+
+- name: Find NAT rule by name
   ansible.builtin.set_fact:
-    _existing_nat: null
+    _existing_nat: "{{ (_nat_list_resp.json.data | default([])) | selectattr('name', 'equalto', nat_name) | list | first | default(none) }}"
+  when: _nat_list_resp.json is mapping
+
+- name: Set nat facts from existing rule (skip creation)
+  ansible.builtin.set_fact:
+    nat_id: "{{ _existing_nat.id }}"
+    nat_already_existed: true
+    nat_existing_rule: "{{ _existing_nat }}"
+  when: _existing_nat is defined and _existing_nat is not none
 
 - name: Create NAT rule
   ansible.builtin.uri:
@@ -57,13 +78,17 @@
     body: "{{ _nat_body }}"
     return_content: true
     status_code: [200, 201]
+    timeout: "{{ netris_timeout | default(30) }}"
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _nat_create_resp
+  when: _existing_nat is not defined or _existing_nat is none
 
-- name: Set nat_id from create response
+- name: Set nat facts from create response
   ansible.builtin.set_fact:
     nat_id: "{{ _nat_create_resp.json.data.id | default(_nat_create_resp.json.data) }}"
+    nat_already_existed: false
   when:
-    - not (_nat_create_resp.skipped | default(false))
+    - _existing_nat is not defined or _existing_nat is none
+    - _nat_create_resp is not skipped
     - _nat_create_resp is changed or (_nat_create_resp.status | default(0)) in [200, 201]
     - _nat_create_resp.json is mapping

--- a/collections/ansible_collections/netris/controller/roles/server_cluster/tasks/create.yaml
+++ b/collections/ansible_collections/netris/controller/roles/server_cluster/tasks/create.yaml
@@ -4,6 +4,24 @@
     name: netris.controller.auth
   when: netris_session_cookie is not defined
 
+- name: Get existing server clusters
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/server-cluster"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _sc_list_resp
+  no_log: true
+
+- name: Find existing server cluster by name
+  ansible.builtin.set_fact:
+    _existing_server_cluster: "{{ (_sc_list_resp.json.data | default([])) | selectattr('name', 'equalto', server_cluster_name) | list | first | default(none) }}"
+  when: _sc_list_resp.json is mapping
+
 - name: Set server names list
   ansible.builtin.set_fact:
     _server_names: "{{ server_cluster_servers }}"
@@ -22,6 +40,7 @@
       Cookie: "connect.sid={{ netris_session_cookie }}"
     return_content: true
     status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _inv_resp
 
@@ -43,6 +62,30 @@
     - server_cluster_servers[0] is mapping
     - server_cluster_servers[0].id is defined
 
+- name: Build update body (servers and tags only)
+  ansible.builtin.set_fact:
+    _update_body:
+      servers: "{{ _server_cluster_servers | default([]) }}"
+      tags: "{{ server_cluster_tags | default([]) }}"
+  when: _existing_server_cluster is defined and _existing_server_cluster is not none
+
+- name: Update existing server cluster
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/server-cluster/{{ _existing_server_cluster.id }}"
+    method: PUT
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+      Content-Type: "application/json"
+    body_format: json
+    body: "{{ _update_body }}"
+    return_content: true
+    status_code: [200]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _update_resp
+  no_log: true
+  when: _existing_server_cluster is defined and _existing_server_cluster is not none
+
 - name: Build create body (base)
   ansible.builtin.set_fact:
     _create_body:
@@ -50,21 +93,30 @@
       site: "{{ {'id': server_cluster_site_id | int} }}"
       servers: "{{ _server_cluster_servers | default([]) }}"
       tags: "{{ server_cluster_tags | default([]) }}"
-      vpc: "{{ {'id': 0, 'name': 'Create New'} }}"
+      vpc: >-
+        {{
+          {'id': server_cluster_vpc_id | int, 'name': server_cluster_vpc_name | default('')}
+          if (server_cluster_vpc_id is defined and server_cluster_vpc_id)
+          else {'id': 0, 'name': 'Create New'}
+        }}
+  when: _existing_server_cluster is not defined or _existing_server_cluster is none
 
 - name: Build create body (with template)
   ansible.builtin.set_fact:
     _create_body: "{{ _create_body | default({}) | combine({'srvClusterTemplate': {'id': server_cluster_template_id}}) }}"
-  when: server_cluster_template_id is defined
+  when:
+    - _existing_server_cluster is not defined or _existing_server_cluster is none
+    - server_cluster_template_id is defined
 
 - name: Build create body (with admin)
   ansible.builtin.set_fact:
     _create_body: "{{ _create_body | default({}) | combine({'admin': {'id': server_cluster_admin_id, 'name': server_cluster_admin_name}}) }}"
   when:
+    - _existing_server_cluster is not defined or _existing_server_cluster is none
     - server_cluster_admin_id is defined
     - server_cluster_admin_name is defined
 
-- name: Create server cluster
+- name: Create new server cluster
   ansible.builtin.uri:
     url: "{{ netris_controller_url }}/api/v2/server-cluster"
     method: POST
@@ -75,16 +127,22 @@
     body: "{{ _create_body }}"
     return_content: true
     status_code: [200, 201]
+    timeout: "{{ netris_timeout | default(30) }}"
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _create_resp
+  when: _existing_server_cluster is not defined or _existing_server_cluster is none
 
-- name: Set server_cluster_id from create response
+- name: Set server_cluster_id from response
   ansible.builtin.set_fact:
-    server_cluster_id: "{{ _create_resp.json.data.id | default(_create_resp.json.data) }}"
-    server_cluster_created: true
-  when: _create_resp.json is mapping
+    server_cluster_id: >-
+      {{
+        _existing_server_cluster.id
+        if (_existing_server_cluster is defined and _existing_server_cluster is not none)
+        else (_create_resp.json.data.id | default(_create_resp.json.data))
+      }}
+    server_cluster_created: "{{ _existing_server_cluster is not defined or _existing_server_cluster is none }}"
 
-- name: Wait for server cluster to be provisioned
+- name: Wait for server cluster to be active
   ansible.builtin.uri:
     url: "{{ netris_controller_url }}/api/v2/server-cluster/{{ server_cluster_id }}"
     method: GET
@@ -92,18 +150,17 @@
       Cookie: "connect.sid={{ netris_session_cookie }}"
     return_content: true
     status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _state_resp
   until: _state_resp.json is mapping and ((_state_resp.json.data | default({}))['status'] | default({}))['label'] | default('') == 'Active'
   retries: 30
   delay: 10
-  when: _create_resp.json is mapping
 
-- name: Set server_cluster_vpc_id from provisioned server cluster
+- name: Set server_cluster_vpc_id from server cluster
   ansible.builtin.set_fact:
     server_cluster_vpc_id: "{{ (_state_resp.json.data | default({})).vpc.id | default((_state_resp.json.data | default({})).vpcId) }}"
     server_cluster_vpc_name: "{{ (_state_resp.json.data | default({})).vpc.name | default('') }}"
   when:
-    - _create_resp.json is mapping
     - _state_resp.json is mapping
     - (_state_resp.json.data | default({})).vpc is defined or (_state_resp.json.data | default({})).vpcId is defined

--- a/collections/ansible_collections/netris/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/netris/steps/roles/cluster_infra/tasks/create.yaml
@@ -61,6 +61,19 @@
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
 
+- name: List already allocated agents
+  kubernetes.core.k8s_info:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ default_agent_namespace }}"
+    label_selectors:
+      - "{{ cluster_order_label }}={{ cluster_infra_name }}"
+  register: _existing_cluster_agents
+
+- name: Record already allocated agent names
+  ansible.builtin.set_fact:
+    _existing_agent_names: "{{ _existing_cluster_agents.resources | map(attribute='metadata.name') | list }}"
+
 - name: Select and label new Agent resources
   ansible.builtin.include_role:
     name: osac.service.manage_agents
@@ -128,14 +141,6 @@
     server_cluster_template_id: "{{ _netris_server_cluster_template_id }}"
     server_cluster_template_state: read
 
-- name: Delete existing Netris server cluster
-  ansible.builtin.include_role:
-    name: netris.controller.server_cluster
-  vars:
-    server_cluster_name: "{{ cluster_infra_name }}"
-    server_cluster_state: absent
-    server_cluster_site_id: "{{ netris_site_id }}"
-
 - name: Create Netris server cluster with attached servers
   ansible.builtin.include_role:
     name: netris.controller.server_cluster
@@ -151,27 +156,49 @@
     server_cluster_admin_id: "{{ netris_tenant_id }}"
     server_cluster_admin_name: "{{ netris_tenant_name }}"
 
-- name: Allocate NAT IP from Netris IPAM
+- name: Ensure Netris auth for SNAT lookup
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Look up existing SNAT rule
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/nat"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _snat_lookup_resp
+  no_log: true
+
+- name: Find existing SNAT rule by name
+  ansible.builtin.set_fact:
+    _existing_snat: "{{ (_snat_lookup_resp.json.data | default([])) | selectattr('name', 'equalto', cluster_infra_name + '-snat') | list | first | default(none) }}"
+  when: _snat_lookup_resp.json is mapping
+
+- name: Set SNAT IP from existing rule
+  ansible.builtin.set_fact:
+    netris_nat_snat_ip: "{{ _existing_snat.snatToIP | ansible.utils.ipaddr('host/prefix') }}"
+  when: _existing_snat is defined and _existing_snat is not none
+
+- name: Allocate NAT IP from Netris IPAM (new cluster only)
   ansible.builtin.include_role:
     name: netris.controller.ipam
   vars:
     ipam_site_id: "{{ netris_site_id }}"
     ipam_purpose: nat
     ipam_count: 1
+  when: _existing_snat is not defined or _existing_snat is none
 
-- name: Set dynamically allocated NAT IP
+- name: Set dynamically allocated NAT IP (new cluster only)
   ansible.builtin.set_fact:
     netris_nat_snat_ip: "{{ ipam_allocated_ips[0] }}/32"
+  when: _existing_snat is not defined or _existing_snat is none
 
-- name: Delete existing SNAT rule for VPC subnet
-  ansible.builtin.include_role:
-    name: netris.controller.nat
-  vars:
-    nat_name: "{{ cluster_infra_name }}-snat"
-    nat_state: absent
-    nat_site_id: "{{ netris_site_id }}"
-
-- name: Create SNAT rule for VPC subnet internet access
+- name: Create SNAT rule for VPC subnet internet access (new cluster only)
   ansible.builtin.include_role:
     name: netris.controller.nat
   vars:
@@ -185,12 +212,17 @@
     nat_source_address: "{{ netris_template_ipv4_gateway | ansible.utils.ipsubnet }}"
     nat_snat_to_ip: "{{ netris_nat_snat_ip }}"
     nat_comment: "OSAC SNAT for {{ cluster_infra_name }}"
+  when: _existing_snat is not defined or _existing_snat is none
 
 - name: Set cluster_infra_network_name
   ansible.builtin.set_fact:
     cluster_infra_network_name: "{{ cluster_infra_name }}"
 
-- name: Create NMStateConfig for cluster agents
+- name: Identify newly added agents
+  ansible.builtin.set_fact:
+    _newly_added_agents: "{{ cluster_agents_for_netris.resources | rejectattr('metadata.name', 'in', _existing_agent_names) | list }}"
+
+- name: Create NMStateConfig CRs for all cluster agents
   ansible.builtin.include_role:
     name: osac.service.nmstate_config
   vars:
@@ -200,6 +232,19 @@
     nmstate_config_interface_names: "{{ server_cluster_template_server_nics }}"
     nmstate_config_server_interfaces: "{{ _server_vpc_interfaces }}"
     nmstate_config_mgmt_interface: "{{ _server_mgmt_interface }}"
+    nmstate_config_apply_live: false
+
+- name: Apply NMState config on newly added agents
+  ansible.builtin.include_role:
+    name: osac.service.nmstate_config
+  vars:
+    nmstate_config_state: present
+    nmstate_config_cluster_name: "{{ cluster_infra_name }}"
+    nmstate_config_agents: "{{ _newly_added_agents }}"
+    nmstate_config_interface_names: "{{ server_cluster_template_server_nics }}"
+    nmstate_config_server_interfaces: "{{ _server_vpc_interfaces }}"
+    nmstate_config_mgmt_interface: "{{ _server_mgmt_interface }}"
+  when: _newly_added_agents | length > 0
 
 - name: Add cluster order label to InfraEnv nmStateConfigLabelSelector
   kubernetes.core.k8s:

--- a/collections/ansible_collections/netris/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/netris/steps/roles/external_access/tasks/create.yaml
@@ -11,6 +11,7 @@
     kind: Service
     namespace: "{{ external_access_namespace }}-{{ external_access_name }}"
     name: kube-apiserver
+    wait_timeout: "{{ external_access_resource_wait_timeout | default(30) }}"
   register: kube_apiserver_service
   until: >-
     (kube_apiserver_service.resources | length > 0) and
@@ -23,26 +24,94 @@
     external_access_api_internal_ip: "{{ kube_apiserver_service.resources[0].status.loadBalancer.ingress[0].ip }}"
     external_access_kube_apiserver_port: "{{ kube_apiserver_service.resources[0].spec.ports[0].port }}"
 
-- name: Allocate NAT IPs from Netris IPAM
+- name: Ensure Netris auth for DNAT lookup
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Look up existing DNAT rules
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/nat"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _dnat_lookup_resp
+  no_log: true
+
+- name: Find existing API DNAT rule
+  ansible.builtin.set_fact:
+    _existing_api_dnat: "{{ (_dnat_lookup_resp.json.data | default([])) | selectattr('name', 'equalto', external_access_name + '-api-dnat') | list | first | default(none) }}"
+  when: _dnat_lookup_resp.json is mapping
+
+- name: Find existing ingress HTTP DNAT rule
+  ansible.builtin.set_fact:
+    _existing_ingress_http_dnat: "{{ (_dnat_lookup_resp.json.data | default([])) | selectattr('name', 'equalto', external_access_name + '-ingress-http-dnat') | list | first | default(none) }}"
+  when: _dnat_lookup_resp.json is mapping
+
+- name: Find existing ingress HTTPS DNAT rule
+  ansible.builtin.set_fact:
+    _existing_ingress_https_dnat: "{{ (_dnat_lookup_resp.json.data | default([])) | selectattr('name', 'equalto', external_access_name + '-ingress-https-dnat') | list | first | default(none) }}"
+  when: _dnat_lookup_resp.json is mapping
+
+- name: Set API DNAT IP from existing rule
+  ansible.builtin.set_fact:
+    netris_dnat_api_ip: "{{ _existing_api_dnat.destinationAddress | ansible.utils.ipaddr('address') }}"
+  when: _existing_api_dnat is defined and _existing_api_dnat is not none
+
+- name: Set ingress DNAT IP from existing rule
+  ansible.builtin.set_fact:
+    netris_dnat_ingress_ip: "{{ _existing_ingress_http_dnat.destinationAddress | ansible.utils.ipaddr('address') }}"
+  when: _existing_ingress_http_dnat is defined and _existing_ingress_http_dnat is not none
+
+- name: Count missing DNAT IPs
+  ansible.builtin.set_fact:
+    _missing_api_dnat: "{{ (_existing_api_dnat is not defined or _existing_api_dnat is none) | bool }}"
+    _missing_ingress_dnat: "{{ (_existing_ingress_http_dnat is not defined or _existing_ingress_http_dnat is none) | bool }}"
+
+- name: Calculate IPAM allocation count
+  ansible.builtin.set_fact:
+    _dnat_ipam_count: "{{ (_missing_api_dnat | bool) | int + (_missing_ingress_dnat | bool) | int }}"
+
+- name: Allocate NAT IPs from Netris IPAM (missing rules only)
   ansible.builtin.include_role:
     name: netris.controller.ipam
   vars:
     ipam_site_id: "{{ netris_site_id }}"
     ipam_purpose: nat
-    ipam_count: 2
+    ipam_count: "{{ _dnat_ipam_count }}"
+  when: _dnat_ipam_count | int > 0
 
-- name: Set dynamically allocated NAT IPs
+- name: Set API DNAT IP from IPAM (when both missing)
   ansible.builtin.set_fact:
     netris_dnat_api_ip: "{{ ipam_allocated_ips[0] }}"
-    netris_dnat_ingress_ip: "{{ ipam_allocated_ips[1] }}"
+  when:
+    - _missing_api_dnat | bool
+    - _missing_ingress_dnat | bool
 
-- name: Delete existing DNAT rule for API endpoint
-  ansible.builtin.include_role:
-    name: netris.controller.nat
-  vars:
-    nat_name: "{{ external_access_name }}-api-dnat"
-    nat_state: absent
-    nat_site_id: "{{ netris_site_id }}"
+- name: Set ingress DNAT IP from IPAM (when both missing)
+  ansible.builtin.set_fact:
+    netris_dnat_ingress_ip: "{{ ipam_allocated_ips[1] }}"
+  when:
+    - _missing_api_dnat | bool
+    - _missing_ingress_dnat | bool
+
+- name: Set API DNAT IP from IPAM (when only API missing)
+  ansible.builtin.set_fact:
+    netris_dnat_api_ip: "{{ ipam_allocated_ips[0] }}"
+  when:
+    - _missing_api_dnat | bool
+    - not (_missing_ingress_dnat | bool)
+
+- name: Set ingress DNAT IP from IPAM (when only ingress missing)
+  ansible.builtin.set_fact:
+    netris_dnat_ingress_ip: "{{ ipam_allocated_ips[0] }}"
+  when:
+    - not (_missing_api_dnat | bool)
+    - _missing_ingress_dnat | bool
 
 - name: Create DNAT rule for API endpoint
   ansible.builtin.include_role:
@@ -60,6 +129,7 @@
     nat_dnat_to_ip: "{{ external_access_api_internal_ip }}/32"
     nat_dnat_to_port: "{{ external_access_kube_apiserver_port }}"
     nat_comment: "OSAC API DNAT for {{ external_access_name }}"
+  when: _existing_api_dnat is not defined or _existing_api_dnat is none
 
 - name: Set external_access_api_floating_ip
   ansible.builtin.set_fact:
@@ -123,14 +193,6 @@
     metallb_ingress_admin_kubeconfig: "{{ admin_kubeconfig }}"
     metallb_ingress_ip: "{{ external_access_metallb_ingress_ip }}"
 
-- name: Delete existing DNAT rule for ingress HTTP
-  ansible.builtin.include_role:
-    name: netris.controller.nat
-  vars:
-    nat_name: "{{ external_access_name }}-ingress-http-dnat"
-    nat_state: absent
-    nat_site_id: "{{ netris_site_id }}"
-
 - name: Create DNAT rule for ingress HTTP
   ansible.builtin.include_role:
     name: netris.controller.nat
@@ -147,14 +209,7 @@
     nat_dnat_to_ip: "{{ external_access_metallb_ingress_ip }}/32"
     nat_dnat_to_port: "80"
     nat_comment: "OSAC ingress HTTP DNAT for {{ external_access_name }}"
-
-- name: Delete existing DNAT rule for ingress HTTPS
-  ansible.builtin.include_role:
-    name: netris.controller.nat
-  vars:
-    nat_name: "{{ external_access_name }}-ingress-https-dnat"
-    nat_state: absent
-    nat_site_id: "{{ netris_site_id }}"
+  when: _existing_ingress_http_dnat is not defined or _existing_ingress_http_dnat is none
 
 - name: Create DNAT rule for ingress HTTPS
   ansible.builtin.include_role:
@@ -172,3 +227,4 @@
     nat_dnat_to_ip: "{{ external_access_metallb_ingress_ip }}/32"
     nat_dnat_to_port: "443"
     nat_comment: "OSAC ingress HTTPS DNAT for {{ external_access_name }}"
+  when: _existing_ingress_https_dnat is not defined or _existing_ingress_https_dnat is none

--- a/collections/ansible_collections/osac/service/roles/wait_for/defaults/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/wait_for/defaults/main.yaml
@@ -4,3 +4,6 @@ wait_for_cluster_retries: 180
 wait_for_cluster_delay: 10
 wait_for_clusteroperators_retries: 60
 wait_for_clusteroperators_delay: 30
+wait_for_nodes_retries: 60
+wait_for_nodes_delay: 30
+wait_for_nodes_expected_count: 2

--- a/collections/ansible_collections/osac/service/roles/wait_for/tasks/wait_for_cluster_operators.yaml
+++ b/collections/ansible_collections/osac/service/roles/wait_for/tasks/wait_for_cluster_operators.yaml
@@ -10,6 +10,7 @@
     api_version: config.openshift.io/v1
     kind: ClusterOperator
     kubeconfig: "{{ wait_for_kubeconfig }}"
+    wait_timeout: "{{ wait_for_request_timeout | default(30) }}"
   register: _wait_co_results
   until: >-
     (_wait_co_results.resources | default([]) | length > 0)

--- a/collections/ansible_collections/osac/service/roles/wait_for/tasks/wait_for_network_cluster_operator.yaml
+++ b/collections/ansible_collections/osac/service/roles/wait_for/tasks/wait_for_network_cluster_operator.yaml
@@ -4,6 +4,7 @@
     kind: ClusterOperator
     name: network
     kubeconfig: "{{ wait_for_kubeconfig }}"
+    wait_timeout: "{{ wait_for_request_timeout | default(30) }}"
   register: network_cluster_operator_results
   until: condition.status == "True"
   retries: "{{ wait_for_cluster_retries }}"

--- a/collections/ansible_collections/osac/service/roles/wait_for/tasks/wait_for_nodes.yaml
+++ b/collections/ansible_collections/osac/service/roles/wait_for/tasks/wait_for_nodes.yaml
@@ -1,0 +1,21 @@
+---
+- name: Wait for Nodes to be Ready
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Node
+    kubeconfig: "{{ wait_for_kubeconfig }}"
+    wait_timeout: "{{ wait_for_request_timeout | default(30) }}"
+  register: _wait_nodes_results
+  until: >-
+    (_wait_nodes_results.resources | default([])
+        | json_query("[?status.conditions[?type=='Ready' && status=='True']]")
+        | length >= (wait_for_nodes_expected_count | int))
+  retries: "{{ wait_for_nodes_retries }}"
+  delay: "{{ wait_for_nodes_delay }}"
+
+- name: Report Nodes status
+  ansible.builtin.debug:
+    msg: >-
+      {{ _wait_nodes_results.resources
+         | json_query("[?status.conditions[?type=='Ready' && status=='True']]")
+         | length }} / {{ wait_for_nodes_expected_count }} Nodes are Ready.

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_17_small/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_17_small/tasks/install.yaml
@@ -15,6 +15,9 @@
     install_step_retrieve_kubeconfig_default:
       name: osac.service.retrieve_kubeconfig
       tasks_from: main.yaml
+    install_step_wait_for_nodes_default:
+      name: osac.service.wait_for
+      tasks_from: wait_for_nodes.yaml
     install_step_wait_for_cluster_operators_default:
       name: osac.service.wait_for
       tasks_from: wait_for_cluster_operators.yaml
@@ -68,6 +71,14 @@
   vars:
     retrieve_kubeconfig_cluster_name: "{{ cluster_order.metadata.name }}"
     retrieve_kubeconfig_namespace: "{{ cluster_working_namespace }}"
+
+- name: Step - Wait for nodes to be ready
+  ansible.builtin.include_role:
+    name: "{{ (install_step_wait_for_nodes_override | default(install_step_wait_for_nodes_default)).name }}"
+    tasks_from: "{{ (install_step_wait_for_nodes_override | default(install_step_wait_for_nodes_default)).tasks_from }}"
+  vars:
+    wait_for_kubeconfig: "{{ admin_kubeconfig }}"
+    wait_for_nodes_expected_count: "{{ cluster_order.spec.nodeRequests | map(attribute='numberOfNodes') | map('int') | sum }}"
 
 - name: Step - Wait for cluster operators
   ansible.builtin.include_role:

--- a/tests/integration/setup_test_env.sh
+++ b/tests/integration/setup_test_env.sh
@@ -8,7 +8,7 @@ echo "=== Setting up test environment ==="
 
 # 0. Delete existing cluster if it exists
 echo "Cleaning up any existing test cluster..."
-kind delete cluster --name osac-test 2>/dev/null || true
+KIND_EXPERIMENTAL_PROVIDER=podman kind delete cluster --name osac-test 2>/dev/null || true
 
 # 0.5. Install required Python libraries
 echo "Installing required Python libraries..."
@@ -16,11 +16,11 @@ pip install --user kubernetes openstacksdk 2>/dev/null || pip3 install --user ku
 
 # 1. Create kind cluster
 echo "Creating kind cluster..."
-kind create cluster --name osac-test --wait 5m
+KIND_EXPERIMENTAL_PROVIDER=podman kind create cluster --name osac-test --wait 5m
 
 # 1.5. Export kubeconfig to dedicated file
 echo "Exporting kubeconfig to dedicated file..."
-kind export kubeconfig --name osac-test --kubeconfig "${SCRIPT_DIR}/kubeconfig-osac-test"
+KIND_EXPERIMENTAL_PROVIDER=podman kind export kubeconfig --name osac-test --kubeconfig "${SCRIPT_DIR}/kubeconfig-osac-test"
 echo "Kubeconfig exported to: ${SCRIPT_DIR}/kubeconfig-osac-test"
 
 # 2. Clone osac-operator for CRDs

--- a/tests/integration/targets/cluster_create/tasks/baseline.yml
+++ b/tests/integration/targets/cluster_create/tasks/baseline.yml
@@ -27,6 +27,9 @@
         install_step_external_access_override:
           name: osac.workflows.workflow_helpers
           tasks_from: noop.yml
+        install_step_wait_for_nodes_override:
+          name: osac.workflows.workflow_helpers
+          tasks_from: noop.yml
         install_step_wait_for_cluster_operators_override:
           name: osac.workflows.workflow_helpers
           tasks_from: noop.yml

--- a/tests/integration/teardown_test_env.sh
+++ b/tests/integration/teardown_test_env.sh
@@ -4,7 +4,7 @@ set -e
 echo "=== Tearing down test environment ==="
 
 # Delete kind cluster
-kind delete cluster --name osac-test
+KIND_EXPERIMENTAL_PROVIDER=podman kind delete cluster --name osac-test
 
 # Clean up temporary files
 rm -f /tmp/osac_test_overrides.log


### PR DESCRIPTION
## Summary

- Make the Netris CaaS create flow fully idempotent so it supports scale up/down without destroying existing infrastructure
- Server clusters are updated in place (PUT) instead of deleted and recreated, preserving the VPC
- NAT rules (SNAT/DNAT) are looked up first; if they exist, their IPs are reused and IPAM allocation is skipped
- NMState config is only applied via SSH to newly added agents, preventing failures on already-provisioned servers with OVS bridges
- Add a "wait for nodes ready" step before cluster operators check
- Add request timeouts to all Netris API and k8s polling calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node readiness wait step with configurable retries, delay, expected count and timeouts.
  * Conditional NAT/DNAT handling to detect and reuse existing rules and IPs.
  * Server cluster flow now updates existing clusters or creates when missing.

* **Bug Fixes**
  * Preserve existing infrastructure and avoid destructive deletions; improved idempotency.
  * Apply NMState only to newly added agents when appropriate.

* **Chores**
  * Test environment scripts switched to Podman-backed provider.
  * .gitignore extended to ignore additional local tooling directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->