### PR TITLE
NO-ISSUE: fixes cross-workflow cancellation in CI concurrency groups

### DIFF
--- a/.github/workflows/execution-environment.yml
+++ b/.github/workflows/execution-environment.yml
@@ -2,7 +2,7 @@
 name: "Build execution environment"
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@
 name: "CI"
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:  # yamllint disable-line rule:truthy


### PR DESCRIPTION
## Summary
- Adds workflow name to concurrency group key in tests.yml and execution-environment.yml
- Without this, both workflows evaluate to the same group (just the branch name), so the slower workflow cancels the faster one on every PR