### PR TITLE
MGMT-23869: supports is_default field in NetworkClass publish_templates

### DIFF
--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -286,6 +286,7 @@ class Metadata(Base):
     allowed_resource_classes: list[str] | None = None
     # Network-specific fields
     implementation_strategy: str | None = None
+    is_default: bool = False
     capabilities: NetworkClassCapabilities | None = None
     parameters: list[TemplateParameterDefinition] = pydantic.Field(default_factory=list)
 
@@ -363,6 +364,7 @@ class NetworkClassTemplate(Base):
     title: str
     description: str | None = None
     implementation_strategy: str
+    is_default: bool = False
     capabilities: NetworkClassCapabilities
 
     @pydantic.field_serializer("path")

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/meta/osac.yaml
@@ -8,6 +8,7 @@ template_type: network
 
 # NetworkClass registration fields
 implementation_strategy: cudn_net
+is_default: true
 capabilities:
   supports_ipv4: true
   supports_ipv6: true


### PR DESCRIPTION
## Summary
- Adds is_default field to Metadata and NetworkClassTemplate Pydantic models in find_template_roles filter
- Sets is_default: true in cudn_net template osac.yaml so CUDN becomes the default NetworkClass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Templates can now be marked as default. The CUDN Network template has been configured as the default network template option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->