### PR TITLE
MGMT-23907: Create and Delete metallb LoadBalancer service from public ip CRs

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -171,6 +171,18 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-create-public-ip"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_create_public_ip.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
   - name: "{{ aap_prefix }}-create-public-ip-pool"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"
@@ -188,6 +200,18 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     organization: "{{ aap_organization_name }}"
     job_type: run
     playbook: "playbook_osac_delete_public_ip_pool.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+  - name: "{{ aap_prefix }}-delete-public-ip"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_delete_public_ip.yml"
     inventory: "{{ aap_prefix }}-networking-operations"
     execution_environment: "{{ aap_prefix }}-ee"
     instance_groups:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
@@ -16,6 +16,33 @@ argument_specs:
         options: {}
         default: {}
 
+  create_public_ip:
+    options:
+      public_ip:
+        type: dict
+        required: true
+        description: PublicIP CR from fulfillment-api via EDA payload
+      public_ip_name:
+        type: str
+        required: true
+        description: Name of the PublicIP resource
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}
+
+  delete_public_ip:
+    options:
+      public_ip:
+        type: dict
+        required: true
+        description: PublicIP CR from fulfillment-api via EDA payload
+      public_ip_name:
+        type: str
+        required: true
+        description: Name of the PublicIP resource
+
   delete_public_ip_pool:
     options:
       public_ip_pool:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/osac.yaml
@@ -1,8 +1,9 @@
 ---
 title: MetalLB L2 Implementation
 description: >
-  Provisions MetalLB IPAddressPool and L2Advertisement resources for PublicIPPool.
-  Handles L2-based IP address advertisement on bare-metal clusters.
+  Provisions MetalLB resources for PublicIPPool and PublicIP using L2 advertisement.
+  Creates IPAddressPool and L2Advertisement for pools, and LoadBalancer
+  Services for individual IP allocation on bare-metal clusters.
 
 template_type: network
 

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
@@ -4,6 +4,14 @@
     name: osac.service.common
     tasks_from: get_remote_cluster_kubeconfig
 
+- name: Validate PublicIP annotations
+  ansible.builtin.assert:
+    that:
+      - public_ip.metadata is defined
+      - public_ip.metadata.annotations is defined
+      - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
+    fail_msg: "PublicIP metadata.annotations['osac.openshift.io/publicippool-name'] is required"
+
 - name: Extract PublicIP configuration
   ansible.builtin.set_fact:
     ip_name: "{{ public_ip.metadata.name }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
@@ -1,0 +1,76 @@
+---
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Extract PublicIP configuration
+  ansible.builtin.set_fact:
+    ip_name: "{{ public_ip.metadata.name }}"
+    ip_pool_name: >-
+      {{ public_ip.metadata.annotations['osac.openshift.io/publicippool-name'] }}
+
+- name: Display PublicIP information
+  ansible.builtin.debug:
+    msg:
+      - "Creating LoadBalancer Service for PublicIP '{{ ip_name }}'"
+      - "Pool name (IPAddressPool): {{ ip_pool_name }}"
+
+# Empty-selector LB Service reserves an IP from the MetalLB pool without
+# routing traffic. Port 65535 is arbitrary — required by the Service spec
+# but unused. MetalLB writes the assigned IP to status.loadBalancer.ingress.
+- name: Create LoadBalancer Service
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "osac-publicip-{{ ip_name }}"
+        namespace: metallb-system
+        annotations:
+          metallb.universe.tf/address-pool: "{{ ip_pool_name }}"
+        labels:
+          osac.openshift.io/publicip: "{{ ip_name }}"
+          osac.io/managed-by: osac-fulfillment
+      spec:
+        type: LoadBalancer
+        selector: {}
+        ports:
+          - name: placeholder
+            protocol: TCP
+            port: 65535
+            targetPort: 65535
+  register: lb_service_result
+  retries: 60
+  delay: 10
+  until: lb_service_result is successful
+
+- name: Display LoadBalancer Service creation result
+  ansible.builtin.debug:
+    msg:
+      - "LoadBalancer Service 'osac-publicip-{{ ip_name }}' created"
+      - "Changed: {{ lb_service_result.changed | default(false) }}"
+
+- name: Wait for IP assignment
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: v1
+    kind: Service
+    name: "osac-publicip-{{ ip_name }}"
+    namespace: metallb-system
+  register: lb_service_info
+  retries: 60
+  delay: 10
+  until: >-
+    lb_service_info.resources | length > 0 and
+    lb_service_info.resources[0].status.loadBalancer.ingress | default([]) | length > 0
+
+- name: Extract assigned IP
+  ansible.builtin.set_fact:
+    assigned_ip: "{{ lb_service_info.resources[0].status.loadBalancer.ingress[0].ip }}"
+
+- name: Display assigned IP
+  ansible.builtin.debug:
+    msg: "PublicIP '{{ ip_name }}' assigned address: {{ assigned_ip }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip.yaml
@@ -24,6 +24,14 @@
     wait: true
     wait_timeout: 300
   register: lb_service_delete_result
+  retries: 3
+  delay: 10
+  until: >-
+    lb_service_delete_result is successful
+    or ('NotFound' in (lb_service_delete_result.msg | default('')))
+  failed_when:
+    - lb_service_delete_result.failed | default(false)
+    - "'NotFound' not in (lb_service_delete_result.msg | default(''))"
 
 - name: Display LoadBalancer Service deletion result
   ansible.builtin.debug:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip.yaml
@@ -1,0 +1,32 @@
+---
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Extract PublicIP configuration
+  ansible.builtin.set_fact:
+    ip_name: "{{ public_ip.metadata.name }}"
+
+- name: Display deletion information
+  ansible.builtin.debug:
+    msg:
+      - "Deleting LoadBalancer Service for PublicIP '{{ ip_name }}'"
+
+- name: Delete LoadBalancer Service
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: absent
+    api_version: v1
+    kind: Service
+    name: "osac-publicip-{{ ip_name }}"
+    namespace: metallb-system
+    wait: true
+    wait_timeout: 300
+  register: lb_service_delete_result
+
+- name: Display LoadBalancer Service deletion result
+  ansible.builtin.debug:
+    msg:
+      - "LoadBalancer Service 'osac-publicip-{{ ip_name }}' deletion completed"
+      - "Changed: {{ lb_service_delete_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -243,6 +243,7 @@
               - lb_svc_result.resources[0].spec.type == "LoadBalancer"
               - lb_svc_result.resources[0].spec.ports[0].port == 65535
               - lb_svc_result.resources[0].spec.ports[0].name == "placeholder"
+              - lb_svc_result.resources[0].spec.selector | default({}) | length == 0
             fail_msg: "LoadBalancer Service not created correctly"
             success_msg: "LoadBalancer Service 'osac-publicip-{{ test_ip_name }}' created with correct spec"
 

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -1,27 +1,41 @@
 ---
 # Test playbook for osac.templates.metallb_l2 role.
 #
-# Tests create and delete of MetalLB IPAddressPool and L2Advertisement
-# resources. Requires a cluster with MetalLB CRDs applied and the
-# metallb-system namespace present. No MetalLB operator is needed since
-# tests only verify CR creation and deletion, not controller behavior.
+# Tests create and delete of MetalLB resources:
+#   - PublicIPPool: IPAddressPool and L2Advertisement
+#   - PublicIP: LoadBalancer Service for IP allocation
+#
+# Requires a cluster with MetalLB CRDs applied and the metallb-system
+# namespace present. No MetalLB operator is needed for pool tests since
+# they only verify CR creation/deletion. PublicIP tests require a
+# running MetalLB controller to assign IPs to LoadBalancer Services.
 #
 # Do NOT set OSAC_REMOTE_CLUSTER_KUBECONFIG when running these tests.
 # The role's get_remote_cluster_kubeconfig include is a no-op without it,
 # and kubernetes.core.k8s falls back to the default kubeconfig.
 #
 # Usage:
-#   # Run all tests in sequence (create, verify, delete, delete-not-found)
+#   # Run all tests in sequence
 #   ansible-playbook test.yml -v
 #
-#   # Run only create tests
-#   ansible-playbook test.yml -e run_create=true -e run_delete=false -e run_delete_not_found=false -v
+#   # Run only pool create tests
+#   ansible-playbook test.yml -e run_create=true -e run_create_ip=false \
+#     -e run_delete_ip=false -e run_delete_ip_not_found=false \
+#     -e run_delete=false -e run_delete_not_found=false -v
 #
-#   # Run only delete tests (resources must already exist)
-#   ansible-playbook test.yml -e run_delete=true -e run_create=false -e run_delete_not_found=false -v
+#   # Run only PublicIP create tests (pool must already exist)
+#   ansible-playbook test.yml -e run_create=false -e run_create_ip=true \
+#     -e run_delete_ip=false -e run_delete_ip_not_found=false \
+#     -e run_delete=false -e run_delete_not_found=false -v
 #
-#   # Run only delete-not-found test (resources must NOT exist)
-#   ansible-playbook test.yml -e run_delete_not_found=true -e run_create=false -e run_delete=false -v
+#   # Run only PublicIP delete tests (LB Service must already exist)
+#   ansible-playbook test.yml -e run_create=false -e run_create_ip=false \
+#     -e run_delete_ip=true -e run_delete_ip_not_found=false \
+#     -e run_delete=false -e run_delete_not_found=false -v
+#
+#   # Run all tests with user impersonation (needed when your user lacks
+#   # direct RBAC for metallb-system resources)
+#   ansible-playbook test.yml -e test_impersonate_user=system:admin -v
 
 # ──────────────────────────────────────────────────────────────
 # Pre-flight: fail fast if OSAC_REMOTE_CLUSTER_KUBECONFIG is set
@@ -45,6 +59,8 @@
 - name: Test metallb_l2 role -- create PublicIPPool resources
   hosts: localhost
   gather_facts: false
+  environment:
+    K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
     test_pool_name: "test-metallb-pool"
@@ -165,12 +181,218 @@
           ignore_errors: true
 
 # ──────────────────────────────────────────────────────────────
+# Test: Create PublicIP (LoadBalancer Service)
+# Expected: LB Service created in metallb-system with correct
+#   annotations, labels, placeholder port, and assigned IP.
+# Prerequisite: IPAddressPool must exist (run pool create first).
+# ──────────────────────────────────────────────────────────────
+- name: Test metallb_l2 role -- create PublicIP resources
+  hosts: localhost
+  gather_facts: false
+  environment:
+    K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
+
+  vars:
+    test_ip_name: "test-publicip"
+    test_pool_name: "test-metallb-pool"
+    public_ip_name: "{{ test_ip_name }}"
+    public_ip:
+      metadata:
+        name: "{{ test_ip_name }}"
+        annotations:
+          osac.openshift.io/publicippool-name: "{{ test_pool_name }}"
+
+  tasks:
+    - name: Run PublicIP create tests
+      when: run_create_ip | default(true) | bool
+      block:
+        - name: Check LB Service does not already exist
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_name }}"
+            namespace: metallb-system
+          register: pre_create_svc
+
+        - name: Assert clean state before PublicIP create
+          ansible.builtin.assert:
+            that:
+              - pre_create_svc.resources | length == 0
+            fail_msg: >-
+              Stale LB Service exists from a previous run. Clean up with:
+              oc delete svc osac-publicip-{{ test_ip_name }} -n metallb-system --ignore-not-found
+            success_msg: "No stale LB Service, proceeding with create"
+
+        - name: Create PublicIP via metallb_l2 role
+          ansible.builtin.include_role:
+            name: osac.templates.metallb_l2
+            tasks_from: create_public_ip
+
+        - name: Fetch LoadBalancer Service
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_name }}"
+            namespace: metallb-system
+          register: lb_svc_result
+
+        - name: Verify LoadBalancer Service exists with correct spec
+          ansible.builtin.assert:
+            that:
+              - lb_svc_result.resources | length == 1
+              - lb_svc_result.resources[0].spec.type == "LoadBalancer"
+              - lb_svc_result.resources[0].spec.ports[0].port == 65535
+              - lb_svc_result.resources[0].spec.ports[0].name == "placeholder"
+            fail_msg: "LoadBalancer Service not created correctly"
+            success_msg: "LoadBalancer Service 'osac-publicip-{{ test_ip_name }}' created with correct spec"
+
+        - name: Verify LoadBalancer Service annotations
+          ansible.builtin.assert:
+            that:
+              - lb_svc_result.resources[0].metadata.annotations['metallb.universe.tf/address-pool'] == test_pool_name
+            fail_msg: "LoadBalancer Service address-pool annotation incorrect"
+            success_msg: "LoadBalancer Service address-pool annotation correct"
+
+        - name: Verify LoadBalancer Service labels
+          ansible.builtin.assert:
+            that:
+              - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_name
+              - lb_svc_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
+            fail_msg: "LoadBalancer Service labels incorrect"
+            success_msg: "LoadBalancer Service labels correct"
+
+        - name: Verify IP was assigned by MetalLB
+          ansible.builtin.assert:
+            that:
+              - lb_svc_result.resources[0].status.loadBalancer.ingress | default([]) | length > 0
+              - lb_svc_result.resources[0].status.loadBalancer.ingress[0].ip is defined
+              - lb_svc_result.resources[0].status.loadBalancer.ingress[0].ip | length > 0
+            fail_msg: "MetalLB did not assign an IP to the LoadBalancer Service"
+            success_msg: >-
+              MetalLB assigned IP
+              '{{ lb_svc_result.resources[0].status.loadBalancer.ingress[0].ip }}'
+
+      always:
+        - name: Clean up LoadBalancer Service on failure
+          kubernetes.core.k8s:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_name }}"
+            namespace: metallb-system
+            state: absent
+          when: ansible_failed_result is defined
+          ignore_errors: true
+
+# ──────────────────────────────────────────────────────────────
+# Test: Delete PublicIP (LoadBalancer Service)
+# Expected: Service deleted from metallb-system.
+# ──────────────────────────────────────────────────────────────
+- name: Test metallb_l2 role -- delete PublicIP resources
+  hosts: localhost
+  gather_facts: false
+  environment:
+    K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
+
+  vars:
+    test_ip_name: "test-publicip"
+    public_ip_name: "{{ test_ip_name }}"
+    public_ip:
+      metadata:
+        name: "{{ test_ip_name }}"
+
+  tasks:
+    - name: Run PublicIP delete tests
+      when: run_delete_ip | default(true) | bool
+      block:
+        - name: Verify LB Service exists before delete
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_name }}"
+            namespace: metallb-system
+          register: pre_delete_svc
+
+        - name: Assert LB Service exists (otherwise delete test is meaningless)
+          ansible.builtin.assert:
+            that:
+              - pre_delete_svc.resources | length == 1
+            fail_msg: "LB Service does not exist before delete. Run PublicIP create test first or run all tests together."
+            success_msg: "LB Service exists, proceeding with delete"
+
+        - name: Delete PublicIP via metallb_l2 role
+          ansible.builtin.include_role:
+            name: osac.templates.metallb_l2
+            tasks_from: delete_public_ip
+
+        - name: Verify LB Service is gone
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_name }}"
+            namespace: metallb-system
+          register: svc_after_delete
+
+        - name: Assert LB Service deleted
+          ansible.builtin.assert:
+            that:
+              - svc_after_delete.resources | length == 0
+            fail_msg: "LB Service still exists after delete"
+            success_msg: "LB Service 'osac-publicip-{{ test_ip_name }}' successfully deleted"
+
+# ──────────────────────────────────────────────────────────────
+# Test: Delete PublicIP when already gone (NotFound handling)
+# Expected: No failure. The role tolerates already-deleted resources.
+# ──────────────────────────────────────────────────────────────
+- name: Test metallb_l2 role -- delete PublicIP tolerates NotFound
+  hosts: localhost
+  gather_facts: false
+  environment:
+    K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
+
+  vars:
+    test_ip_name: "test-publicip"
+    public_ip_name: "{{ test_ip_name }}"
+    public_ip:
+      metadata:
+        name: "{{ test_ip_name }}"
+
+  tasks:
+    - name: Run PublicIP delete-not-found test
+      when: run_delete_ip_not_found | default(true) | bool
+      block:
+        - name: Verify LB Service is absent before NotFound test
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_name }}"
+            namespace: metallb-system
+          register: pre_notfound_svc
+
+        - name: Assert LB Service is absent (otherwise this is not a NotFound test)
+          ansible.builtin.assert:
+            that:
+              - pre_notfound_svc.resources | length == 0
+            fail_msg: "LB Service still exists. Run delete tests first or clean up manually."
+            success_msg: "LB Service absent, proceeding with NotFound test"
+
+        - name: Delete already-gone PublicIP (should not fail)
+          ansible.builtin.include_role:
+            name: osac.templates.metallb_l2
+            tasks_from: delete_public_ip
+
+        - name: Confirm no failure occurred
+          ansible.builtin.debug:
+            msg: "PublicIP delete-not-found test passed: role tolerated already-deleted LB Service"
+
+# ──────────────────────────────────────────────────────────────
 # Test: Delete IPAddressPool and L2Advertisement
 # Expected: Both resources deleted. L2Advertisement deleted first.
 # ──────────────────────────────────────────────────────────────
 - name: Test metallb_l2 role -- delete PublicIPPool resources
   hosts: localhost
   gather_facts: false
+  environment:
+    K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
     test_pool_name: "test-metallb-pool"
@@ -249,6 +471,8 @@
 - name: Test metallb_l2 role -- delete tolerates NotFound
   hosts: localhost
   gather_facts: false
+  environment:
+    K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
     test_pool_name: "test-metallb-pool"

--- a/playbook_osac_create_public_ip.yml
+++ b/playbook_osac_create_public_ip.yml
@@ -1,0 +1,30 @@
+---
+- name: Create a PublicIP resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    public_ip: "{{ ansible_eda.event.payload }}"
+    public_ip_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations
+         ['osac.openshift.io/implementation-strategy'] }}
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display PublicIP information
+      ansible.builtin.debug:
+        msg:
+          - "PublicIP name: {{ public_ip_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+          - "Template parameters: {{ template_parameters }}"
+
+    - name: Call the selected PublicIP role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: create_public_ip

--- a/playbook_osac_create_public_ip_pool.yml
+++ b/playbook_osac_create_public_ip_pool.yml
@@ -24,5 +24,5 @@
 
     - name: Call the selected PublicIPPool role
       ansible.builtin.include_role:
-        name: "osac.templates.{{ implementation_strategy | replace('-', '_') }}"
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
         tasks_from: create_public_ip_pool

--- a/playbook_osac_delete_public_ip.yml
+++ b/playbook_osac_delete_public_ip.yml
@@ -1,0 +1,29 @@
+---
+- name: Delete a PublicIP resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    public_ip: "{{ ansible_eda.event.payload }}"
+    public_ip_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations
+         ['osac.openshift.io/implementation-strategy'] }}
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display PublicIP information
+      ansible.builtin.debug:
+        msg:
+          - "Deleting PublicIP: {{ public_ip_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected PublicIP role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: delete_public_ip

--- a/playbook_osac_delete_public_ip_pool.yml
+++ b/playbook_osac_delete_public_ip_pool.yml
@@ -23,5 +23,5 @@
 
     - name: Call the selected PublicIPPool role
       ansible.builtin.include_role:
-        name: "osac.templates.{{ implementation_strategy | replace('-', '_') }}"
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
         tasks_from: delete_public_ip_pool

--- a/rulebooks/cluster_fulfillment.yml
+++ b/rulebooks/cluster_fulfillment.yml
@@ -63,6 +63,20 @@
           name: "{{ job_template_prefix }}-delete-subnet"
           organization: "{{ job_template_organization }}"
 
+    - name: Create public IP
+      condition: event.meta.endpoint == "create-public-ip"
+      action:
+        run_job_template:
+          name: "{{ job_template_prefix }}-create-public-ip"
+          organization: "{{ job_template_organization }}"
+
+    - name: Delete public IP
+      condition: event.meta.endpoint == "delete-public-ip"
+      action:
+        run_job_template:
+          name: "{{ job_template_prefix }}-delete-public-ip"
+          organization: "{{ job_template_organization }}"
+
     - name: Create public IP pool
       condition: event.meta.endpoint == "create-public-ip-pool"
       action:


### PR DESCRIPTION
[MGMT-23907](https://redhat.atlassian.net/browse/MGMT-23907)

Adds AAP roles and tests covering creation and deletion of a LoadBalancer Service based upon associated Public IP CRs.  The Service is created with an empty selector and placeholder port.  MetalLB assigns an IP and writes to the Service's status.loadBalancer.ingress which can later be read by the operator.

Testing Notes:

This was validated manually in the osac-dakcrowder namespace on the MoC cluster by creating a test Public IP CR.  The role was then used to generate an associated Service in the metallb-system namespace.  Removing the CR then resulted in proper deletion.

```
# Created a test CR
$ oc --as=system:admin -n osac-dakcrowder get publicip test-pip-e2e
NAME           POOL                ADDRESS   STATE   PHASE   AGE
test-pip-e2e   test-pool-e2e-001                     Ready   78m
# Which in turn created an associated LoadBalancer by the role
$ oc --as=system:admin -n metallb-system get svc osac-publicip-test-pip-e2e
NAME                         TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)           AGE
osac-publicip-test-pip-e2e   LoadBalancer   172.30.58.19   192.168.100.0   65535:31677/TCP   2m53s

# Manually delete the CR
$ oc --as=system:admin -n osac-dakcrowder delete publicip test-pip-e2e
# After processing occurs the LoadBalancer has also been removed by the role
$ oc --as=system:admin -n metallb-system get svc osac-publicip-test-pip-e2e
Error from server (NotFound): services "osac-publicip-test-pip-e2e" not found
```

Additionally the existing MetalLB tests were extended to validate creation and deletion of the LoadBalancer Service.  These can be run like:

```
$ ansible-playbook collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml -e test_impersonate_user=system:admin -v
...
[Redacting lots of output logs]
...
PLAY RECAP *************************************************************************************************
dcrowder-thinkpadt14gen4.rht.csb : ok=83   changed=6    unreachable=0    failed=0    skipped=10   rescued=0    ignored=0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public IP creation and deletion functionality with MetalLB LoadBalancer Service management.
  * Introduced automation rules for public IP lifecycle management via webhook endpoints.
  * Expanded MetalLB template capabilities for PublicIP resource provisioning.

* **Tests**
  * Added comprehensive test coverage for public IP creation, deletion, and error-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->