### PR TITLE
Create AAP attach and detach task for MetalLB L2 PublicIP

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -243,13 +243,6 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
-    inventory: "{{ aap_prefix }}-networking-operations"
-    execution_environment: "{{ aap_prefix }}-ee"
-    instance_groups:
-      - "{{ aap_prefix }}-networking-operations-ig"
-    allow_simultaneous: true
-    ask_variables_on_launch: true
-    verbosity: 0
   - name: "{{ aap_prefix }}-import-agents"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"

--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -219,6 +219,37 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-attach-public-ip"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_attach_public_ip.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+  - name: "{{ aap_prefix }}-detach-public-ip"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_detach_public_ip.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
   - name: "{{ aap_prefix }}-import-agents"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
@@ -74,7 +74,7 @@ argument_specs:
         description: Template-specific parameters (reserved for future use)
         options: {}
         default: {}
-        
+
   delete_public_ip_pool:
     options:
       public_ip_pool:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
@@ -17,10 +17,12 @@ argument_specs:
         default: {}
 
   create_public_ip:
+  attach_public_ip:
     options:
       public_ip:
         type: dict
         required: true
+<<<<<<< HEAD
         description: PublicIP CR from fulfillment-api via EDA payload
       public_ip_name:
         type: str
@@ -33,15 +35,38 @@ argument_specs:
         default: {}
 
   delete_public_ip:
+=======
+        description: >-
+          Full PublicIP CR dict from fulfillment-api via EDA payload.
+          Must carry annotations osac.openshift.io/publicip-target-namespace
+          and osac.openshift.io/publicippool-name.
+      public_ip_name:
+        type: str
+        required: true
+        description: metadata.name of the PublicIP CR
+
+  detach_public_ip:
+>>>>>>> 72aac9c (Add tasks for attach and detach public IP to VM)
     options:
       public_ip:
         type: dict
         required: true
+<<<<<<< HEAD
         description: PublicIP CR from fulfillment-api via EDA payload
       public_ip_name:
         type: str
         required: true
         description: Name of the PublicIP resource
+=======
+        description: >-
+          Full PublicIP CR dict from fulfillment-api via EDA payload.
+          Must carry annotations osac.openshift.io/publicip-target-namespace
+          and osac.openshift.io/publicippool-name.
+      public_ip_name:
+        type: str
+        required: true
+        description: metadata.name of the PublicIP CR
+>>>>>>> 72aac9c (Add tasks for attach and detach public IP to VM)
 
   delete_public_ip_pool:
     options:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
@@ -65,8 +65,7 @@ argument_specs:
         type: dict
         description: Template-specific parameters (reserved for future use)
         options: {}
-        default: {}  
-  
+        default: {}
   delete_public_ip_pool:
     options:
       public_ip_pool:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
@@ -22,10 +22,10 @@ argument_specs:
         type: dict
         required: true
         description: PublicIP CR from fulfillment-api via EDA payload
-      public_ip_name:
+      public_ip_id:
         type: str
         required: true
-        description: Name of the PublicIP resource
+        description: ID of the PublicIP resource
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
@@ -38,17 +38,20 @@ argument_specs:
         type: dict
         required: true
         description: PublicIP CR from fulfillment-api via EDA payload
-      public_ip_name:
+      public_ip_id:
         type: str
         required: true
-        description: Name of the PublicIP resource
+        description: ID of the PublicIP resource
 
   attach_public_ip:
     options:
       public_ip:
         type: dict
         required: true
-        description: PublicIP CR from fulfillment-api via EDA payload
+        description: >-
+          PublicIP CR from fulfillment-api via EDA payload. Must include
+          annotations osac.openshift.io/publicippool-name and
+          osac.openshift.io/publicip-target-namespace.
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
@@ -60,7 +63,10 @@ argument_specs:
       public_ip:
         type: dict
         required: true
-        description: PublicIP CR from fulfillment-api via EDA payload
+        description: >-
+          PublicIP CR from fulfillment-api via EDA payload. Must include
+          annotations osac.openshift.io/publicippool-name and
+          osac.openshift.io/publicip-target-namespace.
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
@@ -17,12 +17,10 @@ argument_specs:
         default: {}
 
   create_public_ip:
-  attach_public_ip:
     options:
       public_ip:
         type: dict
         required: true
-<<<<<<< HEAD
         description: PublicIP CR from fulfillment-api via EDA payload
       public_ip_name:
         type: str
@@ -35,39 +33,40 @@ argument_specs:
         default: {}
 
   delete_public_ip:
-=======
-        description: >-
-          Full PublicIP CR dict from fulfillment-api via EDA payload.
-          Must carry annotations osac.openshift.io/publicip-target-namespace
-          and osac.openshift.io/publicippool-name.
-      public_ip_name:
-        type: str
-        required: true
-        description: metadata.name of the PublicIP CR
-
-  detach_public_ip:
->>>>>>> 72aac9c (Add tasks for attach and detach public IP to VM)
     options:
       public_ip:
         type: dict
         required: true
-<<<<<<< HEAD
         description: PublicIP CR from fulfillment-api via EDA payload
       public_ip_name:
         type: str
         required: true
         description: Name of the PublicIP resource
-=======
-        description: >-
-          Full PublicIP CR dict from fulfillment-api via EDA payload.
-          Must carry annotations osac.openshift.io/publicip-target-namespace
-          and osac.openshift.io/publicippool-name.
-      public_ip_name:
-        type: str
-        required: true
-        description: metadata.name of the PublicIP CR
->>>>>>> 72aac9c (Add tasks for attach and detach public IP to VM)
 
+  attach_public_ip:
+    options:
+      public_ip:
+        type: dict
+        required: true
+        description: PublicIP CR from fulfillment-api via EDA payload
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}
+
+  detach_public_ip:
+    options:
+      public_ip:
+        type: dict
+        required: true
+        description: PublicIP CR from fulfillment-api via EDA payload
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}  
+  
   delete_public_ip_pool:
     options:
       public_ip_pool:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/argument_specs.yaml
@@ -22,10 +22,10 @@ argument_specs:
         type: dict
         required: true
         description: PublicIP CR from fulfillment-api via EDA payload
-      public_ip_id:
+      public_ip_name:
         type: str
         required: true
-        description: ID of the PublicIP resource
+        description: Name of the PublicIP resource
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
@@ -38,10 +38,10 @@ argument_specs:
         type: dict
         required: true
         description: PublicIP CR from fulfillment-api via EDA payload
-      public_ip_id:
+      public_ip_name:
         type: str
         required: true
-        description: ID of the PublicIP resource
+        description: Name of the PublicIP resource
 
   attach_public_ip:
     options:
@@ -50,7 +50,8 @@ argument_specs:
         required: true
         description: >-
           PublicIP CR from fulfillment-api via EDA payload. Must include
-          annotations osac.openshift.io/publicippool-name and
+          metadata.name, metadata.namespace, spec.computeInstance, and annotations
+          osac.openshift.io/publicippool-name and
           osac.openshift.io/publicip-target-namespace.
       template_parameters:
         type: dict
@@ -65,13 +66,15 @@ argument_specs:
         required: true
         description: >-
           PublicIP CR from fulfillment-api via EDA payload. Must include
-          annotations osac.openshift.io/publicippool-name and
+          metadata.name, metadata.namespace, spec.computeInstance, and annotations
+          osac.openshift.io/publicippool-name and
           osac.openshift.io/publicip-target-namespace.
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
         options: {}
         default: {}
+        
   delete_public_ip_pool:
     options:
       public_ip_pool:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
@@ -59,14 +59,14 @@
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: v1
     kind: Service
-    name: "osac-publicip-{{ public_ip_name }}"
+    name: "osac-pip-{{ public_ip_name }}"
     namespace: metallb-system
   register: parking_service_info
 
 - name: Fail if parking Service not found or IP not yet assigned
   ansible.builtin.fail:
     msg: >-
-      Parking Service 'osac-publicip-{{ public_ip_name }}' not found in metallb-system
+      Parking Service 'osac-pip-{{ public_ip_name }}' not found in metallb-system
       or MetalLB has not yet assigned an IP. Run create_public_ip first.
   when: >-
     parking_service_info.resources | length == 0 or
@@ -96,7 +96,7 @@
         state: absent
         api_version: v1
         kind: Service
-        name: "osac-publicip-{{ public_ip_name }}"
+        name: "osac-pip-{{ public_ip_name }}"
         namespace: metallb-system
         wait: true
         wait_timeout: 60
@@ -111,7 +111,7 @@
     - name: Display parking Service deletion result
       ansible.builtin.debug:
         msg:
-          - "Parking Service 'osac-publicip-{{ public_ip_name }}' deleted"
+          - "Parking Service 'osac-pip-{{ public_ip_name }}' deleted"
           - "Changed: {{ reservation_delete_result.changed | default(false) }}"
 
     # Create a LoadBalancer Service in the VM namespace.
@@ -124,7 +124,7 @@
           apiVersion: v1
           kind: Service
           metadata:
-            name: "{{ public_ip_name }}-lb"
+            name: "osac-pip-{{ public_ip_name }}-ingress"
             namespace: "{{ attach_vm_namespace }}"
             labels:
               osac.openshift.io/publicip: "{{ public_ip_name }}"
@@ -151,7 +151,7 @@
     - name: Display LoadBalancer Service creation result
       ansible.builtin.debug:
         msg:
-          - "LoadBalancer Service '{{ public_ip_name }}-lb' created in '{{ attach_vm_namespace }}'"
+          - "LoadBalancer Service 'osac-pip-{{ public_ip_name }}-ingress' created in '{{ attach_vm_namespace }}'"
           - "Changed: {{ lb_service_result.changed | default(false) }}"
 
   rescue:
@@ -164,7 +164,7 @@
           apiVersion: v1
           kind: Service
           metadata:
-            name: "osac-publicip-{{ public_ip_name }}"
+            name: "osac-pip-{{ public_ip_name }}"
             namespace: metallb-system
             labels:
               osac.openshift.io/publicip: "{{ public_ip_name }}"
@@ -190,7 +190,7 @@
       ansible.builtin.fail:
         msg: >-
           Attach of PublicIP '{{ public_ip_name }}' failed; the parking Service
-          'osac-publicip-{{ public_ip_name }}' in metallb-system has been restored
+          'osac-pip-{{ public_ip_name }}' in metallb-system has been restored
           if it had been deleted. Check the preceding error for details.
 
 # Annotate the ComputeInstance CR with the assigned floating IP.

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
@@ -7,9 +7,11 @@
 - name: Validate PublicIP fields and annotations
   ansible.builtin.assert:
     that:
-      - public_ip.id is defined
-      - public_ip.id | length > 0
       - public_ip.metadata is defined
+      - public_ip.metadata.name is defined
+      - public_ip.metadata.name | length > 0
+      - public_ip.metadata.namespace is defined
+      - public_ip.metadata.namespace | length > 0
       - public_ip.metadata.annotations is defined
       - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
       - "'osac.openshift.io/publicip-target-namespace' in public_ip.metadata.annotations"
@@ -18,37 +20,38 @@
       - public_ip.spec.computeInstance | length > 0
     fail_msg: >-
       PublicIP is missing required fields/annotations:
-      id and spec.computeInstance must be set, and annotations
-      osac.openshift.io/publicippool-name and
+      metadata.name, metadata.namespace, and spec.computeInstance must be set,
+      and annotations osac.openshift.io/publicippool-name and
       osac.openshift.io/publicip-target-namespace must both be present.
 
 - name: Extract PublicIP attach configuration
   ansible.builtin.set_fact:
-    public_ip_id: "{{ public_ip.id }}"
-    public_ip_name: "{{ public_ip.metadata.name | default(public_ip.id) }}"
+    public_ip_name: "{{ public_ip.metadata.name }}"
     attach_vm_namespace: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicip-target-namespace'] }}
     attach_pool_name: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicippool-name'] }}
 
-- name: Fetch ComputeInstance CR by ID
+- name: Fetch ComputeInstance CR
   kubernetes.core.k8s_info:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: osac.openshift.io/v1alpha1
     kind: ComputeInstance
-    name: "{{ public_ip.spec.computeInstance }}"
+    namespace: "{{ public_ip.metadata.namespace }}"
+    label_selectors:
+      - "osac.openshift.io/computeinstance-uuid={{ public_ip.spec.computeInstance }}"
   register: attach_ci_lookup
 
 - name: Fail if ComputeInstance not found
   ansible.builtin.fail:
     msg: >-
-      ComputeInstance '{{ public_ip.spec.computeInstance }}' not found.
+      ComputeInstance with uuid '{{ public_ip.spec.computeInstance }}' not found
+      in namespace '{{ public_ip.metadata.namespace }}'.
   when: attach_ci_lookup.resources | length == 0
 
-- name: Extract ComputeInstance name and namespace from fetched CR
+- name: Extract ComputeInstance name from fetched CR
   ansible.builtin.set_fact:
     attach_compute_instance_name: "{{ attach_ci_lookup.resources[0].metadata.name }}"
-    attach_compute_instance_namespace: "{{ attach_ci_lookup.resources[0].metadata.namespace }}"
 
 # Read the reserved IP directly from the parking Service status.
 - name: Read reserved IP from parking Service
@@ -56,16 +59,15 @@
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: v1
     kind: Service
-    name: "osac-publicip-{{ public_ip_id }}"
+    name: "osac-publicip-{{ public_ip_name }}"
     namespace: metallb-system
   register: parking_service_info
 
 - name: Fail if parking Service not found or IP not yet assigned
   ansible.builtin.fail:
     msg: >-
-      Parking Service 'osac-publicip-{{ public_ip_id }}' (PublicIP '{{ public_ip_name }}')
-      not found in metallb-system or MetalLB has not yet assigned an IP.
-      Run create_public_ip first.
+      Parking Service 'osac-publicip-{{ public_ip_name }}' not found in metallb-system
+      or MetalLB has not yet assigned an IP. Run create_public_ip first.
   when: >-
     parking_service_info.resources | length == 0 or
     parking_service_info.resources[0].status.loadBalancer.ingress | default([]) | length == 0
@@ -77,11 +79,11 @@
 - name: Display PublicIP attach information
   ansible.builtin.debug:
     msg:
-      - "Attaching PublicIP id='{{ public_ip_id }}' name='{{ public_ip_name }}'"
+      - "Attaching PublicIP '{{ public_ip_name }}'"
       - "IP address: {{ attach_ip_address }} (read from parking Service)"
       - "Pool: {{ attach_pool_name }}"
       - "VM namespace: {{ attach_vm_namespace }}"
-      - "ComputeInstance: {{ attach_compute_instance_name }} ({{ attach_compute_instance_namespace }})"
+      - "ComputeInstance: {{ attach_compute_instance_name }} ({{ public_ip.metadata.namespace }})"
 
 # Delete the parking Service and create the VM-namespace LB Service atomically.
 # The rescue restores the parking Service if LB Service creation fails so the IP
@@ -94,16 +96,14 @@
         state: absent
         api_version: v1
         kind: Service
-        name: "osac-publicip-{{ public_ip_id }}"
+        name: "osac-publicip-{{ public_ip_name }}"
         namespace: metallb-system
         wait: true
         wait_timeout: 60
       register: reservation_delete_result
       retries: 3
       delay: 5
-      until: >-
-        reservation_delete_result is successful
-        or ('NotFound' in (reservation_delete_result.msg | default('')))
+      until: reservation_delete_result is successful
       failed_when:
         - reservation_delete_result.failed | default(false)
         - "'NotFound' not in (reservation_delete_result.msg | default(''))"
@@ -111,7 +111,7 @@
     - name: Display parking Service deletion result
       ansible.builtin.debug:
         msg:
-          - "Parking Service 'osac-publicip-{{ public_ip_id }}' deleted"
+          - "Parking Service 'osac-publicip-{{ public_ip_name }}' deleted"
           - "Changed: {{ reservation_delete_result.changed | default(false) }}"
 
     # Create a LoadBalancer Service in the VM namespace.
@@ -124,10 +124,10 @@
           apiVersion: v1
           kind: Service
           metadata:
-            name: "{{ public_ip_id }}-lb"
+            name: "{{ public_ip_name }}-lb"
             namespace: "{{ attach_vm_namespace }}"
             labels:
-              osac.openshift.io/publicip: "{{ public_ip_id }}"
+              osac.openshift.io/publicip: "{{ public_ip_name }}"
               osac.io/managed-by: osac-fulfillment
             annotations:
               metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
@@ -144,11 +144,14 @@
                 targetPort: 22
                 protocol: TCP
       register: lb_service_result
+      retries: 6
+      delay: 10
+      until: lb_service_result is successful
 
     - name: Display LoadBalancer Service creation result
       ansible.builtin.debug:
         msg:
-          - "LoadBalancer Service '{{ public_ip_id }}-lb' created in '{{ attach_vm_namespace }}'"
+          - "LoadBalancer Service '{{ public_ip_name }}-lb' created in '{{ attach_vm_namespace }}'"
           - "Changed: {{ lb_service_result.changed | default(false) }}"
 
   rescue:
@@ -161,10 +164,10 @@
           apiVersion: v1
           kind: Service
           metadata:
-            name: "osac-publicip-{{ public_ip_id }}"
+            name: "osac-publicip-{{ public_ip_name }}"
             namespace: metallb-system
             labels:
-              osac.openshift.io/publicip: "{{ public_ip_id }}"
+              osac.openshift.io/publicip: "{{ public_ip_name }}"
               osac.io/managed-by: osac-fulfillment
             annotations:
               metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
@@ -178,12 +181,16 @@
                 port: 65535
                 targetPort: 65535
       when: reservation_delete_result.changed | default(false)
+      register: rescue_parking_result
+      retries: 3
+      delay: 5
+      until: rescue_parking_result is successful
 
     - name: Fail after attempted rollback of attach operation
       ansible.builtin.fail:
         msg: >-
           Attach of PublicIP '{{ public_ip_name }}' failed; the parking Service
-          'osac-publicip-{{ public_ip_id }}' in metallb-system has been restored
+          'osac-publicip-{{ public_ip_name }}' in metallb-system has been restored
           if it had been deleted. Check the preceding error for details.
 
 # Annotate the ComputeInstance CR with the assigned floating IP.
@@ -193,7 +200,7 @@
     api_version: osac.openshift.io/v1alpha1
     kind: ComputeInstance
     name: "{{ attach_compute_instance_name }}"
-    namespace: "{{ attach_compute_instance_namespace }}"
+    namespace: "{{ public_ip.metadata.namespace }}"
     state: present
     definition:
       metadata:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
@@ -13,10 +13,14 @@
       - public_ip.metadata.annotations is defined
       - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
       - "'osac.openshift.io/publicip-target-namespace' in public_ip.metadata.annotations"
+      - public_ip.spec is defined
+      - public_ip.spec.computeInstance is defined
+      - public_ip.spec.computeInstance | length > 0
     fail_msg: >-
       PublicIP is missing required fields/annotations:
-      id must be set, and annotations osac.openshift.io/publicippool-name
-      and osac.openshift.io/publicip-target-namespace must both be present.
+      id and spec.computeInstance must be set, and annotations
+      osac.openshift.io/publicippool-name and
+      osac.openshift.io/publicip-target-namespace must both be present.
 
 - name: Extract PublicIP attach configuration
   ansible.builtin.set_fact:
@@ -33,14 +37,12 @@
     api_version: osac.openshift.io/v1alpha1
     kind: ComputeInstance
     name: "{{ public_ip.spec.computeInstance }}"
-    namespace: "{{ public_ip.metadata.namespace }}"
   register: attach_ci_lookup
 
 - name: Fail if ComputeInstance not found
   ansible.builtin.fail:
     msg: >-
-      ComputeInstance '{{ public_ip.spec.computeInstance }}' not found in
-      namespace '{{ public_ip.metadata.namespace }}'.
+      ComputeInstance '{{ public_ip.spec.computeInstance }}' not found.
   when: attach_ci_lookup.resources | length == 0
 
 - name: Extract ComputeInstance name and namespace from fetched CR
@@ -81,67 +83,108 @@
       - "VM namespace: {{ attach_vm_namespace }}"
       - "ComputeInstance: {{ attach_compute_instance_name }} ({{ attach_compute_instance_namespace }})"
 
-# Remove the parking Service from metallb-system.
-- name: Delete parking Service from metallb-system
-  kubernetes.core.k8s:
-    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
-    state: absent
-    api_version: v1
-    kind: Service
-    name: "osac-publicip-{{ public_ip_id }}"
-    namespace: metallb-system
-    wait: true
-    wait_timeout: 60
-  register: reservation_delete_result
-  retries: 3
-  delay: 5
-  until: >-
-    reservation_delete_result is successful
-    or ('NotFound' in (reservation_delete_result.msg | default('')))
-  failed_when:
-    - reservation_delete_result.failed | default(false)
-    - "'NotFound' not in (reservation_delete_result.msg | default(''))"
+# Delete the parking Service and create the VM-namespace LB Service atomically.
+# The rescue restores the parking Service if LB Service creation fails so the IP
+# is never left unparked without a reservation in metallb-system.
+- name: Attach PublicIP - delete parking Service and create LB Service
+  block:
+    - name: Delete parking Service from metallb-system
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: absent
+        api_version: v1
+        kind: Service
+        name: "osac-publicip-{{ public_ip_id }}"
+        namespace: metallb-system
+        wait: true
+        wait_timeout: 60
+      register: reservation_delete_result
+      retries: 3
+      delay: 5
+      until: >-
+        reservation_delete_result is successful
+        or ('NotFound' in (reservation_delete_result.msg | default('')))
+      failed_when:
+        - reservation_delete_result.failed | default(false)
+        - "'NotFound' not in (reservation_delete_result.msg | default(''))"
 
-- name: Display parking Service deletion result
-  ansible.builtin.debug:
-    msg:
-      - "Parking Service 'osac-publicip-{{ public_ip_id }}' deleted"
-      - "Changed: {{ reservation_delete_result.changed | default(false) }}"
+    - name: Display parking Service deletion result
+      ansible.builtin.debug:
+        msg:
+          - "Parking Service 'osac-publicip-{{ public_ip_id }}' deleted"
+          - "Changed: {{ reservation_delete_result.changed | default(false) }}"
 
-# Create a LoadBalancer Service in the VM namespace.
-- name: Create LoadBalancer Service in VM namespace
-  kubernetes.core.k8s:
-    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
-    state: present
-    apply: true
-    definition:
-      apiVersion: v1
-      kind: Service
-      metadata:
-        name: "{{ public_ip_id }}-lb"
-        namespace: "{{ attach_vm_namespace }}"
-        labels:
-          osac.openshift.io/publicip: "{{ public_ip_id }}"
-          osac.io/managed-by: osac-fulfillment
-        annotations:
-          metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
-          metallb.universe.tf/loadBalancerIPs: "{{ attach_ip_address }}"
-      spec:
-        type: LoadBalancer
-        selector:
-          vm.kubevirt.io/name: "{{ attach_compute_instance_name }}"
-        ports:
-          - name: ssh
-            port: 22
-            targetPort: 22
-            protocol: TCP
-  register: lb_service_result
+    # Create a LoadBalancer Service in the VM namespace.
+    - name: Create LoadBalancer Service in VM namespace
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: present
+        apply: true
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: "{{ public_ip_id }}-lb"
+            namespace: "{{ attach_vm_namespace }}"
+            labels:
+              osac.openshift.io/publicip: "{{ public_ip_id }}"
+              osac.io/managed-by: osac-fulfillment
+            annotations:
+              metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
+              metallb.universe.tf/loadBalancerIPs: "{{ attach_ip_address }}"
+          spec:
+            type: LoadBalancer
+            selector:
+              vm.kubevirt.io/name: "{{ attach_compute_instance_name }}"
+            # Initial floating IP support exposes SSH only.
+            # Additional ports can be added as needed for other access patterns.
+            ports:
+              - name: ssh
+                port: 22
+                targetPort: 22
+                protocol: TCP
+      register: lb_service_result
 
-- name: Display LoadBalancer Service creation result
-  ansible.builtin.debug:
-    msg:
-      - "LoadBalancer Service '{{ public_ip_id }}-lb' created in '{{ attach_vm_namespace }}'"
-      - "Changed: {{ lb_service_result.changed | default(false) }}"
+    - name: Display LoadBalancer Service creation result
+      ansible.builtin.debug:
+        msg:
+          - "LoadBalancer Service '{{ public_ip_id }}-lb' created in '{{ attach_vm_namespace }}'"
+          - "Changed: {{ lb_service_result.changed | default(false) }}"
+
+  rescue:
+    - name: Restore parking Service in metallb-system after failed LB Service creation
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: present
+        apply: true
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: "osac-publicip-{{ public_ip_id }}"
+            namespace: metallb-system
+            labels:
+              osac.openshift.io/publicip: "{{ public_ip_id }}"
+              osac.io/managed-by: osac-fulfillment
+            annotations:
+              metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
+              metallb.universe.tf/loadBalancerIPs: "{{ attach_ip_address }}"
+          spec:
+            type: LoadBalancer
+            selector: {}
+            ports:
+              - name: placeholder
+                protocol: TCP
+                port: 65535
+                targetPort: 65535
+      when: reservation_delete_result.changed | default(false)
+
+    - name: Fail after attempted rollback of attach operation
+      ansible.builtin.fail:
+        msg: >-
+          Attach of PublicIP '{{ public_ip_name }}' failed; the parking Service
+          'osac-publicip-{{ public_ip_id }}' in metallb-system has been restored
+          if it had been deleted. Check the preceding error for details.
 
 # Annotate the ComputeInstance CR with the assigned floating IP.
 - name: Annotate ComputeInstance with floating-ip-address

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
@@ -1,0 +1,160 @@
+---
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Validate PublicIP annotations
+  ansible.builtin.assert:
+    that:
+      - public_ip.metadata is defined
+      - public_ip.metadata.annotations is defined
+      - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
+      - "'osac.openshift.io/publicip-target-namespace' in public_ip.metadata.annotations"
+    fail_msg: >-
+      PublicIP is missing required annotations:
+      osac.openshift.io/publicippool-name and
+      osac.openshift.io/publicip-target-namespace must both be set.
+
+- name: Extract PublicIP attach configuration
+  ansible.builtin.set_fact:
+    attach_vm_namespace: >-
+      {{ public_ip.metadata.annotations['osac.openshift.io/publicip-target-namespace'] }}
+    attach_pool_name: >-
+      {{ public_ip.metadata.annotations['osac.openshift.io/publicippool-name'] }}
+
+- name: Fetch ComputeInstance CR by ID
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    name: "{{ public_ip.spec.computeInstance }}"
+    namespace: "{{ public_ip.metadata.namespace }}"
+  register: attach_ci_lookup
+
+- name: Fail if ComputeInstance not found
+  ansible.builtin.fail:
+    msg: >-
+      ComputeInstance '{{ public_ip.spec.computeInstance }}' not found in
+      namespace '{{ public_ip.metadata.namespace }}'.
+  when: attach_ci_lookup.resources | length == 0
+
+- name: Extract ComputeInstance name and namespace from fetched CR
+  ansible.builtin.set_fact:
+    attach_compute_instance_name: "{{ attach_ci_lookup.resources[0].metadata.name }}"
+    attach_compute_instance_namespace: "{{ attach_ci_lookup.resources[0].metadata.namespace }}"
+
+# Read the reserved IP directly from the parking Service status.
+- name: Read reserved IP from parking Service
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: v1
+    kind: Service
+    name: "osac-publicip-{{ public_ip_name }}"
+    namespace: metallb-system
+  register: parking_service_info
+
+- name: Fail if parking Service not found or IP not yet assigned
+  ansible.builtin.fail:
+    msg: >-
+      Parking Service 'osac-publicip-{{ public_ip_name }}' not found in metallb-system
+      or MetalLB has not yet assigned an IP. Run create_public_ip first.
+  when: >-
+    parking_service_info.resources | length == 0 or
+    parking_service_info.resources[0].status.loadBalancer.ingress | default([]) | length == 0
+
+- name: Extract allocated IP from parking Service status
+  ansible.builtin.set_fact:
+    attach_ip_address: "{{ parking_service_info.resources[0].status.loadBalancer.ingress[0].ip }}"
+
+- name: Display PublicIP attach information
+  ansible.builtin.debug:
+    msg:
+      - "Attaching PublicIP '{{ public_ip_name }}'"
+      - "IP address: {{ attach_ip_address }} (read from parking Service)"
+      - "Pool: {{ attach_pool_name }}"
+      - "VM namespace: {{ attach_vm_namespace }}"
+      - "ComputeInstance: {{ attach_compute_instance_name }} ({{ attach_compute_instance_namespace }})"
+
+# Remove the parking Service from metallb-system.
+- name: Delete parking Service from metallb-system
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: absent
+    api_version: v1
+    kind: Service
+    name: "osac-publicip-{{ public_ip_name }}"
+    namespace: metallb-system
+    wait: true
+    wait_timeout: 60
+  register: reservation_delete_result
+  retries: 3
+  delay: 5
+  until: >-
+    reservation_delete_result is successful
+    or ('NotFound' in (reservation_delete_result.msg | default('')))
+  failed_when:
+    - reservation_delete_result.failed | default(false)
+    - "'NotFound' not in (reservation_delete_result.msg | default(''))"
+
+- name: Display parking Service deletion result
+  ansible.builtin.debug:
+    msg:
+      - "Parking Service 'osac-publicip-{{ public_ip_name }}' deleted"
+      - "Changed: {{ reservation_delete_result.changed | default(false) }}"
+
+# Create a LoadBalancer Service in the VM namespace.
+- name: Create LoadBalancer Service in VM namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: present
+    apply: true
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "{{ public_ip_name }}-lb"
+        namespace: "{{ attach_vm_namespace }}"
+        labels:
+          osac.openshift.io/publicip: "{{ public_ip_name }}"
+          osac.io/managed-by: osac-fulfillment
+        annotations:
+          metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
+          metallb.universe.tf/loadBalancerIPs: "{{ attach_ip_address }}"
+      spec:
+        type: LoadBalancer
+        selector:
+          vm.kubevirt.io/name: "{{ attach_compute_instance_name }}"
+        ports:
+          - name: ssh
+            port: 22
+            targetPort: 22
+            protocol: TCP
+  register: lb_service_result
+
+- name: Display LoadBalancer Service creation result
+  ansible.builtin.debug:
+    msg:
+      - "LoadBalancer Service '{{ public_ip_name }}-lb' created in '{{ attach_vm_namespace }}'"
+      - "Changed: {{ lb_service_result.changed | default(false) }}"
+
+# Annotate the ComputeInstance CR with the assigned floating IP.
+- name: Annotate ComputeInstance with floating-ip-address
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    name: "{{ attach_compute_instance_name }}"
+    namespace: "{{ attach_compute_instance_namespace }}"
+    state: present
+    definition:
+      metadata:
+        annotations:
+          osac.openshift.io/floating-ip-address: "{{ attach_ip_address }}"
+  register: ci_annotate_result
+
+- name: Display ComputeInstance annotation result
+  ansible.builtin.debug:
+    msg:
+      - "ComputeInstance '{{ attach_compute_instance_name }}' annotated with floating-ip-address '{{ attach_ip_address }}'"
+      - "Changed: {{ ci_annotate_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
@@ -4,20 +4,24 @@
     name: osac.service.common
     tasks_from: get_remote_cluster_kubeconfig
 
-- name: Validate PublicIP annotations
+- name: Validate PublicIP fields and annotations
   ansible.builtin.assert:
     that:
+      - public_ip.id is defined
+      - public_ip.id | length > 0
       - public_ip.metadata is defined
       - public_ip.metadata.annotations is defined
       - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
       - "'osac.openshift.io/publicip-target-namespace' in public_ip.metadata.annotations"
     fail_msg: >-
-      PublicIP is missing required annotations:
-      osac.openshift.io/publicippool-name and
-      osac.openshift.io/publicip-target-namespace must both be set.
+      PublicIP is missing required fields/annotations:
+      id must be set, and annotations osac.openshift.io/publicippool-name
+      and osac.openshift.io/publicip-target-namespace must both be present.
 
 - name: Extract PublicIP attach configuration
   ansible.builtin.set_fact:
+    public_ip_id: "{{ public_ip.id }}"
+    public_ip_name: "{{ public_ip.metadata.name | default(public_ip.id) }}"
     attach_vm_namespace: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicip-target-namespace'] }}
     attach_pool_name: >-
@@ -50,15 +54,16 @@
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: v1
     kind: Service
-    name: "osac-publicip-{{ public_ip_name }}"
+    name: "osac-publicip-{{ public_ip_id }}"
     namespace: metallb-system
   register: parking_service_info
 
 - name: Fail if parking Service not found or IP not yet assigned
   ansible.builtin.fail:
     msg: >-
-      Parking Service 'osac-publicip-{{ public_ip_name }}' not found in metallb-system
-      or MetalLB has not yet assigned an IP. Run create_public_ip first.
+      Parking Service 'osac-publicip-{{ public_ip_id }}' (PublicIP '{{ public_ip_name }}')
+      not found in metallb-system or MetalLB has not yet assigned an IP.
+      Run create_public_ip first.
   when: >-
     parking_service_info.resources | length == 0 or
     parking_service_info.resources[0].status.loadBalancer.ingress | default([]) | length == 0
@@ -70,7 +75,7 @@
 - name: Display PublicIP attach information
   ansible.builtin.debug:
     msg:
-      - "Attaching PublicIP '{{ public_ip_name }}'"
+      - "Attaching PublicIP id='{{ public_ip_id }}' name='{{ public_ip_name }}'"
       - "IP address: {{ attach_ip_address }} (read from parking Service)"
       - "Pool: {{ attach_pool_name }}"
       - "VM namespace: {{ attach_vm_namespace }}"
@@ -83,7 +88,7 @@
     state: absent
     api_version: v1
     kind: Service
-    name: "osac-publicip-{{ public_ip_name }}"
+    name: "osac-publicip-{{ public_ip_id }}"
     namespace: metallb-system
     wait: true
     wait_timeout: 60
@@ -100,7 +105,7 @@
 - name: Display parking Service deletion result
   ansible.builtin.debug:
     msg:
-      - "Parking Service 'osac-publicip-{{ public_ip_name }}' deleted"
+      - "Parking Service 'osac-publicip-{{ public_ip_id }}' deleted"
       - "Changed: {{ reservation_delete_result.changed | default(false) }}"
 
 # Create a LoadBalancer Service in the VM namespace.
@@ -113,10 +118,10 @@
       apiVersion: v1
       kind: Service
       metadata:
-        name: "{{ public_ip_name }}-lb"
+        name: "{{ public_ip_id }}-lb"
         namespace: "{{ attach_vm_namespace }}"
         labels:
-          osac.openshift.io/publicip: "{{ public_ip_name }}"
+          osac.openshift.io/publicip: "{{ public_ip_id }}"
           osac.io/managed-by: osac-fulfillment
         annotations:
           metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
@@ -135,7 +140,7 @@
 - name: Display LoadBalancer Service creation result
   ansible.builtin.debug:
     msg:
-      - "LoadBalancer Service '{{ public_ip_name }}-lb' created in '{{ attach_vm_namespace }}'"
+      - "LoadBalancer Service '{{ public_ip_id }}-lb' created in '{{ attach_vm_namespace }}'"
       - "Changed: {{ lb_service_result.changed | default(false) }}"
 
 # Annotate the ComputeInstance CR with the assigned floating IP.

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
@@ -35,7 +35,7 @@
       apiVersion: v1
       kind: Service
       metadata:
-        name: "osac-publicip-{{ ip_name }}"
+        name: "osac-pip-{{ ip_name }}"
         namespace: metallb-system
         annotations:
           metallb.universe.tf/address-pool: "{{ ip_pool_name }}"
@@ -58,7 +58,7 @@
 - name: Display LoadBalancer Service creation result
   ansible.builtin.debug:
     msg:
-      - "LoadBalancer Service 'osac-publicip-{{ ip_name }}' created"
+      - "LoadBalancer Service 'osac-pip-{{ ip_name }}' created"
       - "Changed: {{ lb_service_result.changed | default(false) }}"
 
 - name: Wait for IP assignment
@@ -66,7 +66,7 @@
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: v1
     kind: Service
-    name: "osac-publicip-{{ ip_name }}"
+    name: "osac-pip-{{ ip_name }}"
     namespace: metallb-system
   register: lb_service_info
   retries: 60

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
@@ -7,25 +7,25 @@
 - name: Validate PublicIP annotations
   ansible.builtin.assert:
     that:
-      - public_ip.id is defined
-      - public_ip.id | length > 0
       - public_ip.metadata is defined
+      - public_ip.metadata.name is defined
+      - public_ip.metadata.name | length > 0
       - public_ip.metadata.annotations is defined
       - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
     fail_msg: >-
       PublicIP is missing required fields:
-      id must be set and metadata.annotations['osac.openshift.io/publicippool-name'] is required
+      metadata.name must be set and metadata.annotations['osac.openshift.io/publicippool-name'] is required
 
 - name: Extract PublicIP configuration
   ansible.builtin.set_fact:
-    ip_id: "{{ public_ip.id }}"
+    ip_name: "{{ public_ip.metadata.name }}"
     ip_pool_name: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicippool-name'] }}
 
 - name: Display PublicIP information
   ansible.builtin.debug:
     msg:
-      - "Creating LoadBalancer Service for PublicIP id='{{ ip_id }}'"
+      - "Creating LoadBalancer Service for PublicIP '{{ ip_name }}'"
       - "Pool name (IPAddressPool): {{ ip_pool_name }}"
 
 # Empty-selector LB Service reserves an IP from the MetalLB pool without
@@ -39,12 +39,12 @@
       apiVersion: v1
       kind: Service
       metadata:
-        name: "osac-publicip-{{ ip_id }}"
+        name: "osac-publicip-{{ ip_name }}"
         namespace: metallb-system
         annotations:
           metallb.universe.tf/address-pool: "{{ ip_pool_name }}"
         labels:
-          osac.openshift.io/publicip: "{{ ip_id }}"
+          osac.openshift.io/publicip: "{{ ip_name }}"
           osac.io/managed-by: osac-fulfillment
       spec:
         type: LoadBalancer
@@ -62,7 +62,7 @@
 - name: Display LoadBalancer Service creation result
   ansible.builtin.debug:
     msg:
-      - "LoadBalancer Service 'osac-publicip-{{ ip_id }}' created"
+      - "LoadBalancer Service 'osac-publicip-{{ ip_name }}' created"
       - "Changed: {{ lb_service_result.changed | default(false) }}"
 
 - name: Wait for IP assignment
@@ -70,7 +70,7 @@
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: v1
     kind: Service
-    name: "osac-publicip-{{ ip_id }}"
+    name: "osac-publicip-{{ ip_name }}"
     namespace: metallb-system
   register: lb_service_info
   retries: 60
@@ -85,4 +85,4 @@
 
 - name: Display assigned IP
   ansible.builtin.debug:
-    msg: "PublicIP id='{{ ip_id }}' assigned address: {{ assigned_ip }}"
+    msg: "PublicIP '{{ ip_name }}' assigned address: {{ assigned_ip }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
@@ -8,13 +8,9 @@
   ansible.builtin.assert:
     that:
       - public_ip.metadata is defined
-      - public_ip.metadata.name is defined
-      - public_ip.metadata.name | length > 0
       - public_ip.metadata.annotations is defined
       - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
-    fail_msg: >-
-      PublicIP is missing required fields:
-      metadata.name must be set and metadata.annotations['osac.openshift.io/publicippool-name'] is required
+    fail_msg: "PublicIP metadata.annotations['osac.openshift.io/publicippool-name'] is required"
 
 - name: Extract PublicIP configuration
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
@@ -7,21 +7,25 @@
 - name: Validate PublicIP annotations
   ansible.builtin.assert:
     that:
+      - public_ip.id is defined
+      - public_ip.id | length > 0
       - public_ip.metadata is defined
       - public_ip.metadata.annotations is defined
       - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
-    fail_msg: "PublicIP metadata.annotations['osac.openshift.io/publicippool-name'] is required"
+    fail_msg: >-
+      PublicIP is missing required fields:
+      id must be set and metadata.annotations['osac.openshift.io/publicippool-name'] is required
 
 - name: Extract PublicIP configuration
   ansible.builtin.set_fact:
-    ip_name: "{{ public_ip.metadata.name }}"
+    ip_id: "{{ public_ip.id }}"
     ip_pool_name: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicippool-name'] }}
 
 - name: Display PublicIP information
   ansible.builtin.debug:
     msg:
-      - "Creating LoadBalancer Service for PublicIP '{{ ip_name }}'"
+      - "Creating LoadBalancer Service for PublicIP id='{{ ip_id }}'"
       - "Pool name (IPAddressPool): {{ ip_pool_name }}"
 
 # Empty-selector LB Service reserves an IP from the MetalLB pool without
@@ -35,12 +39,12 @@
       apiVersion: v1
       kind: Service
       metadata:
-        name: "osac-publicip-{{ ip_name }}"
+        name: "osac-publicip-{{ ip_id }}"
         namespace: metallb-system
         annotations:
           metallb.universe.tf/address-pool: "{{ ip_pool_name }}"
         labels:
-          osac.openshift.io/publicip: "{{ ip_name }}"
+          osac.openshift.io/publicip: "{{ ip_id }}"
           osac.io/managed-by: osac-fulfillment
       spec:
         type: LoadBalancer
@@ -58,7 +62,7 @@
 - name: Display LoadBalancer Service creation result
   ansible.builtin.debug:
     msg:
-      - "LoadBalancer Service 'osac-publicip-{{ ip_name }}' created"
+      - "LoadBalancer Service 'osac-publicip-{{ ip_id }}' created"
       - "Changed: {{ lb_service_result.changed | default(false) }}"
 
 - name: Wait for IP assignment
@@ -66,7 +70,7 @@
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: v1
     kind: Service
-    name: "osac-publicip-{{ ip_name }}"
+    name: "osac-publicip-{{ ip_id }}"
     namespace: metallb-system
   register: lb_service_info
   retries: 60
@@ -81,4 +85,4 @@
 
 - name: Display assigned IP
   ansible.builtin.debug:
-    msg: "PublicIP '{{ ip_name }}' assigned address: {{ assigned_ip }}"
+    msg: "PublicIP id='{{ ip_id }}' assigned address: {{ assigned_ip }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip.yaml
@@ -6,12 +6,12 @@
 
 - name: Extract PublicIP configuration
   ansible.builtin.set_fact:
-    ip_name: "{{ public_ip.metadata.name }}"
+    ip_id: "{{ public_ip.id }}"
 
 - name: Display deletion information
   ansible.builtin.debug:
     msg:
-      - "Deleting LoadBalancer Service for PublicIP '{{ ip_name }}'"
+      - "Deleting LoadBalancer Service for PublicIP id='{{ ip_id }}'"
 
 - name: Delete LoadBalancer Service
   kubernetes.core.k8s:
@@ -19,7 +19,7 @@
     state: absent
     api_version: v1
     kind: Service
-    name: "osac-publicip-{{ ip_name }}"
+    name: "osac-publicip-{{ ip_id }}"
     namespace: metallb-system
     wait: true
     wait_timeout: 300
@@ -36,5 +36,5 @@
 - name: Display LoadBalancer Service deletion result
   ansible.builtin.debug:
     msg:
-      - "LoadBalancer Service 'osac-publicip-{{ ip_name }}' deletion completed"
+      - "LoadBalancer Service 'osac-publicip-{{ ip_id }}' deletion completed"
       - "Changed: {{ lb_service_delete_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip.yaml
@@ -6,12 +6,12 @@
 
 - name: Extract PublicIP configuration
   ansible.builtin.set_fact:
-    ip_id: "{{ public_ip.id }}"
+    ip_name: "{{ public_ip.metadata.name }}"
 
 - name: Display deletion information
   ansible.builtin.debug:
     msg:
-      - "Deleting LoadBalancer Service for PublicIP id='{{ ip_id }}'"
+      - "Deleting LoadBalancer Service for PublicIP '{{ ip_name }}'"
 
 - name: Delete LoadBalancer Service
   kubernetes.core.k8s:
@@ -19,7 +19,7 @@
     state: absent
     api_version: v1
     kind: Service
-    name: "osac-publicip-{{ ip_id }}"
+    name: "osac-publicip-{{ ip_name }}"
     namespace: metallb-system
     wait: true
     wait_timeout: 300
@@ -36,5 +36,5 @@
 - name: Display LoadBalancer Service deletion result
   ansible.builtin.debug:
     msg:
-      - "LoadBalancer Service 'osac-publicip-{{ ip_id }}' deletion completed"
+      - "LoadBalancer Service 'osac-publicip-{{ ip_name }}' deletion completed"
       - "Changed: {{ lb_service_delete_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_public_ip.yaml
@@ -19,7 +19,7 @@
     state: absent
     api_version: v1
     kind: Service
-    name: "osac-publicip-{{ ip_name }}"
+    name: "osac-pip-{{ ip_name }}"
     namespace: metallb-system
     wait: true
     wait_timeout: 300
@@ -36,5 +36,5 @@
 - name: Display LoadBalancer Service deletion result
   ansible.builtin.debug:
     msg:
-      - "LoadBalancer Service 'osac-publicip-{{ ip_name }}' deletion completed"
+      - "LoadBalancer Service 'osac-pip-{{ ip_name }}' deletion completed"
       - "Changed: {{ lb_service_delete_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -59,14 +59,14 @@
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: v1
     kind: Service
-    name: "{{ public_ip_name }}-lb"
+    name: "osac-pip-{{ public_ip_name }}-ingress"
     namespace: "{{ detach_vm_namespace }}"
   register: lb_service_info
 
 - name: Fail if VM namespace LB Service not found or IP not assigned
   ansible.builtin.fail:
     msg: >-
-      LoadBalancer Service '{{ public_ip_name }}-lb' not found in '{{ detach_vm_namespace }}'
+      LoadBalancer Service 'osac-pip-{{ public_ip_name }}-ingress' not found in '{{ detach_vm_namespace }}'
       or MetalLB has not assigned an IP. Run attach_public_ip first.
   when: >-
     lb_service_info.resources | length == 0 or
@@ -96,7 +96,7 @@
         state: absent
         api_version: v1
         kind: Service
-        name: "{{ public_ip_name }}-lb"
+        name: "osac-pip-{{ public_ip_name }}-ingress"
         namespace: "{{ detach_vm_namespace }}"
         wait: true
         wait_timeout: 60
@@ -111,7 +111,7 @@
     - name: Display LB Service deletion result
       ansible.builtin.debug:
         msg:
-          - "LoadBalancer Service '{{ public_ip_name }}-lb' deleted from '{{ detach_vm_namespace }}'"
+          - "LoadBalancer Service 'osac-pip-{{ public_ip_name }}-ingress' deleted from '{{ detach_vm_namespace }}'"
           - "Changed: {{ lb_service_delete_result.changed | default(false) }}"
 
     - name: Re-create placeholder Service in metallb-system
@@ -123,7 +123,7 @@
           apiVersion: v1
           kind: Service
           metadata:
-            name: "osac-publicip-{{ public_ip_name }}"
+            name: "osac-pip-{{ public_ip_name }}"
             namespace: metallb-system
             labels:
               osac.openshift.io/publicip: "{{ public_ip_name }}"
@@ -147,7 +147,7 @@
     - name: Display placeholder Service creation result
       ansible.builtin.debug:
         msg:
-          - "Placeholder Service 'osac-publicip-{{ public_ip_name }}' re-created in metallb-system"
+          - "Placeholder Service 'osac-pip-{{ public_ip_name }}' re-created in metallb-system"
           - "IP preserved: {{ detach_ip_address }}"
           - "Changed: {{ placeholder_service_result.changed | default(false) }}"
 
@@ -161,7 +161,7 @@
           apiVersion: v1
           kind: Service
           metadata:
-            name: "{{ public_ip_name }}-lb"
+            name: "osac-pip-{{ public_ip_name }}-ingress"
             namespace: "{{ detach_vm_namespace }}"
             labels:
               osac.openshift.io/publicip: "{{ public_ip_name }}"
@@ -188,7 +188,7 @@
       ansible.builtin.fail:
         msg: >-
           Detach of PublicIP '{{ public_ip_name }}' failed; the LoadBalancer Service
-          '{{ public_ip_name }}-lb' in '{{ detach_vm_namespace }}' has been restored
+          'osac-pip-{{ public_ip_name }}-ingress' in '{{ detach_vm_namespace }}' has been restored
           if it had been deleted. Check the preceding error for details.
 
 # Remove the floating-ip-address annotation from the ComputeInstance CR.

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -1,0 +1,182 @@
+---
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Validate PublicIP annotations
+  ansible.builtin.assert:
+    that:
+      - public_ip.metadata is defined
+      - public_ip.metadata.annotations is defined
+      - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
+      - "'osac.openshift.io/publicip-target-namespace' in public_ip.metadata.annotations"
+    fail_msg: >-
+      PublicIP is missing required annotations:
+      osac.openshift.io/publicippool-name and
+      osac.openshift.io/publicip-target-namespace must both be set.
+
+- name: Extract PublicIP detach configuration
+  ansible.builtin.set_fact:
+    detach_vm_namespace: >-
+      {{ public_ip.metadata.annotations['osac.openshift.io/publicip-target-namespace'] }}
+    detach_pool_name: >-
+      {{ public_ip.metadata.annotations['osac.openshift.io/publicippool-name'] }}
+
+- name: Fetch ComputeInstance CR by ID
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    name: "{{ public_ip.spec.computeInstance }}"
+    namespace: "{{ public_ip.metadata.namespace }}"
+  register: detach_ci_lookup
+
+- name: Fail if ComputeInstance not found
+  ansible.builtin.fail:
+    msg: >-
+      ComputeInstance '{{ public_ip.spec.computeInstance }}' not found in
+      namespace '{{ public_ip.metadata.namespace }}'.
+  when: detach_ci_lookup.resources | length == 0
+
+- name: Extract ComputeInstance name and namespace from fetched CR
+  ansible.builtin.set_fact:
+    detach_compute_instance_name: "{{ detach_ci_lookup.resources[0].metadata.name }}"
+    detach_compute_instance_namespace: "{{ detach_ci_lookup.resources[0].metadata.namespace }}"
+
+# Read the IP from the VM namespace LB Service before deleting it.
+- name: Read IP from VM namespace LoadBalancer Service
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: v1
+    kind: Service
+    name: "{{ public_ip_name }}-lb"
+    namespace: "{{ detach_vm_namespace }}"
+  register: lb_service_info
+
+- name: Fail if VM namespace LB Service not found or IP not assigned
+  ansible.builtin.fail:
+    msg: >-
+      LoadBalancer Service '{{ public_ip_name }}-lb' not found in '{{ detach_vm_namespace }}'
+      or MetalLB has not assigned an IP. Run attach_public_ip first.
+  when: >-
+    lb_service_info.resources | length == 0 or
+    lb_service_info.resources[0].status.loadBalancer.ingress | default([]) | length == 0
+
+- name: Extract IP address from VM namespace LB Service
+  ansible.builtin.set_fact:
+    detach_ip_address: "{{ lb_service_info.resources[0].status.loadBalancer.ingress[0].ip }}"
+
+- name: Display PublicIP detach information
+  ansible.builtin.debug:
+    msg:
+      - "Detaching PublicIP '{{ public_ip_name }}'"
+      - "IP address: {{ detach_ip_address }} (read from VM namespace LB Service)"
+      - "Pool: {{ detach_pool_name }}"
+      - "VM namespace: {{ detach_vm_namespace }}"
+      - "ComputeInstance: {{ detach_compute_instance_name }} ({{ detach_compute_instance_namespace }})"
+
+# Delete the LoadBalancer Service from the VM namespace.
+- name: Delete LoadBalancer Service from VM namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: absent
+    api_version: v1
+    kind: Service
+    name: "{{ public_ip_name }}-lb"
+    namespace: "{{ detach_vm_namespace }}"
+    wait: true
+    wait_timeout: 60
+  register: lb_service_delete_result
+  retries: 3
+  delay: 5
+  until: >-
+    lb_service_delete_result is successful
+    or ('NotFound' in (lb_service_delete_result.msg | default('')))
+  failed_when:
+    - lb_service_delete_result.failed | default(false)
+    - "'NotFound' not in (lb_service_delete_result.msg | default(''))"
+
+- name: Display LB Service deletion result
+  ansible.builtin.debug:
+    msg:
+      - "LoadBalancer Service '{{ public_ip_name }}-lb' deleted from '{{ detach_vm_namespace }}'"
+      - "Changed: {{ lb_service_delete_result.changed | default(false) }}"
+
+# Remove floating-ip-address annotation from the ComputeInstance CR.
+- name: Fetch ComputeInstance to inspect annotations
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    name: "{{ detach_compute_instance_name }}"
+    namespace: "{{ detach_compute_instance_namespace }}"
+  register: ci_info
+
+- name: Remove floating-ip-address annotation from ComputeInstance CR
+  kubernetes.core.k8s_json_patch:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    name: "{{ detach_compute_instance_name }}"
+    namespace: "{{ detach_compute_instance_namespace }}"
+    patch:
+      - op: remove
+        path: /metadata/annotations/osac.openshift.io~1floating-ip-address
+  register: ci_patch_result
+  when: >-
+    ci_info.resources | length > 0 and
+    (ci_info.resources[0].metadata.annotations | default({}))
+    ['osac.openshift.io/floating-ip-address'] is defined
+
+- name: Display ComputeInstance annotation removal result
+  ansible.builtin.debug:
+    msg:
+      - "ComputeInstance '{{ detach_compute_instance_name }}': floating-ip-address annotation removed"
+      - "Changed: {{ ci_patch_result.changed | default(false) }}"
+  when: ci_patch_result is not skipped
+
+- name: Display ComputeInstance annotation already absent
+  ansible.builtin.debug:
+    msg: >-
+      ComputeInstance '{{ detach_compute_instance_name }}':
+      floating-ip-address annotation not present, nothing to remove
+  when: ci_patch_result is skipped
+
+# Re-create the placeholder reservation Service in metallb-system.
+- name: Re-create placeholder Service in metallb-system
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: present
+    apply: true
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "osac-publicip-{{ public_ip_name }}"
+        namespace: metallb-system
+        labels:
+          osac.openshift.io/publicip: "{{ public_ip_name }}"
+          osac.io/managed-by: osac-fulfillment
+        annotations:
+          metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
+          metallb.universe.tf/loadBalancerIPs: "{{ detach_ip_address }}"
+      spec:
+        type: LoadBalancer
+        selector: {}
+        ports:
+          - name: placeholder
+            protocol: TCP
+            port: 65535
+            targetPort: 65535
+  register: placeholder_service_result
+  retries: 60
+  delay: 10
+  until: placeholder_service_result is successful
+
+- name: Display placeholder Service creation result
+  ansible.builtin.debug:
+    msg:
+      - "Placeholder Service 'osac-publicip-{{ public_ip_name }}' re-created in metallb-system"
+      - "IP preserved: {{ detach_ip_address }}"
+      - "Changed: {{ placeholder_service_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -13,10 +13,14 @@
       - public_ip.metadata.annotations is defined
       - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
       - "'osac.openshift.io/publicip-target-namespace' in public_ip.metadata.annotations"
+      - public_ip.spec is defined
+      - public_ip.spec.computeInstance is defined
+      - public_ip.spec.computeInstance | length > 0
     fail_msg: >-
       PublicIP is missing required fields/annotations:
-      id must be set, and annotations osac.openshift.io/publicippool-name
-      and osac.openshift.io/publicip-target-namespace must both be present.
+      id and spec.computeInstance must be set, and annotations
+      osac.openshift.io/publicippool-name and
+      osac.openshift.io/publicip-target-namespace must both be present.
 
 - name: Extract PublicIP detach configuration
   ansible.builtin.set_fact:
@@ -33,14 +37,12 @@
     api_version: osac.openshift.io/v1alpha1
     kind: ComputeInstance
     name: "{{ public_ip.spec.computeInstance }}"
-    namespace: "{{ public_ip.metadata.namespace }}"
   register: detach_ci_lookup
 
 - name: Fail if ComputeInstance not found
   ansible.builtin.fail:
     msg: >-
-      ComputeInstance '{{ public_ip.spec.computeInstance }}' not found in
-      namespace '{{ public_ip.metadata.namespace }}'.
+      ComputeInstance '{{ public_ip.spec.computeInstance }}' not found.
   when: detach_ci_lookup.resources | length == 0
 
 - name: Extract ComputeInstance name and namespace from fetched CR
@@ -81,107 +83,147 @@
       - "VM namespace: {{ detach_vm_namespace }}"
       - "ComputeInstance: {{ detach_compute_instance_name }} ({{ detach_compute_instance_namespace }})"
 
-# Delete the LoadBalancer Service from the VM namespace.
-- name: Delete LoadBalancer Service from VM namespace
-  kubernetes.core.k8s:
-    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
-    state: absent
-    api_version: v1
-    kind: Service
-    name: "{{ public_ip_id }}-lb"
-    namespace: "{{ detach_vm_namespace }}"
-    wait: true
-    wait_timeout: 60
-  register: lb_service_delete_result
-  retries: 3
-  delay: 5
-  until: >-
-    lb_service_delete_result is successful
-    or ('NotFound' in (lb_service_delete_result.msg | default('')))
-  failed_when:
-    - lb_service_delete_result.failed | default(false)
-    - "'NotFound' not in (lb_service_delete_result.msg | default(''))"
+# Delete the LB Service, clear the annotation, and restore the placeholder atomically.
+# The rescue restores the LB Service if placeholder re-creation fails so the IP
+# is never left unparked without a reservation in metallb-system.
+- name: Detach PublicIP - remove LB Service, clear annotation, restore placeholder
+  block:
+    - name: Delete LoadBalancer Service from VM namespace
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: absent
+        api_version: v1
+        kind: Service
+        name: "{{ public_ip_id }}-lb"
+        namespace: "{{ detach_vm_namespace }}"
+        wait: true
+        wait_timeout: 60
+      register: lb_service_delete_result
+      retries: 3
+      delay: 5
+      until: >-
+        lb_service_delete_result is successful
+        or ('NotFound' in (lb_service_delete_result.msg | default('')))
+      failed_when:
+        - lb_service_delete_result.failed | default(false)
+        - "'NotFound' not in (lb_service_delete_result.msg | default(''))"
 
-- name: Display LB Service deletion result
-  ansible.builtin.debug:
-    msg:
-      - "LoadBalancer Service '{{ public_ip_id }}-lb' deleted from '{{ detach_vm_namespace }}'"
-      - "Changed: {{ lb_service_delete_result.changed | default(false) }}"
+    - name: Display LB Service deletion result
+      ansible.builtin.debug:
+        msg:
+          - "LoadBalancer Service '{{ public_ip_id }}-lb' deleted from '{{ detach_vm_namespace }}'"
+          - "Changed: {{ lb_service_delete_result.changed | default(false) }}"
 
-# Remove floating-ip-address annotation from the ComputeInstance CR.
-- name: Fetch ComputeInstance to inspect annotations
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
-    api_version: osac.openshift.io/v1alpha1
-    kind: ComputeInstance
-    name: "{{ detach_compute_instance_name }}"
-    namespace: "{{ detach_compute_instance_namespace }}"
-  register: ci_info
+    # Remove floating-ip-address annotation from the ComputeInstance CR.
+    - name: Fetch ComputeInstance to inspect annotations
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        api_version: osac.openshift.io/v1alpha1
+        kind: ComputeInstance
+        name: "{{ detach_compute_instance_name }}"
+        namespace: "{{ detach_compute_instance_namespace }}"
+      register: ci_info
 
-- name: Remove floating-ip-address annotation from ComputeInstance CR
-  kubernetes.core.k8s_json_patch:
-    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
-    api_version: osac.openshift.io/v1alpha1
-    kind: ComputeInstance
-    name: "{{ detach_compute_instance_name }}"
-    namespace: "{{ detach_compute_instance_namespace }}"
-    patch:
-      - op: remove
-        path: /metadata/annotations/osac.openshift.io~1floating-ip-address
-  register: ci_patch_result
-  when: >-
-    ci_info.resources | length > 0 and
-    (ci_info.resources[0].metadata.annotations | default({}))
-    ['osac.openshift.io/floating-ip-address'] is defined
+    - name: Remove floating-ip-address annotation from ComputeInstance CR
+      kubernetes.core.k8s_json_patch:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        api_version: osac.openshift.io/v1alpha1
+        kind: ComputeInstance
+        name: "{{ detach_compute_instance_name }}"
+        namespace: "{{ detach_compute_instance_namespace }}"
+        patch:
+          - op: remove
+            path: /metadata/annotations/osac.openshift.io~1floating-ip-address
+      register: ci_patch_result
+      when: >-
+        ci_info.resources | length > 0 and
+        (ci_info.resources[0].metadata.annotations | default({}))
+        ['osac.openshift.io/floating-ip-address'] is defined
 
-- name: Display ComputeInstance annotation removal result
-  ansible.builtin.debug:
-    msg:
-      - "ComputeInstance '{{ detach_compute_instance_name }}': floating-ip-address annotation removed"
-      - "Changed: {{ ci_patch_result.changed | default(false) }}"
-  when: ci_patch_result is not skipped
+    - name: Display ComputeInstance annotation removal result
+      ansible.builtin.debug:
+        msg:
+          - "ComputeInstance '{{ detach_compute_instance_name }}': floating-ip-address annotation removed"
+          - "Changed: {{ ci_patch_result.changed | default(false) }}"
+      when: ci_patch_result is not skipped
 
-- name: Display ComputeInstance annotation already absent
-  ansible.builtin.debug:
-    msg: >-
-      ComputeInstance '{{ detach_compute_instance_name }}':
-      floating-ip-address annotation not present, nothing to remove
-  when: ci_patch_result is skipped
+    - name: Display ComputeInstance annotation already absent
+      ansible.builtin.debug:
+        msg: >-
+          ComputeInstance '{{ detach_compute_instance_name }}':
+          floating-ip-address annotation not present, nothing to remove
+      when: ci_patch_result is skipped
 
-# Re-create the placeholder reservation Service in metallb-system.
-- name: Re-create placeholder Service in metallb-system
-  kubernetes.core.k8s:
-    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
-    state: present
-    apply: true
-    definition:
-      apiVersion: v1
-      kind: Service
-      metadata:
-        name: "osac-publicip-{{ public_ip_id }}"
-        namespace: metallb-system
-        labels:
-          osac.openshift.io/publicip: "{{ public_ip_id }}"
-          osac.io/managed-by: osac-fulfillment
-        annotations:
-          metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
-          metallb.universe.tf/loadBalancerIPs: "{{ detach_ip_address }}"
-      spec:
-        type: LoadBalancer
-        selector: {}
-        ports:
-          - name: placeholder
-            protocol: TCP
-            port: 65535
-            targetPort: 65535
-  register: placeholder_service_result
-  retries: 60
-  delay: 10
-  until: placeholder_service_result is successful
+    # Re-create the placeholder reservation Service in metallb-system.
+    - name: Re-create placeholder Service in metallb-system
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: present
+        apply: true
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: "osac-publicip-{{ public_ip_id }}"
+            namespace: metallb-system
+            labels:
+              osac.openshift.io/publicip: "{{ public_ip_id }}"
+              osac.io/managed-by: osac-fulfillment
+            annotations:
+              metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
+              metallb.universe.tf/loadBalancerIPs: "{{ detach_ip_address }}"
+          spec:
+            type: LoadBalancer
+            selector: {}
+            ports:
+              - name: placeholder
+                protocol: TCP
+                port: 65535
+                targetPort: 65535
+      register: placeholder_service_result
+      retries: 60
+      delay: 10
+      until: placeholder_service_result is successful
 
-- name: Display placeholder Service creation result
-  ansible.builtin.debug:
-    msg:
-      - "Placeholder Service 'osac-publicip-{{ public_ip_id }}' re-created in metallb-system"
-      - "IP preserved: {{ detach_ip_address }}"
-      - "Changed: {{ placeholder_service_result.changed | default(false) }}"
+    - name: Display placeholder Service creation result
+      ansible.builtin.debug:
+        msg:
+          - "Placeholder Service 'osac-publicip-{{ public_ip_id }}' re-created in metallb-system"
+          - "IP preserved: {{ detach_ip_address }}"
+          - "Changed: {{ placeholder_service_result.changed | default(false) }}"
+
+  rescue:
+    - name: Restore LoadBalancer Service in VM namespace after failed placeholder re-creation
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: present
+        apply: true
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: "{{ public_ip_id }}-lb"
+            namespace: "{{ detach_vm_namespace }}"
+            labels:
+              osac.openshift.io/publicip: "{{ public_ip_id }}"
+              osac.io/managed-by: osac-fulfillment
+            annotations:
+              metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
+              metallb.universe.tf/loadBalancerIPs: "{{ detach_ip_address }}"
+          spec:
+            type: LoadBalancer
+            selector:
+              vm.kubevirt.io/name: "{{ detach_compute_instance_name }}"
+            ports:
+              - name: ssh
+                port: 22
+                targetPort: 22
+                protocol: TCP
+      when: lb_service_delete_result.changed | default(false)
+
+    - name: Fail after attempted rollback of detach operation
+      ansible.builtin.fail:
+        msg: >-
+          Detach of PublicIP '{{ public_ip_name }}' failed; the LoadBalancer Service
+          '{{ public_ip_id }}-lb' in '{{ detach_vm_namespace }}' has been restored
+          if it had been deleted. Check the preceding error for details.

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -4,20 +4,24 @@
     name: osac.service.common
     tasks_from: get_remote_cluster_kubeconfig
 
-- name: Validate PublicIP annotations
+- name: Validate PublicIP fields and annotations
   ansible.builtin.assert:
     that:
+      - public_ip.id is defined
+      - public_ip.id | length > 0
       - public_ip.metadata is defined
       - public_ip.metadata.annotations is defined
       - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
       - "'osac.openshift.io/publicip-target-namespace' in public_ip.metadata.annotations"
     fail_msg: >-
-      PublicIP is missing required annotations:
-      osac.openshift.io/publicippool-name and
-      osac.openshift.io/publicip-target-namespace must both be set.
+      PublicIP is missing required fields/annotations:
+      id must be set, and annotations osac.openshift.io/publicippool-name
+      and osac.openshift.io/publicip-target-namespace must both be present.
 
 - name: Extract PublicIP detach configuration
   ansible.builtin.set_fact:
+    public_ip_id: "{{ public_ip.id }}"
+    public_ip_name: "{{ public_ip.metadata.name | default(public_ip.id) }}"
     detach_vm_namespace: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicip-target-namespace'] }}
     detach_pool_name: >-
@@ -50,15 +54,16 @@
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: v1
     kind: Service
-    name: "{{ public_ip_name }}-lb"
+    name: "{{ public_ip_id }}-lb"
     namespace: "{{ detach_vm_namespace }}"
   register: lb_service_info
 
 - name: Fail if VM namespace LB Service not found or IP not assigned
   ansible.builtin.fail:
     msg: >-
-      LoadBalancer Service '{{ public_ip_name }}-lb' not found in '{{ detach_vm_namespace }}'
-      or MetalLB has not assigned an IP. Run attach_public_ip first.
+      LoadBalancer Service '{{ public_ip_id }}-lb' (PublicIP '{{ public_ip_name }}')
+      not found in '{{ detach_vm_namespace }}' or MetalLB has not assigned an IP.
+      Run attach_public_ip first.
   when: >-
     lb_service_info.resources | length == 0 or
     lb_service_info.resources[0].status.loadBalancer.ingress | default([]) | length == 0
@@ -70,7 +75,7 @@
 - name: Display PublicIP detach information
   ansible.builtin.debug:
     msg:
-      - "Detaching PublicIP '{{ public_ip_name }}'"
+      - "Detaching PublicIP id='{{ public_ip_id }}' name='{{ public_ip_name }}'"
       - "IP address: {{ detach_ip_address }} (read from VM namespace LB Service)"
       - "Pool: {{ detach_pool_name }}"
       - "VM namespace: {{ detach_vm_namespace }}"
@@ -83,7 +88,7 @@
     state: absent
     api_version: v1
     kind: Service
-    name: "{{ public_ip_name }}-lb"
+    name: "{{ public_ip_id }}-lb"
     namespace: "{{ detach_vm_namespace }}"
     wait: true
     wait_timeout: 60
@@ -100,7 +105,7 @@
 - name: Display LB Service deletion result
   ansible.builtin.debug:
     msg:
-      - "LoadBalancer Service '{{ public_ip_name }}-lb' deleted from '{{ detach_vm_namespace }}'"
+      - "LoadBalancer Service '{{ public_ip_id }}-lb' deleted from '{{ detach_vm_namespace }}'"
       - "Changed: {{ lb_service_delete_result.changed | default(false) }}"
 
 # Remove floating-ip-address annotation from the ComputeInstance CR.
@@ -153,10 +158,10 @@
       apiVersion: v1
       kind: Service
       metadata:
-        name: "osac-publicip-{{ public_ip_name }}"
+        name: "osac-publicip-{{ public_ip_id }}"
         namespace: metallb-system
         labels:
-          osac.openshift.io/publicip: "{{ public_ip_name }}"
+          osac.openshift.io/publicip: "{{ public_ip_id }}"
           osac.io/managed-by: osac-fulfillment
         annotations:
           metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
@@ -177,6 +182,6 @@
 - name: Display placeholder Service creation result
   ansible.builtin.debug:
     msg:
-      - "Placeholder Service 'osac-publicip-{{ public_ip_name }}' re-created in metallb-system"
+      - "Placeholder Service 'osac-publicip-{{ public_ip_id }}' re-created in metallb-system"
       - "IP preserved: {{ detach_ip_address }}"
       - "Changed: {{ placeholder_service_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -7,9 +7,11 @@
 - name: Validate PublicIP fields and annotations
   ansible.builtin.assert:
     that:
-      - public_ip.id is defined
-      - public_ip.id | length > 0
       - public_ip.metadata is defined
+      - public_ip.metadata.name is defined
+      - public_ip.metadata.name | length > 0
+      - public_ip.metadata.namespace is defined
+      - public_ip.metadata.namespace | length > 0
       - public_ip.metadata.annotations is defined
       - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
       - "'osac.openshift.io/publicip-target-namespace' in public_ip.metadata.annotations"
@@ -18,37 +20,38 @@
       - public_ip.spec.computeInstance | length > 0
     fail_msg: >-
       PublicIP is missing required fields/annotations:
-      id and spec.computeInstance must be set, and annotations
-      osac.openshift.io/publicippool-name and
+      metadata.name, metadata.namespace, and spec.computeInstance must be set,
+      and annotations osac.openshift.io/publicippool-name and
       osac.openshift.io/publicip-target-namespace must both be present.
 
 - name: Extract PublicIP detach configuration
   ansible.builtin.set_fact:
-    public_ip_id: "{{ public_ip.id }}"
-    public_ip_name: "{{ public_ip.metadata.name | default(public_ip.id) }}"
+    public_ip_name: "{{ public_ip.metadata.name }}"
     detach_vm_namespace: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicip-target-namespace'] }}
     detach_pool_name: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicippool-name'] }}
 
-- name: Fetch ComputeInstance CR by ID
+- name: Fetch ComputeInstance CR
   kubernetes.core.k8s_info:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: osac.openshift.io/v1alpha1
     kind: ComputeInstance
-    name: "{{ public_ip.spec.computeInstance }}"
+    namespace: "{{ public_ip.metadata.namespace }}"
+    label_selectors:
+      - "osac.openshift.io/computeinstance-uuid={{ public_ip.spec.computeInstance }}"
   register: detach_ci_lookup
 
 - name: Fail if ComputeInstance not found
   ansible.builtin.fail:
     msg: >-
-      ComputeInstance '{{ public_ip.spec.computeInstance }}' not found.
+      ComputeInstance with uuid '{{ public_ip.spec.computeInstance }}' not found
+      in namespace '{{ public_ip.metadata.namespace }}'.
   when: detach_ci_lookup.resources | length == 0
 
-- name: Extract ComputeInstance name and namespace from fetched CR
+- name: Extract ComputeInstance name from fetched CR
   ansible.builtin.set_fact:
     detach_compute_instance_name: "{{ detach_ci_lookup.resources[0].metadata.name }}"
-    detach_compute_instance_namespace: "{{ detach_ci_lookup.resources[0].metadata.namespace }}"
 
 # Read the IP from the VM namespace LB Service before deleting it.
 - name: Read IP from VM namespace LoadBalancer Service
@@ -56,16 +59,15 @@
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: v1
     kind: Service
-    name: "{{ public_ip_id }}-lb"
+    name: "{{ public_ip_name }}-lb"
     namespace: "{{ detach_vm_namespace }}"
   register: lb_service_info
 
 - name: Fail if VM namespace LB Service not found or IP not assigned
   ansible.builtin.fail:
     msg: >-
-      LoadBalancer Service '{{ public_ip_id }}-lb' (PublicIP '{{ public_ip_name }}')
-      not found in '{{ detach_vm_namespace }}' or MetalLB has not assigned an IP.
-      Run attach_public_ip first.
+      LoadBalancer Service '{{ public_ip_name }}-lb' not found in '{{ detach_vm_namespace }}'
+      or MetalLB has not assigned an IP. Run attach_public_ip first.
   when: >-
     lb_service_info.resources | length == 0 or
     lb_service_info.resources[0].status.loadBalancer.ingress | default([]) | length == 0
@@ -77,11 +79,11 @@
 - name: Display PublicIP detach information
   ansible.builtin.debug:
     msg:
-      - "Detaching PublicIP id='{{ public_ip_id }}' name='{{ public_ip_name }}'"
+      - "Detaching PublicIP '{{ public_ip_name }}'"
       - "IP address: {{ detach_ip_address }} (read from VM namespace LB Service)"
       - "Pool: {{ detach_pool_name }}"
       - "VM namespace: {{ detach_vm_namespace }}"
-      - "ComputeInstance: {{ detach_compute_instance_name }} ({{ detach_compute_instance_namespace }})"
+      - "ComputeInstance: {{ detach_compute_instance_name }} ({{ public_ip.metadata.namespace }})"
 
 # Delete the LB Service, clear the annotation, and restore the placeholder atomically.
 # The rescue restores the LB Service if placeholder re-creation fails so the IP
@@ -94,16 +96,14 @@
         state: absent
         api_version: v1
         kind: Service
-        name: "{{ public_ip_id }}-lb"
+        name: "{{ public_ip_name }}-lb"
         namespace: "{{ detach_vm_namespace }}"
         wait: true
         wait_timeout: 60
       register: lb_service_delete_result
       retries: 3
       delay: 5
-      until: >-
-        lb_service_delete_result is successful
-        or ('NotFound' in (lb_service_delete_result.msg | default('')))
+      until: lb_service_delete_result is successful
       failed_when:
         - lb_service_delete_result.failed | default(false)
         - "'NotFound' not in (lb_service_delete_result.msg | default(''))"
@@ -111,50 +111,9 @@
     - name: Display LB Service deletion result
       ansible.builtin.debug:
         msg:
-          - "LoadBalancer Service '{{ public_ip_id }}-lb' deleted from '{{ detach_vm_namespace }}'"
+          - "LoadBalancer Service '{{ public_ip_name }}-lb' deleted from '{{ detach_vm_namespace }}'"
           - "Changed: {{ lb_service_delete_result.changed | default(false) }}"
 
-    # Remove floating-ip-address annotation from the ComputeInstance CR.
-    - name: Fetch ComputeInstance to inspect annotations
-      kubernetes.core.k8s_info:
-        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
-        api_version: osac.openshift.io/v1alpha1
-        kind: ComputeInstance
-        name: "{{ detach_compute_instance_name }}"
-        namespace: "{{ detach_compute_instance_namespace }}"
-      register: ci_info
-
-    - name: Remove floating-ip-address annotation from ComputeInstance CR
-      kubernetes.core.k8s_json_patch:
-        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
-        api_version: osac.openshift.io/v1alpha1
-        kind: ComputeInstance
-        name: "{{ detach_compute_instance_name }}"
-        namespace: "{{ detach_compute_instance_namespace }}"
-        patch:
-          - op: remove
-            path: /metadata/annotations/osac.openshift.io~1floating-ip-address
-      register: ci_patch_result
-      when: >-
-        ci_info.resources | length > 0 and
-        (ci_info.resources[0].metadata.annotations | default({}))
-        ['osac.openshift.io/floating-ip-address'] is defined
-
-    - name: Display ComputeInstance annotation removal result
-      ansible.builtin.debug:
-        msg:
-          - "ComputeInstance '{{ detach_compute_instance_name }}': floating-ip-address annotation removed"
-          - "Changed: {{ ci_patch_result.changed | default(false) }}"
-      when: ci_patch_result is not skipped
-
-    - name: Display ComputeInstance annotation already absent
-      ansible.builtin.debug:
-        msg: >-
-          ComputeInstance '{{ detach_compute_instance_name }}':
-          floating-ip-address annotation not present, nothing to remove
-      when: ci_patch_result is skipped
-
-    # Re-create the placeholder reservation Service in metallb-system.
     - name: Re-create placeholder Service in metallb-system
       kubernetes.core.k8s:
         kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
@@ -164,10 +123,10 @@
           apiVersion: v1
           kind: Service
           metadata:
-            name: "osac-publicip-{{ public_ip_id }}"
+            name: "osac-publicip-{{ public_ip_name }}"
             namespace: metallb-system
             labels:
-              osac.openshift.io/publicip: "{{ public_ip_id }}"
+              osac.openshift.io/publicip: "{{ public_ip_name }}"
               osac.io/managed-by: osac-fulfillment
             annotations:
               metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
@@ -188,7 +147,7 @@
     - name: Display placeholder Service creation result
       ansible.builtin.debug:
         msg:
-          - "Placeholder Service 'osac-publicip-{{ public_ip_id }}' re-created in metallb-system"
+          - "Placeholder Service 'osac-publicip-{{ public_ip_name }}' re-created in metallb-system"
           - "IP preserved: {{ detach_ip_address }}"
           - "Changed: {{ placeholder_service_result.changed | default(false) }}"
 
@@ -202,10 +161,10 @@
           apiVersion: v1
           kind: Service
           metadata:
-            name: "{{ public_ip_id }}-lb"
+            name: "{{ public_ip_name }}-lb"
             namespace: "{{ detach_vm_namespace }}"
             labels:
-              osac.openshift.io/publicip: "{{ public_ip_id }}"
+              osac.openshift.io/publicip: "{{ public_ip_name }}"
               osac.io/managed-by: osac-fulfillment
             annotations:
               metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
@@ -220,10 +179,54 @@
                 targetPort: 22
                 protocol: TCP
       when: lb_service_delete_result.changed | default(false)
+      register: rescue_lb_result
+      retries: 3
+      delay: 5
+      until: rescue_lb_result is successful
 
     - name: Fail after attempted rollback of detach operation
       ansible.builtin.fail:
         msg: >-
           Detach of PublicIP '{{ public_ip_name }}' failed; the LoadBalancer Service
-          '{{ public_ip_id }}-lb' in '{{ detach_vm_namespace }}' has been restored
+          '{{ public_ip_name }}-lb' in '{{ detach_vm_namespace }}' has been restored
           if it had been deleted. Check the preceding error for details.
+
+# Remove the floating-ip-address annotation from the ComputeInstance CR. 
+- name: Fetch ComputeInstance to inspect annotations
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    name: "{{ detach_compute_instance_name }}"
+    namespace: "{{ public_ip.metadata.namespace }}"
+  register: ci_info
+
+- name: Remove floating-ip-address annotation from ComputeInstance CR
+  kubernetes.core.k8s_json_patch:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    name: "{{ detach_compute_instance_name }}"
+    namespace: "{{ public_ip.metadata.namespace }}"
+    patch:
+      - op: remove
+        path: /metadata/annotations/osac.openshift.io~1floating-ip-address
+  register: ci_patch_result
+  when: >-
+    ci_info.resources | length > 0 and
+    (ci_info.resources[0].metadata.annotations | default({}))
+    ['osac.openshift.io/floating-ip-address'] is defined
+
+- name: Display ComputeInstance annotation removal result
+  ansible.builtin.debug:
+    msg:
+      - "ComputeInstance '{{ detach_compute_instance_name }}': floating-ip-address annotation removed"
+      - "Changed: {{ ci_patch_result.changed | default(false) }}"
+  when: ci_patch_result is defined and ci_patch_result is not skipped
+
+- name: Display ComputeInstance annotation already absent
+  ansible.builtin.debug:
+    msg: >-
+      ComputeInstance '{{ detach_compute_instance_name }}':
+      floating-ip-address annotation not present, nothing to remove
+  when: ci_patch_result is defined and ci_patch_result is skipped

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -191,7 +191,7 @@
           '{{ public_ip_name }}-lb' in '{{ detach_vm_namespace }}' has been restored
           if it had been deleted. Check the preceding error for details.
 
-# Remove the floating-ip-address annotation from the ComputeInstance CR. 
+# Remove the floating-ip-address annotation from the ComputeInstance CR.
 - name: Fetch ComputeInstance to inspect annotations
   kubernetes.core.k8s_info:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -208,13 +208,11 @@
     K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
-    test_ip_id: "test-publicip-id"
+    test_ip_name: "test-publicip-id"
     test_pool_name: "test-metallb-pool"
-    public_ip_id: "{{ test_ip_id }}"
     public_ip:
-      id: "{{ test_ip_id }}"
       metadata:
-        name: "{{ test_ip_id }}"
+        name: "{{ test_ip_name }}"
         annotations:
           osac.openshift.io/publicippool-name: "{{ test_pool_name }}"
 
@@ -226,7 +224,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
           register: pre_create_svc
 
@@ -236,7 +234,7 @@
               - pre_create_svc.resources | length == 0
             fail_msg: >-
               Stale LB Service exists from a previous run. Clean up with:
-              oc delete svc osac-publicip-{{ test_ip_id }} -n metallb-system --ignore-not-found
+              oc delete svc osac-publicip-{{ test_ip_name }} -n metallb-system --ignore-not-found
             success_msg: "No stale LB Service, proceeding with create"
 
         - name: Create PublicIP via metallb_l2 role
@@ -248,7 +246,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
           register: lb_svc_result
 
@@ -261,7 +259,7 @@
               - lb_svc_result.resources[0].spec.ports[0].name == "placeholder"
               - lb_svc_result.resources[0].spec.selector | default({}) | length == 0
             fail_msg: "LoadBalancer Service not created correctly"
-            success_msg: "LoadBalancer Service 'osac-publicip-{{ test_ip_id }}' created with correct spec"
+            success_msg: "LoadBalancer Service 'osac-publicip-{{ test_ip_name }}' created with correct spec"
 
         - name: Verify LoadBalancer Service annotations
           ansible.builtin.assert:
@@ -273,7 +271,7 @@
         - name: Verify LoadBalancer Service labels
           ansible.builtin.assert:
             that:
-              - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_id
+              - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_name
               - lb_svc_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
             fail_msg: "LoadBalancer Service labels incorrect"
             success_msg: "LoadBalancer Service labels correct"
@@ -294,7 +292,7 @@
           kubernetes.core.k8s:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
             state: absent
           when: ansible_failed_result is defined
@@ -311,12 +309,10 @@
     K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
-    test_ip_id: "test-publicip-id"
-    public_ip_id: "{{ test_ip_id }}"
+    test_ip_name: "test-publicip-id"
     public_ip:
-      id: "{{ test_ip_id }}"
       metadata:
-        name: "{{ test_ip_id }}"
+        name: "{{ test_ip_name }}"
 
   tasks:
     - name: Run PublicIP delete tests
@@ -326,7 +322,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
           register: pre_delete_svc
 
@@ -346,7 +342,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
           register: svc_after_delete
 
@@ -355,7 +351,7 @@
             that:
               - svc_after_delete.resources | length == 0
             fail_msg: "LB Service still exists after delete"
-            success_msg: "LB Service 'osac-publicip-{{ test_ip_id }}' successfully deleted"
+            success_msg: "LB Service 'osac-publicip-{{ test_ip_name }}' successfully deleted"
 
 # ──────────────────────────────────────────────────────────────
 # Test: Delete PublicIP when already gone (NotFound handling)
@@ -368,12 +364,10 @@
     K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
-    test_ip_id: "test-publicip-id"
-    public_ip_id: "{{ test_ip_id }}"
+    test_ip_name: "test-publicip"
     public_ip:
-      id: "{{ test_ip_id }}"
       metadata:
-        name: "{{ test_ip_id }}"
+        name: "{{ test_ip_name }}"
 
   tasks:
     - name: Run PublicIP delete-not-found test
@@ -383,7 +377,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
           register: pre_notfound_svc
 
@@ -555,21 +549,21 @@
     K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
-    test_ip_id: "test-publicip-id"
+    test_ip_name: "test-publicip-id"
     test_pool_name: "test-metallb-pool"
     test_vm_namespace: "test-publicip-vm-ns"
     test_ci_name: "test-compute-instance"
     test_ci_namespace: "default"
+    test_ci_uuid: "a1b2c3d4-0000-0000-0000-test-ci-uuid"
     public_ip:
-      id: "{{ test_ip_id }}"
       metadata:
-        name: "{{ test_ip_id }}"
+        name: "{{ test_ip_name }}"
         namespace: "{{ test_ci_namespace }}"
         annotations:
           osac.openshift.io/publicippool-name: "{{ test_pool_name }}"
           osac.openshift.io/publicip-target-namespace: "{{ test_vm_namespace }}"
       spec:
-        computeInstance: "{{ test_ci_name }}"
+        computeInstance: "{{ test_ci_uuid }}"
 
   tasks:
     - name: Run attach tests
@@ -593,6 +587,8 @@
               metadata:
                 name: "{{ test_ci_name }}"
                 namespace: "{{ test_ci_namespace }}"
+                labels:
+                  osac.openshift.io/computeinstance-uuid: "{{ test_ci_uuid }}"
               spec:
                 templateID: osac.templates.ocp_virt_vm
                 cores: 2
@@ -611,12 +607,12 @@
               apiVersion: v1
               kind: Service
               metadata:
-                name: "osac-publicip-{{ test_ip_id }}"
+                name: "osac-publicip-{{ test_ip_name }}"
                 namespace: metallb-system
                 annotations:
                   metallb.universe.tf/address-pool: "{{ test_pool_name }}"
                 labels:
-                  osac.openshift.io/publicip: "{{ test_ip_id }}"
+                  osac.openshift.io/publicip: "{{ test_ip_name }}"
                   osac.io/managed-by: osac-fulfillment
               spec:
                 type: LoadBalancer
@@ -635,7 +631,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
           register: parking_svc_info
           retries: 60
@@ -654,7 +650,7 @@
               kubernetes.core.k8s_info:
                 api_version: v1
                 kind: Service
-                name: "{{ test_ip_id }}-lb"
+                name: "{{ test_ip_name }}-lb"
                 namespace: "{{ test_vm_namespace }}"
               register: pre_attach_lb_svc
 
@@ -663,8 +659,8 @@
                 that:
                   - pre_attach_lb_svc.resources | length == 0
                 fail_msg: >-
-                  Stale LB Service '{{ test_ip_id }}-lb' already exists in '{{ test_vm_namespace }}'.
-                  Clean up with: oc delete svc {{ test_ip_id }}-lb -n {{ test_vm_namespace }} --ignore-not-found
+                  Stale LB Service '{{ test_ip_name }}-lb' already exists in '{{ test_vm_namespace }}'.
+                  Clean up with: oc delete svc {{ test_ip_name }}-lb -n {{ test_vm_namespace }} --ignore-not-found
                 success_msg: "No stale LB Service in VM namespace, proceeding with attach"
 
         - name: Run attach_public_ip role
@@ -676,7 +672,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
           register: parking_svc_after_attach
 
@@ -685,13 +681,13 @@
             that:
               - parking_svc_after_attach.resources | length == 0
             fail_msg: "Parking Service still exists in metallb-system after attach"
-            success_msg: "Parking Service 'osac-publicip-{{ test_ip_id }}' correctly removed from metallb-system"
+            success_msg: "Parking Service 'osac-publicip-{{ test_ip_name }}' correctly removed from metallb-system"
 
         - name: Fetch LoadBalancer Service in VM namespace
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "{{ test_ip_id }}-lb"
+            name: "{{ test_ip_name }}-lb"
             namespace: "{{ test_vm_namespace }}"
           register: lb_svc_result
 
@@ -701,7 +697,7 @@
               - lb_svc_result.resources | length == 1
               - lb_svc_result.resources[0].spec.type == "LoadBalancer"
             fail_msg: "LB Service not created in VM namespace after attach"
-            success_msg: "LB Service '{{ test_ip_id }}-lb' created in '{{ test_vm_namespace }}'"
+            success_msg: "LB Service '{{ test_ip_name }}-lb' created in '{{ test_vm_namespace }}'"
 
         - name: Verify LB Service annotations preserve pool and IP
           ansible.builtin.assert:
@@ -714,7 +710,7 @@
         - name: Verify LB Service labels
           ansible.builtin.assert:
             that:
-              - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_id
+              - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_name
               - lb_svc_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
             fail_msg: "LB Service labels incorrect after attach"
             success_msg: "LB Service labels correct"
@@ -749,7 +745,7 @@
           kubernetes.core.k8s:
             api_version: v1
             kind: Service
-            name: "{{ test_ip_id }}-lb"
+            name: "{{ test_ip_name }}-lb"
             namespace: "{{ test_vm_namespace }}"
             state: absent
           when: ansible_failed_result is defined
@@ -759,7 +755,7 @@
           kubernetes.core.k8s:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
             state: absent
           when: ansible_failed_result is defined
@@ -792,21 +788,21 @@
     K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
-    test_ip_id: "test-publicip-id"
+    test_ip_name: "test-publicip-id"
     test_pool_name: "test-metallb-pool"
     test_vm_namespace: "test-publicip-vm-ns"
     test_ci_name: "test-compute-instance"
     test_ci_namespace: "default"
+    test_ci_uuid: "a1b2c3d4-0000-0000-0000-test-ci-uuid"
     public_ip:
-      id: "{{ test_ip_id }}"
       metadata:
-        name: "{{ test_ip_id }}"
+        name: "{{ test_ip_name }}"
         namespace: "{{ test_ci_namespace }}"
         annotations:
           osac.openshift.io/publicippool-name: "{{ test_pool_name }}"
           osac.openshift.io/publicip-target-namespace: "{{ test_vm_namespace }}"
       spec:
-        computeInstance: "{{ test_ci_name }}"
+        computeInstance: "{{ test_ci_uuid }}"
 
   tasks:
     - name: Run detach tests
@@ -816,7 +812,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "{{ test_ip_id }}-lb"
+            name: "{{ test_ip_name }}-lb"
             namespace: "{{ test_vm_namespace }}"
           register: pre_detach_lb_svc
 
@@ -826,7 +822,7 @@
               - pre_detach_lb_svc.resources | length == 1
               - pre_detach_lb_svc.resources[0].status.loadBalancer.ingress | default([]) | length > 0
             fail_msg: >-
-              LB Service '{{ test_ip_id }}-lb' not found in '{{ test_vm_namespace }}' or has no IP.
+              LB Service '{{ test_ip_name }}-lb' not found in '{{ test_vm_namespace }}' or has no IP.
               Run the attach test first or run all tests together.
             success_msg: "LB Service exists with IP, proceeding with detach"
 
@@ -843,7 +839,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "{{ test_ip_id }}-lb"
+            name: "{{ test_ip_name }}-lb"
             namespace: "{{ test_vm_namespace }}"
           register: lb_svc_after_detach
 
@@ -852,7 +848,7 @@
             that:
               - lb_svc_after_detach.resources | length == 0
             fail_msg: "LB Service still exists in VM namespace after detach"
-            success_msg: "LB Service '{{ test_ip_id }}-lb' correctly removed from '{{ test_vm_namespace }}'"
+            success_msg: "LB Service '{{ test_ip_name }}-lb' correctly removed from '{{ test_vm_namespace }}'"
 
         - name: Fetch ComputeInstance to verify annotation removed
           kubernetes.core.k8s_info:
@@ -876,7 +872,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
           register: parking_svc_after_detach
           retries: 60
@@ -891,7 +887,7 @@
               - parking_svc_after_detach.resources[0].spec.type == "LoadBalancer"
               - parking_svc_after_detach.resources[0].spec.selector | default({}) | length == 0
             fail_msg: "Re-created parking Service has incorrect spec after detach"
-            success_msg: "Parking Service 'osac-publicip-{{ test_ip_id }}' re-created with correct placeholder spec"
+            success_msg: "Parking Service 'osac-publicip-{{ test_ip_name }}' re-created with correct placeholder spec"
 
         - name: Verify parking Service preserves the same IP
           ansible.builtin.assert:
@@ -905,7 +901,7 @@
         - name: Verify parking Service labels
           ansible.builtin.assert:
             that:
-              - parking_svc_after_detach.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_id
+              - parking_svc_after_detach.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_name
               - parking_svc_after_detach.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
             fail_msg: "Re-created parking Service labels incorrect after detach"
             success_msg: "Parking Service labels correct"
@@ -915,7 +911,7 @@
           kubernetes.core.k8s:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_id }}"
+            name: "osac-publicip-{{ test_ip_name }}"
             namespace: metallb-system
             state: absent
           ignore_errors: true

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -1,9 +1,11 @@
 ---
 # Test playbook for osac.templates.metallb_l2 role.
 #
-# Tests create and delete of MetalLB resources:
+# Tests create, delete, attach, and detach of MetalLB resources:
 #   - PublicIPPool: IPAddressPool and L2Advertisement
 #   - PublicIP: LoadBalancer Service for IP allocation
+#   - Attach: moves IP from parking Service to VM namespace LB Service
+#   - Detach: removes VM namespace LB Service and re-parks the IP
 #
 # Requires a cluster with MetalLB CRDs applied and the metallb-system
 # namespace present. No MetalLB operator is needed for pool tests since
@@ -31,7 +33,20 @@
 #   # Run only PublicIP delete tests (LB Service must already exist)
 #   ansible-playbook test.yml -e run_create=false -e run_create_ip=false \
 #     -e run_delete_ip=true -e run_delete_ip_not_found=false \
-#     -e run_delete=false -e run_delete_not_found=false -v
+#     -e run_delete=false -e run_delete_not_found=false \
+#     -e run_attach=false -e run_detach=false -v
+#
+#   # Run only attach test (pool and parking Service must already exist)
+#   ansible-playbook test.yml -e run_create=false -e run_create_ip=false \
+#     -e run_delete_ip=false -e run_delete_ip_not_found=false \
+#     -e run_delete=false -e run_delete_not_found=false \
+#     -e run_attach=true -e run_detach=false -v
+#
+#   # Run only detach test (attach test must have run first)
+#   ansible-playbook test.yml -e run_create=false -e run_create_ip=false \
+#     -e run_delete_ip=false -e run_delete_ip_not_found=false \
+#     -e run_delete=false -e run_delete_not_found=false \
+#     -e run_attach=false -e run_detach=true -v
 #
 #   # Run all tests with user impersonation (needed when your user lacks
 #   # direct RBAC for metallb-system resources)
@@ -193,12 +208,13 @@
     K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
-    test_ip_name: "test-publicip"
+    test_ip_id: "test-publicip-id"
     test_pool_name: "test-metallb-pool"
-    public_ip_name: "{{ test_ip_name }}"
+    public_ip_id: "{{ test_ip_id }}"
     public_ip:
+      id: "{{ test_ip_id }}"
       metadata:
-        name: "{{ test_ip_name }}"
+        name: "{{ test_ip_id }}"
         annotations:
           osac.openshift.io/publicippool-name: "{{ test_pool_name }}"
 
@@ -210,7 +226,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-publicip-{{ test_ip_id }}"
             namespace: metallb-system
           register: pre_create_svc
 
@@ -220,7 +236,7 @@
               - pre_create_svc.resources | length == 0
             fail_msg: >-
               Stale LB Service exists from a previous run. Clean up with:
-              oc delete svc osac-publicip-{{ test_ip_name }} -n metallb-system --ignore-not-found
+              oc delete svc osac-publicip-{{ test_ip_id }} -n metallb-system --ignore-not-found
             success_msg: "No stale LB Service, proceeding with create"
 
         - name: Create PublicIP via metallb_l2 role
@@ -232,7 +248,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-publicip-{{ test_ip_id }}"
             namespace: metallb-system
           register: lb_svc_result
 
@@ -245,7 +261,7 @@
               - lb_svc_result.resources[0].spec.ports[0].name == "placeholder"
               - lb_svc_result.resources[0].spec.selector | default({}) | length == 0
             fail_msg: "LoadBalancer Service not created correctly"
-            success_msg: "LoadBalancer Service 'osac-publicip-{{ test_ip_name }}' created with correct spec"
+            success_msg: "LoadBalancer Service 'osac-publicip-{{ test_ip_id }}' created with correct spec"
 
         - name: Verify LoadBalancer Service annotations
           ansible.builtin.assert:
@@ -257,7 +273,7 @@
         - name: Verify LoadBalancer Service labels
           ansible.builtin.assert:
             that:
-              - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_name
+              - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_id
               - lb_svc_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
             fail_msg: "LoadBalancer Service labels incorrect"
             success_msg: "LoadBalancer Service labels correct"
@@ -278,7 +294,7 @@
           kubernetes.core.k8s:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-publicip-{{ test_ip_id }}"
             namespace: metallb-system
             state: absent
           when: ansible_failed_result is defined
@@ -295,11 +311,12 @@
     K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
-    test_ip_name: "test-publicip"
-    public_ip_name: "{{ test_ip_name }}"
+    test_ip_id: "test-publicip-id"
+    public_ip_id: "{{ test_ip_id }}"
     public_ip:
+      id: "{{ test_ip_id }}"
       metadata:
-        name: "{{ test_ip_name }}"
+        name: "{{ test_ip_id }}"
 
   tasks:
     - name: Run PublicIP delete tests
@@ -309,7 +326,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-publicip-{{ test_ip_id }}"
             namespace: metallb-system
           register: pre_delete_svc
 
@@ -329,7 +346,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-publicip-{{ test_ip_id }}"
             namespace: metallb-system
           register: svc_after_delete
 
@@ -338,7 +355,7 @@
             that:
               - svc_after_delete.resources | length == 0
             fail_msg: "LB Service still exists after delete"
-            success_msg: "LB Service 'osac-publicip-{{ test_ip_name }}' successfully deleted"
+            success_msg: "LB Service 'osac-publicip-{{ test_ip_id }}' successfully deleted"
 
 # ──────────────────────────────────────────────────────────────
 # Test: Delete PublicIP when already gone (NotFound handling)
@@ -351,11 +368,12 @@
     K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
 
   vars:
-    test_ip_name: "test-publicip"
-    public_ip_name: "{{ test_ip_name }}"
+    test_ip_id: "test-publicip-id"
+    public_ip_id: "{{ test_ip_id }}"
     public_ip:
+      id: "{{ test_ip_id }}"
       metadata:
-        name: "{{ test_ip_name }}"
+        name: "{{ test_ip_id }}"
 
   tasks:
     - name: Run PublicIP delete-not-found test
@@ -365,7 +383,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-publicip-{{ test_ip_id }}"
             namespace: metallb-system
           register: pre_notfound_svc
 
@@ -518,3 +536,403 @@
         - name: Confirm no failure occurred
           ansible.builtin.debug:
             msg: "Delete-not-found test passed: role tolerated already-deleted resources"
+
+# ──────────────────────────────────────────────────────────────
+# Test: Attach PublicIP to a ComputeInstance
+# Expected:
+#   - Parking Service deleted from metallb-system
+#   - LoadBalancer Service created in VM namespace with correct
+#     selector, labels, annotations, and the reserved IP
+#   - ComputeInstance annotated with floating-ip-address
+# Prerequisites:
+#   - IPAddressPool exists (run pool create first or run all tests)
+#   - ComputeInstance CRD installed (osac.openshift.io/v1alpha1)
+# ──────────────────────────────────────────────────────────────
+- name: Test metallb_l2 role -- attach PublicIP to ComputeInstance
+  hosts: localhost
+  gather_facts: false
+  environment:
+    K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
+
+  vars:
+    test_ip_id: "test-publicip-id"
+    test_pool_name: "test-metallb-pool"
+    test_vm_namespace: "test-publicip-vm-ns"
+    test_ci_name: "test-compute-instance"
+    test_ci_namespace: "default"
+    public_ip:
+      id: "{{ test_ip_id }}"
+      metadata:
+        name: "{{ test_ip_id }}"
+        namespace: "{{ test_ci_namespace }}"
+        annotations:
+          osac.openshift.io/publicippool-name: "{{ test_pool_name }}"
+          osac.openshift.io/publicip-target-namespace: "{{ test_vm_namespace }}"
+      spec:
+        computeInstance: "{{ test_ci_name }}"
+
+  tasks:
+    - name: Run attach tests
+      when: run_attach | default(true) | bool
+      block:
+        - name: Create VM target namespace
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: "{{ test_vm_namespace }}"
+
+        - name: Create ComputeInstance fixture CR
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: osac.openshift.io/v1alpha1
+              kind: ComputeInstance
+              metadata:
+                name: "{{ test_ci_name }}"
+                namespace: "{{ test_ci_namespace }}"
+              spec:
+                templateID: osac.templates.ocp_virt_vm
+                cores: 2
+                memoryGiB: 4
+                bootDisk:
+                  sizeGiB: 20
+                image:
+                  sourceType: registry
+                  sourceRef: "quay.io/containerdisks/fedora:latest"
+                runStrategy: "Always"
+
+        - name: Create parking Service in metallb-system (simulate pre-existing PublicIP)
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: "osac-publicip-{{ test_ip_id }}"
+                namespace: metallb-system
+                annotations:
+                  metallb.universe.tf/address-pool: "{{ test_pool_name }}"
+                labels:
+                  osac.openshift.io/publicip: "{{ test_ip_id }}"
+                  osac.io/managed-by: osac-fulfillment
+              spec:
+                type: LoadBalancer
+                selector: {}
+                ports:
+                  - name: placeholder
+                    protocol: TCP
+                    port: 65535
+                    targetPort: 65535
+          register: parking_svc_create
+          retries: 60
+          delay: 10
+          until: parking_svc_create is successful
+
+        - name: Wait for MetalLB to assign IP to parking Service
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_id }}"
+            namespace: metallb-system
+          register: parking_svc_info
+          retries: 60
+          delay: 10
+          until: >-
+            parking_svc_info.resources | length > 0 and
+            parking_svc_info.resources[0].status.loadBalancer.ingress | default([]) | length > 0
+
+        - name: Record IP assigned to parking Service
+          ansible.builtin.set_fact:
+            pre_attach_ip: "{{ parking_svc_info.resources[0].status.loadBalancer.ingress[0].ip }}"
+
+        - name: Assert clean state -- LB Service not yet in VM namespace
+          block:
+            - name: Check LB Service absent from VM namespace before attach
+              kubernetes.core.k8s_info:
+                api_version: v1
+                kind: Service
+                name: "{{ test_ip_id }}-lb"
+                namespace: "{{ test_vm_namespace }}"
+              register: pre_attach_lb_svc
+
+            - name: Assert LB Service not in VM namespace
+              ansible.builtin.assert:
+                that:
+                  - pre_attach_lb_svc.resources | length == 0
+                fail_msg: >-
+                  Stale LB Service '{{ test_ip_id }}-lb' already exists in '{{ test_vm_namespace }}'.
+                  Clean up with: oc delete svc {{ test_ip_id }}-lb -n {{ test_vm_namespace }} --ignore-not-found
+                success_msg: "No stale LB Service in VM namespace, proceeding with attach"
+
+        - name: Run attach_public_ip role
+          ansible.builtin.include_role:
+            name: osac.templates.metallb_l2
+            tasks_from: attach_public_ip
+
+        - name: Verify parking Service deleted from metallb-system
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_id }}"
+            namespace: metallb-system
+          register: parking_svc_after_attach
+
+        - name: Assert parking Service is gone
+          ansible.builtin.assert:
+            that:
+              - parking_svc_after_attach.resources | length == 0
+            fail_msg: "Parking Service still exists in metallb-system after attach"
+            success_msg: "Parking Service 'osac-publicip-{{ test_ip_id }}' correctly removed from metallb-system"
+
+        - name: Fetch LoadBalancer Service in VM namespace
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "{{ test_ip_id }}-lb"
+            namespace: "{{ test_vm_namespace }}"
+          register: lb_svc_result
+
+        - name: Verify LB Service created in VM namespace with correct type
+          ansible.builtin.assert:
+            that:
+              - lb_svc_result.resources | length == 1
+              - lb_svc_result.resources[0].spec.type == "LoadBalancer"
+            fail_msg: "LB Service not created in VM namespace after attach"
+            success_msg: "LB Service '{{ test_ip_id }}-lb' created in '{{ test_vm_namespace }}'"
+
+        - name: Verify LB Service annotations preserve pool and IP
+          ansible.builtin.assert:
+            that:
+              - lb_svc_result.resources[0].metadata.annotations['metallb.universe.tf/address-pool'] == test_pool_name
+              - lb_svc_result.resources[0].metadata.annotations['metallb.universe.tf/loadBalancerIPs'] == pre_attach_ip
+            fail_msg: "LB Service annotations (pool or IP) incorrect after attach"
+            success_msg: "LB Service annotations correct: pool='{{ test_pool_name }}' ip='{{ pre_attach_ip }}'"
+
+        - name: Verify LB Service labels
+          ansible.builtin.assert:
+            that:
+              - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_id
+              - lb_svc_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
+            fail_msg: "LB Service labels incorrect after attach"
+            success_msg: "LB Service labels correct"
+
+        - name: Verify LB Service VM selector
+          ansible.builtin.assert:
+            that:
+              - lb_svc_result.resources[0].spec.selector['vm.kubevirt.io/name'] == test_ci_name
+            fail_msg: "LB Service selector does not target the correct VM"
+            success_msg: "LB Service selector targets VM '{{ test_ci_name }}'"
+
+        - name: Fetch ComputeInstance to verify annotation
+          kubernetes.core.k8s_info:
+            api_version: osac.openshift.io/v1alpha1
+            kind: ComputeInstance
+            name: "{{ test_ci_name }}"
+            namespace: "{{ test_ci_namespace }}"
+          register: ci_after_attach
+
+        - name: Verify ComputeInstance annotated with floating-ip-address
+          ansible.builtin.assert:
+            that:
+              - ci_after_attach.resources | length == 1
+              - (ci_after_attach.resources[0].metadata.annotations | default({}))['osac.openshift.io/floating-ip-address'] == pre_attach_ip
+            fail_msg: "ComputeInstance not annotated with floating-ip-address after attach"
+            success_msg: >-
+              ComputeInstance '{{ test_ci_name }}' annotated with
+              floating-ip-address='{{ pre_attach_ip }}'
+
+      always:
+        - name: Clean up LB Service from VM namespace on failure
+          kubernetes.core.k8s:
+            api_version: v1
+            kind: Service
+            name: "{{ test_ip_id }}-lb"
+            namespace: "{{ test_vm_namespace }}"
+            state: absent
+          when: ansible_failed_result is defined
+          ignore_errors: true
+
+        - name: Clean up parking Service from metallb-system on failure
+          kubernetes.core.k8s:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_id }}"
+            namespace: metallb-system
+            state: absent
+          when: ansible_failed_result is defined
+          ignore_errors: true
+
+        - name: Clean up ComputeInstance fixture on failure
+          kubernetes.core.k8s:
+            api_version: osac.openshift.io/v1alpha1
+            kind: ComputeInstance
+            name: "{{ test_ci_name }}"
+            namespace: "{{ test_ci_namespace }}"
+            state: absent
+          when: ansible_failed_result is defined
+          ignore_errors: true
+
+# ──────────────────────────────────────────────────────────────
+# Test: Detach PublicIP from a ComputeInstance
+# Expected:
+#   - LoadBalancer Service removed from VM namespace
+#   - floating-ip-address annotation removed from ComputeInstance
+#   - Parking Service re-created in metallb-system with the same IP
+# Prerequisites:
+#   - attach test must have run (or LB Service + annotated ComputeInstance
+#     must exist in the test VM namespace)
+# ──────────────────────────────────────────────────────────────
+- name: Test metallb_l2 role -- detach PublicIP from ComputeInstance
+  hosts: localhost
+  gather_facts: false
+  environment:
+    K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
+
+  vars:
+    test_ip_id: "test-publicip-id"
+    test_pool_name: "test-metallb-pool"
+    test_vm_namespace: "test-publicip-vm-ns"
+    test_ci_name: "test-compute-instance"
+    test_ci_namespace: "default"
+    public_ip:
+      id: "{{ test_ip_id }}"
+      metadata:
+        name: "{{ test_ip_id }}"
+        namespace: "{{ test_ci_namespace }}"
+        annotations:
+          osac.openshift.io/publicippool-name: "{{ test_pool_name }}"
+          osac.openshift.io/publicip-target-namespace: "{{ test_vm_namespace }}"
+      spec:
+        computeInstance: "{{ test_ci_name }}"
+
+  tasks:
+    - name: Run detach tests
+      when: run_detach | default(true) | bool
+      block:
+        - name: Verify LB Service exists in VM namespace before detach
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "{{ test_ip_id }}-lb"
+            namespace: "{{ test_vm_namespace }}"
+          register: pre_detach_lb_svc
+
+        - name: Assert LB Service exists (otherwise detach test is meaningless)
+          ansible.builtin.assert:
+            that:
+              - pre_detach_lb_svc.resources | length == 1
+              - pre_detach_lb_svc.resources[0].status.loadBalancer.ingress | default([]) | length > 0
+            fail_msg: >-
+              LB Service '{{ test_ip_id }}-lb' not found in '{{ test_vm_namespace }}' or has no IP.
+              Run the attach test first or run all tests together.
+            success_msg: "LB Service exists with IP, proceeding with detach"
+
+        - name: Record IP held by LB Service
+          ansible.builtin.set_fact:
+            pre_detach_ip: "{{ pre_detach_lb_svc.resources[0].status.loadBalancer.ingress[0].ip }}"
+
+        - name: Run detach_public_ip role
+          ansible.builtin.include_role:
+            name: osac.templates.metallb_l2
+            tasks_from: detach_public_ip
+
+        - name: Verify LB Service deleted from VM namespace
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "{{ test_ip_id }}-lb"
+            namespace: "{{ test_vm_namespace }}"
+          register: lb_svc_after_detach
+
+        - name: Assert LB Service is gone from VM namespace
+          ansible.builtin.assert:
+            that:
+              - lb_svc_after_detach.resources | length == 0
+            fail_msg: "LB Service still exists in VM namespace after detach"
+            success_msg: "LB Service '{{ test_ip_id }}-lb' correctly removed from '{{ test_vm_namespace }}'"
+
+        - name: Fetch ComputeInstance to verify annotation removed
+          kubernetes.core.k8s_info:
+            api_version: osac.openshift.io/v1alpha1
+            kind: ComputeInstance
+            name: "{{ test_ci_name }}"
+            namespace: "{{ test_ci_namespace }}"
+          register: ci_after_detach
+
+        - name: Assert floating-ip-address annotation removed from ComputeInstance
+          ansible.builtin.assert:
+            that:
+              - ci_after_detach.resources | length == 1
+              - >-
+                (ci_after_detach.resources[0].metadata.annotations | default({}))
+                ['osac.openshift.io/floating-ip-address'] is not defined
+            fail_msg: "floating-ip-address annotation still present on ComputeInstance after detach"
+            success_msg: "floating-ip-address annotation correctly removed from ComputeInstance '{{ test_ci_name }}'"
+
+        - name: Wait for parking Service to be re-created in metallb-system
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_id }}"
+            namespace: metallb-system
+          register: parking_svc_after_detach
+          retries: 60
+          delay: 10
+          until: >-
+            parking_svc_after_detach.resources | length > 0 and
+            parking_svc_after_detach.resources[0].status.loadBalancer.ingress | default([]) | length > 0
+
+        - name: Verify parking Service spec is a placeholder (empty selector)
+          ansible.builtin.assert:
+            that:
+              - parking_svc_after_detach.resources[0].spec.type == "LoadBalancer"
+              - parking_svc_after_detach.resources[0].spec.selector | default({}) | length == 0
+            fail_msg: "Re-created parking Service has incorrect spec after detach"
+            success_msg: "Parking Service 'osac-publicip-{{ test_ip_id }}' re-created with correct placeholder spec"
+
+        - name: Verify parking Service preserves the same IP
+          ansible.builtin.assert:
+            that:
+              - parking_svc_after_detach.resources[0].status.loadBalancer.ingress[0].ip == pre_detach_ip
+            fail_msg: >-
+              Parking Service IP '{{ parking_svc_after_detach.resources[0].status.loadBalancer.ingress[0].ip }}'
+              does not match the original IP '{{ pre_detach_ip }}'
+            success_msg: "Parking Service correctly preserved IP '{{ pre_detach_ip }}'"
+
+        - name: Verify parking Service labels
+          ansible.builtin.assert:
+            that:
+              - parking_svc_after_detach.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_id
+              - parking_svc_after_detach.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
+            fail_msg: "Re-created parking Service labels incorrect after detach"
+            success_msg: "Parking Service labels correct"
+
+      always:
+        - name: Clean up parking Service from metallb-system
+          kubernetes.core.k8s:
+            api_version: v1
+            kind: Service
+            name: "osac-publicip-{{ test_ip_id }}"
+            namespace: metallb-system
+            state: absent
+          ignore_errors: true
+
+        - name: Clean up ComputeInstance fixture
+          kubernetes.core.k8s:
+            api_version: osac.openshift.io/v1alpha1
+            kind: ComputeInstance
+            name: "{{ test_ci_name }}"
+            namespace: "{{ test_ci_namespace }}"
+            state: absent
+          ignore_errors: true
+
+        - name: Clean up VM target namespace
+          kubernetes.core.k8s:
+            api_version: v1
+            kind: Namespace
+            name: "{{ test_vm_namespace }}"
+            state: absent
+          ignore_errors: true

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -224,7 +224,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
           register: pre_create_svc
 
@@ -234,7 +234,7 @@
               - pre_create_svc.resources | length == 0
             fail_msg: >-
               Stale LB Service exists from a previous run. Clean up with:
-              oc delete svc osac-publicip-{{ test_ip_name }} -n metallb-system --ignore-not-found
+              oc delete svc osac-pip-{{ test_ip_name }} -n metallb-system --ignore-not-found
             success_msg: "No stale LB Service, proceeding with create"
 
         - name: Create PublicIP via metallb_l2 role
@@ -246,7 +246,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
           register: lb_svc_result
 
@@ -259,7 +259,7 @@
               - lb_svc_result.resources[0].spec.ports[0].name == "placeholder"
               - lb_svc_result.resources[0].spec.selector | default({}) | length == 0
             fail_msg: "LoadBalancer Service not created correctly"
-            success_msg: "LoadBalancer Service 'osac-publicip-{{ test_ip_name }}' created with correct spec"
+            success_msg: "LoadBalancer Service 'osac-pip-{{ test_ip_name }}' created with correct spec"
 
         - name: Verify LoadBalancer Service annotations
           ansible.builtin.assert:
@@ -292,7 +292,7 @@
           kubernetes.core.k8s:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
             state: absent
           when: ansible_failed_result is defined
@@ -322,7 +322,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
           register: pre_delete_svc
 
@@ -342,7 +342,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
           register: svc_after_delete
 
@@ -351,7 +351,7 @@
             that:
               - svc_after_delete.resources | length == 0
             fail_msg: "LB Service still exists after delete"
-            success_msg: "LB Service 'osac-publicip-{{ test_ip_name }}' successfully deleted"
+            success_msg: "LB Service 'osac-pip-{{ test_ip_name }}' successfully deleted"
 
 # ──────────────────────────────────────────────────────────────
 # Test: Delete PublicIP when already gone (NotFound handling)
@@ -377,7 +377,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
           register: pre_notfound_svc
 
@@ -607,7 +607,7 @@
               apiVersion: v1
               kind: Service
               metadata:
-                name: "osac-publicip-{{ test_ip_name }}"
+                name: "osac-pip-{{ test_ip_name }}"
                 namespace: metallb-system
                 annotations:
                   metallb.universe.tf/address-pool: "{{ test_pool_name }}"
@@ -631,7 +631,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
           register: parking_svc_info
           retries: 60
@@ -650,7 +650,7 @@
               kubernetes.core.k8s_info:
                 api_version: v1
                 kind: Service
-                name: "{{ test_ip_name }}-lb"
+                name: "osac-pip-{{ test_ip_name }}-ingress"
                 namespace: "{{ test_vm_namespace }}"
               register: pre_attach_lb_svc
 
@@ -659,8 +659,8 @@
                 that:
                   - pre_attach_lb_svc.resources | length == 0
                 fail_msg: >-
-                  Stale LB Service '{{ test_ip_name }}-lb' already exists in '{{ test_vm_namespace }}'.
-                  Clean up with: oc delete svc {{ test_ip_name }}-lb -n {{ test_vm_namespace }} --ignore-not-found
+                  Stale LB Service 'osac-pip-{{ test_ip_name }}-ingress' already exists in '{{ test_vm_namespace }}'.
+                  Clean up with: oc delete svc osac-pip-{{ test_ip_name }}-ingress -n {{ test_vm_namespace }} --ignore-not-found
                 success_msg: "No stale LB Service in VM namespace, proceeding with attach"
 
         - name: Run attach_public_ip role
@@ -672,7 +672,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
           register: parking_svc_after_attach
 
@@ -681,13 +681,13 @@
             that:
               - parking_svc_after_attach.resources | length == 0
             fail_msg: "Parking Service still exists in metallb-system after attach"
-            success_msg: "Parking Service 'osac-publicip-{{ test_ip_name }}' correctly removed from metallb-system"
+            success_msg: "Parking Service 'osac-pip-{{ test_ip_name }}' correctly removed from metallb-system"
 
         - name: Fetch LoadBalancer Service in VM namespace
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "{{ test_ip_name }}-lb"
+            name: "osac-pip-{{ test_ip_name }}-ingress"
             namespace: "{{ test_vm_namespace }}"
           register: lb_svc_result
 
@@ -697,7 +697,7 @@
               - lb_svc_result.resources | length == 1
               - lb_svc_result.resources[0].spec.type == "LoadBalancer"
             fail_msg: "LB Service not created in VM namespace after attach"
-            success_msg: "LB Service '{{ test_ip_name }}-lb' created in '{{ test_vm_namespace }}'"
+            success_msg: "LB Service 'osac-pip-{{ test_ip_name }}-ingress' created in '{{ test_vm_namespace }}'"
 
         - name: Verify LB Service annotations preserve pool and IP
           ansible.builtin.assert:
@@ -745,7 +745,7 @@
           kubernetes.core.k8s:
             api_version: v1
             kind: Service
-            name: "{{ test_ip_name }}-lb"
+            name: "osac-pip-{{ test_ip_name }}-ingress"
             namespace: "{{ test_vm_namespace }}"
             state: absent
           when: ansible_failed_result is defined
@@ -755,7 +755,7 @@
           kubernetes.core.k8s:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
             state: absent
           when: ansible_failed_result is defined
@@ -812,7 +812,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "{{ test_ip_name }}-lb"
+            name: "osac-pip-{{ test_ip_name }}-ingress"
             namespace: "{{ test_vm_namespace }}"
           register: pre_detach_lb_svc
 
@@ -822,7 +822,7 @@
               - pre_detach_lb_svc.resources | length == 1
               - pre_detach_lb_svc.resources[0].status.loadBalancer.ingress | default([]) | length > 0
             fail_msg: >-
-              LB Service '{{ test_ip_name }}-lb' not found in '{{ test_vm_namespace }}' or has no IP.
+              LB Service 'osac-pip-{{ test_ip_name }}-ingress' not found in '{{ test_vm_namespace }}' or has no IP.
               Run the attach test first or run all tests together.
             success_msg: "LB Service exists with IP, proceeding with detach"
 
@@ -839,7 +839,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "{{ test_ip_name }}-lb"
+            name: "osac-pip-{{ test_ip_name }}-ingress"
             namespace: "{{ test_vm_namespace }}"
           register: lb_svc_after_detach
 
@@ -848,7 +848,7 @@
             that:
               - lb_svc_after_detach.resources | length == 0
             fail_msg: "LB Service still exists in VM namespace after detach"
-            success_msg: "LB Service '{{ test_ip_name }}-lb' correctly removed from '{{ test_vm_namespace }}'"
+            success_msg: "LB Service 'osac-pip-{{ test_ip_name }}-ingress' correctly removed from '{{ test_vm_namespace }}'"
 
         - name: Fetch ComputeInstance to verify annotation removed
           kubernetes.core.k8s_info:
@@ -872,7 +872,7 @@
           kubernetes.core.k8s_info:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
           register: parking_svc_after_detach
           retries: 60
@@ -887,7 +887,7 @@
               - parking_svc_after_detach.resources[0].spec.type == "LoadBalancer"
               - parking_svc_after_detach.resources[0].spec.selector | default({}) | length == 0
             fail_msg: "Re-created parking Service has incorrect spec after detach"
-            success_msg: "Parking Service 'osac-publicip-{{ test_ip_name }}' re-created with correct placeholder spec"
+            success_msg: "Parking Service 'osac-pip-{{ test_ip_name }}' re-created with correct placeholder spec"
 
         - name: Verify parking Service preserves the same IP
           ansible.builtin.assert:
@@ -911,7 +911,7 @@
           kubernetes.core.k8s:
             api_version: v1
             kind: Service
-            name: "osac-publicip-{{ test_ip_name }}"
+            name: "osac-pip-{{ test_ip_name }}"
             namespace: metallb-system
             state: absent
           ignore_errors: true

--- a/playbook_osac_attach_public_ip.yml
+++ b/playbook_osac_attach_public_ip.yml
@@ -5,7 +5,6 @@
 
   vars:
     public_ip: "{{ ansible_eda.event.payload }}"
-    public_ip_name: "{{ ansible_eda.event.payload.metadata.name }}"
     implementation_strategy: >-
       {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
@@ -19,7 +18,7 @@
     - name: Display PublicIP attach information
       ansible.builtin.debug:
         msg:
-          - "PublicIP name: {{ public_ip_name }}"
+          - "PublicIP id: {{ ansible_eda.event.payload.id }} name: {{ ansible_eda.event.payload.metadata.name | default(ansible_eda.event.payload.id) }}"
           - "Implementation strategy: {{ implementation_strategy }}"
 
     - name: Call the selected PublicIP attach role

--- a/playbook_osac_attach_public_ip.yml
+++ b/playbook_osac_attach_public_ip.yml
@@ -1,0 +1,28 @@
+---
+- name: Attach a PublicIP to a ComputeInstance
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    public_ip: "{{ ansible_eda.event.payload }}"
+    public_ip_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display PublicIP attach information
+      ansible.builtin.debug:
+        msg:
+          - "PublicIP name: {{ public_ip_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected PublicIP attach role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: attach_public_ip

--- a/playbook_osac_attach_public_ip.yml
+++ b/playbook_osac_attach_public_ip.yml
@@ -18,7 +18,7 @@
     - name: Display PublicIP attach information
       ansible.builtin.debug:
         msg:
-          - "PublicIP id: {{ ansible_eda.event.payload.id }} name: {{ ansible_eda.event.payload.metadata.name | default(ansible_eda.event.payload.id) }}"
+          - "PublicIP name: {{ ansible_eda.event.payload.metadata.name }}"
           - "Implementation strategy: {{ implementation_strategy }}"
 
     - name: Call the selected PublicIP attach role

--- a/playbook_osac_detach_public_ip.yml
+++ b/playbook_osac_detach_public_ip.yml
@@ -18,7 +18,7 @@
     - name: Display PublicIP detach information
       ansible.builtin.debug:
         msg:
-          - "PublicIP id: {{ ansible_eda.event.payload.id }} name: {{ ansible_eda.event.payload.metadata.name | default(ansible_eda.event.payload.id) }}"
+          - "PublicIP name: {{ ansible_eda.event.payload.metadata.name }}"
           - "Implementation strategy: {{ implementation_strategy }}"
 
     - name: Call the selected PublicIP detach role

--- a/playbook_osac_detach_public_ip.yml
+++ b/playbook_osac_detach_public_ip.yml
@@ -5,7 +5,6 @@
 
   vars:
     public_ip: "{{ ansible_eda.event.payload }}"
-    public_ip_name: "{{ ansible_eda.event.payload.metadata.name }}"
     implementation_strategy: >-
       {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
@@ -19,7 +18,7 @@
     - name: Display PublicIP detach information
       ansible.builtin.debug:
         msg:
-          - "PublicIP name: {{ public_ip_name }}"
+          - "PublicIP id: {{ ansible_eda.event.payload.id }} name: {{ ansible_eda.event.payload.metadata.name | default(ansible_eda.event.payload.id) }}"
           - "Implementation strategy: {{ implementation_strategy }}"
 
     - name: Call the selected PublicIP detach role

--- a/playbook_osac_detach_public_ip.yml
+++ b/playbook_osac_detach_public_ip.yml
@@ -1,0 +1,28 @@
+---
+- name: Detach a PublicIP from a ComputeInstance
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    public_ip: "{{ ansible_eda.event.payload }}"
+    public_ip_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display PublicIP detach information
+      ansible.builtin.debug:
+        msg:
+          - "PublicIP name: {{ public_ip_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected PublicIP detach role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: detach_public_ip

--- a/rulebooks/cluster_fulfillment.yml
+++ b/rulebooks/cluster_fulfillment.yml
@@ -77,6 +77,21 @@
           name: "{{ job_template_prefix }}-delete-public-ip"
           organization: "{{ job_template_organization }}"
 
+    - name: Attach public IP
+      condition: event.meta.endpoint == "attach-public-ip"
+      action:
+        run_job_template:
+          name: "{{ job_template_prefix }}-attach-public-ip"
+          organization: "{{ job_template_organization }}"
+
+    - name: Detach public IP
+      condition: event.meta.endpoint == "detach-public-ip"
+      action:
+        run_job_template:
+          name: "{{ job_template_prefix }}-detach-public-ip"
+          organization: "{{ job_template_organization }}"
+          organization: "{{ job_template_organization }}"
+
     - name: Create public IP pool
       condition: event.meta.endpoint == "create-public-ip-pool"
       action:

--- a/rulebooks/cluster_fulfillment.yml
+++ b/rulebooks/cluster_fulfillment.yml
@@ -90,7 +90,6 @@
         run_job_template:
           name: "{{ job_template_prefix }}-detach-public-ip"
           organization: "{{ job_template_organization }}"
-          organization: "{{ job_template_organization }}"
 
     - name: Create public IP pool
       condition: event.meta.endpoint == "create-public-ip-pool"


### PR DESCRIPTION
Implements the attach and detach flows for floating public IPs using MetalLB L2 as the implementation strategy.
Attach — moves the IP from a parking Service in metallb-system into a real LoadBalancer Service in the VM's namespace, routes traffic to the VM pod, and stamps the assigned IP onto the ComputeInstance.
Detach — reverses the process: removes the VM namespace Service, clears the IP annotation from the ComputeInstance, and parks the IP back in metallb-system so MetalLB continues holding it without routing to any VM.

Testing

-  ansible-lint passes

Note: Integration tests for attach and detach and full E2E coverage will be added once the create and delete PublicIP task changes are merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attach/detach public IP workflows to assign and release floating IPs from compute instances
  * Event-driven integration to trigger attach/detach operations via incoming webhooks

* **Tests**
  * Comprehensive end-to-end tests for attach and detach flows; new CLI switches to run attach/detach scenarios

* **Chores**
  * Service naming standardized to use the osac-pip- prefix for LoadBalancer resources
<!-- end of auto-generated comment: release notes by coderabbit.ai -->