### PR TITLE
MOC template revendor after Namespace changes

### DIFF
--- a/vendor/ansible_collections/ansible.eda-2.8.2.info/GALAXY.yml
+++ b/vendor/ansible_collections/ansible.eda-2.8.2.info/GALAXY.yml
@@ -1,4 +1,4 @@
-download_url: https://console.redhat.com/api/automation-hub/v3/plugin/ansible/content/1274467-synclist/collections/artifacts/ansible-eda-2.8.2.tar.gz
+download_url: https://console.redhat.com/api/automation-hub/v3/plugin/ansible/content/published/collections/artifacts/ansible-eda-2.8.2.tar.gz
 format_version: 1.0.0
 name: eda
 namespace: ansible
@@ -42,4 +42,4 @@ signatures:
     '
   signing_service: null
 version: 2.8.2
-version_url: /api/automation-hub/content/1274467-synclist/v3/plugin/ansible/content/1274467-synclist/collections/index/ansible/eda/versions/2.8.2/
+version_url: /api/automation-hub/content/published/v3/plugin/ansible/content/published/collections/index/ansible/eda/versions/2.8.2/

--- a/vendor/ansible_collections/osac/massopencloud/FILES.json
+++ b/vendor/ansible_collections/osac/massopencloud/FILES.json
@@ -221,7 +221,7 @@
    "name": "roles/ocp_4_17_small_github/tasks/delete.yaml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "7c1d0ec85dd2655faded3ad028b39c93d40b91eda9d77e5ca25fefa224dbcd11",
+   "chksum_sha256": "193e3e7c3cc6a7e848c465289d19ba10a788460367bcc487641ddcc5b01f8a80",
    "format": 1
   },
   {
@@ -291,7 +291,7 @@
    "name": "roles/ocp_virt_vm/tasks/create.yaml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "1df6973fceec2453202c46ece3d33f73aa27b798f85af35b74da469bb495e0b5",
+   "chksum_sha256": "ae888d1f11e61e8bb75e7200cbab30804346d5ea8268a4e311d7a8c7906a2a8f",
    "format": 1
   },
   {

--- a/vendor/ansible_collections/osac/massopencloud/MANIFEST.json
+++ b/vendor/ansible_collections/osac/massopencloud/MANIFEST.json
@@ -27,7 +27,7 @@
   "name": "FILES.json",
   "ftype": "file",
   "chksum_type": "sha256",
-  "chksum_sha256": "1b5e045e5aaa1fb2894892a910b0dd7ce8bc9bf815588252e23e88a035e8e8e9",
+  "chksum_sha256": "01cbc84f5c6910a760e7278a587fc1c8efe1249b7069359493e484b2dbe74e16",
   "format": 1
  },
  "format": 1

--- a/vendor/ansible_collections/osac/massopencloud/roles/ocp_4_17_small_github/tasks/delete.yaml
+++ b/vendor/ansible_collections/osac/massopencloud/roles/ocp_4_17_small_github/tasks/delete.yaml
@@ -2,18 +2,18 @@
   ansible.builtin.import_role:
     name: osac.templates.ocp_4_17_small
 
-- name: Delete VM service (if it exists)
-  kubernetes.core.k8s:
-    api_version: v1
-    kind: Service
-    name: "{{ compute_instance_name }}-service"
-    namespace: "{{ compute_instance_working_namespace }}"
-    state: absent
+# TODO: The delete flow below needs investigation — it is unclear whether this
+# cleanup is reachable in practice.
+- name: Determine target namespace
+  ansible.builtin.set_fact:
+    compute_instance_target_namespace: >-
+      {{ (compute_instance.metadata.annotations | default({})).get(
+         'osac.openshift.io/subnet-target-namespace', tenant_target_namespace) }}
 
 - name: Delete VM load balancer service
   kubernetes.core.k8s:
     api_version: v1
     kind: Service
     name: "{{ compute_instance_name }}-load-balancer"
-    namespace: "{{ compute_instance_working_namespace }}"
+    namespace: "{{ compute_instance_target_namespace }}"
     state: absent

--- a/vendor/ansible_collections/osac/massopencloud/roles/ocp_virt_vm/tasks/create.yaml
+++ b/vendor/ansible_collections/osac/massopencloud/roles/ocp_virt_vm/tasks/create.yaml
@@ -34,7 +34,7 @@
       kind: Service
       metadata:
         name: "{{ compute_instance_name }}-load-balancer"
-        namespace: "{{ compute_instance_working_namespace }}"
+        namespace: "{{ compute_instance_target_namespace }}"
         labels: "{{ default_vm_labels }}"
       spec:
         type: LoadBalancer
@@ -46,7 +46,7 @@
     api_version: v1
     kind: Service
     name: "{{ compute_instance_name }}-load-balancer"
-    namespace: "{{ compute_instance_working_namespace }}"
+    namespace: "{{ compute_instance_target_namespace }}"
   register: load_balancer
   until: load_balancer.resources[0].status.loadBalancer.ingress is defined
   retries: 30
@@ -57,7 +57,7 @@
     api_version: kubevirt.io/v1
     kind: VirtualMachineInstance
     name: "{{ compute_instance_name }}"
-    namespace: "{{ compute_instance_working_namespace }}"
+    namespace: "{{ compute_instance_target_namespace }}"
   register: vmi_info
 
 - name: Get Node information for the VM


### PR DESCRIPTION
Re-vendors osac.massopencloud after the upstream [osac-massopencloud-templates fix](https://github.com/osac-project/osac-massopencloud-templates/pull/7)

Changes: 
- `compute_instance_working_namespace` was renamed to `compute_instance_target_namespace`
