### PR TITLE
OSAC-9: Add template for netris networking API

### DIFF
--- a/collections/ansible_collections/netris/controller/README.md
+++ b/collections/ansible_collections/netris/controller/README.md
@@ -85,18 +85,90 @@ Create or delete L4 load balancers.
 
 See `meta/argument_specs.yaml` for the full variable list.
 
-### ipam
+### vpc
 
-Query the Netris IPAM for available IPs by subnet purpose.
+Create or delete a Netris VPC (Virtual Private Cloud / VRF).
 
-**State variable:** `ipam_state` (default: `read`)
+**State variable:** `vpc_state` (`present` | `absent`)
 
 **Variables:**
-- `ipam_site_id` (required) — Netris site ID to filter subnets by
+- `vpc_name` (required) — Name of the VPC
+- `vpc_tenant_id` (required for create) — Admin tenant ID
+
+**Output:** `vpc_id`, `vpc_already_existed`
+
+**API:** `POST /api/v2/vpc` (create), `DELETE /api/v2/vpc/{id}` (delete)
+
+### vnet
+
+Create or delete a Netris V-Net (virtual network segment within a VPC).
+
+**State variable:** `vnet_state` (`present` | `absent`)
+
+**Variables:**
+- `vnet_name` (required) — Name of the V-Net
+- `vnet_vpc_id` (required for create) — Parent VPC ID
+- `vnet_site_id` (required for create) — Netris site ID
+- `vnet_tenant_id` — Owner tenant ID
+- `vnet_gateway` — Gateway CIDR (e.g. `10.0.1.1/24`), enables L3 routing
+- `vnet_vlan_id` — VLAN ID (integer, required by API)
+- `vnet_ports` — Switch ports to attach
+
+**Output:** `vnet_id`, `vnet_already_existed`
+
+**API:** `POST /api/v2/vnet` (create), `DELETE /api/v2/vnet/{id}` (delete). Uses `tenant` (singular object), `vlan` (integer).
+
+### acl
+
+Create or delete Netris ACL (Access Control List) firewall rules.
+
+**State variable:** `acl_state` (`present` | `absent`)
+
+**Variables:**
+- `acl_name` (required) — Name of the ACL rule
+- `acl_action` (default: `permit`) — `permit` or `deny`
+- `acl_proto` (default: `all`) — Protocol: `all`, `tcp`, `udp`, `icmp`, `ip`, `icmpv6`
+- `acl_vpc_id` (default: `1`) — VPC ID for the rule
+- `acl_src_prefix` — Source prefix in CIDR notation
+- `acl_dst_prefix` — Destination prefix in CIDR notation
+- `acl_src_port_from` / `acl_src_port_to` — Source port range
+- `acl_dst_port_from` / `acl_dst_port_to` — Destination port range
+- `acl_src_port_group` / `acl_dst_port_group` — Port group IDs (0 for none)
+- `acl_established` — Match established connections (0 or 1)
+- `acl_reverse` — Generate reverse rule (`yes` / `no`)
+- `acl_comment` — Comment
+
+**Output:** `acl_id`, `acl_already_existed`
+
+**API:** `POST /api/acl` (create, v1 API), `DELETE /api/acl` with `{"id": [<id>]}` (delete). Field names use snake_case: `proto`, `src_prefix`, `dst_prefix`, `src_port_from`, etc.
+
+### ipam
+
+Query, create, or delete Netris IPAM allocations and subnets.
+
+**State variable:** `ipam_state` (`read` | `create` | `delete`, default: `read`)
+
+**Read variables:**
+- `ipam_site_id` — Netris site ID to filter subnets by
 - `ipam_purpose` (default: `nat`) — Subnet purpose to filter by (e.g. `nat`, `load-balancer`)
 - `ipam_count` (default: `1`) — Number of IPs to allocate
 
-**Output:** `ipam_allocated_ips` (list of allocated IP addresses)
+**Read output:** `ipam_allocated_ips` (list of allocated IP addresses)
+
+**Create variables:**
+- `ipam_name` (required) — Name for the IPAM subnet
+- `ipam_cidr` (required) — CIDR block
+- `ipam_purpose` (required) — Subnet purpose: `common`, `load-balancer`, `nat`, `inactive`
+- `ipam_site_id` (required) — Netris site ID
+- `ipam_tenant_id` — Owner tenant ID
+- `ipam_vpc_id` — VPC to assign the subnet to
+
+**Create output:** `ipam_subnet_id`, `ipam_alloc_id`, `ipam_already_existed`
+
+**Delete variables:**
+- `ipam_name` (required) — Name of the IPAM subnet to delete (also deletes the `<name>-alloc` allocation)
+
+**API:** Create is two-step: `POST /api/v2/ipam/allocation` (parent), then `POST /api/v2/ipam/subnet` (child). Delete: `DELETE /api/v2/ipam/subnet/{id}`, then `DELETE /api/v2/ipam/allocation/{id}`.
 
 ## Common Variables
 

--- a/collections/ansible_collections/netris/controller/roles/acl/defaults/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/acl/defaults/main.yaml
@@ -1,0 +1,4 @@
+---
+acl_state: present
+acl_action: permit
+acl_proto: all

--- a/collections/ansible_collections/netris/controller/roles/acl/meta/argument_specs.yaml
+++ b/collections/ansible_collections/netris/controller/roles/acl/meta/argument_specs.yaml
@@ -1,0 +1,76 @@
+---
+argument_specs:
+  main:
+    options:
+      acl_state:
+        type: str
+        choices: [present, absent]
+        default: present
+        description: "Whether to create or delete the ACL rule."
+
+  create:
+    options:
+      acl_name:
+        type: str
+        required: true
+        description: "Name of the ACL rule."
+      acl_action:
+        type: str
+        choices: [permit, deny]
+        default: permit
+        description: "ACL action: permit or deny traffic."
+      acl_proto:
+        type: str
+        default: all
+        description: "Protocol: all, tcp, udp, icmp, ip, icmpv6."
+      acl_vpc_id:
+        type: int
+        default: 1
+        description: "VPC ID for the ACL rule."
+      acl_src_prefix:
+        type: str
+        default: "0.0.0.0/0"
+        description: "Source prefix in CIDR notation."
+      acl_dst_prefix:
+        type: str
+        default: "0.0.0.0/0"
+        description: "Destination prefix in CIDR notation."
+      acl_src_port_from:
+        type: int
+        description: "Source port range start."
+      acl_src_port_to:
+        type: int
+        description: "Source port range end."
+      acl_dst_port_from:
+        type: int
+        description: "Destination port range start."
+      acl_dst_port_to:
+        type: int
+        description: "Destination port range end."
+      acl_src_port_group:
+        type: int
+        default: 0
+        description: "Source port group ID (0 for none)."
+      acl_dst_port_group:
+        type: int
+        default: 0
+        description: "Destination port group ID (0 for none)."
+      acl_established:
+        type: int
+        default: 0
+        description: "Match established connections (0 or 1)."
+      acl_reverse:
+        type: str
+        default: "no"
+        description: "Generate reverse rule (yes/no)."
+      acl_comment:
+        type: str
+        default: ""
+        description: "Comment for the ACL rule."
+
+  delete:
+    options:
+      acl_name:
+        type: str
+        required: true
+        description: "Name of the ACL rule to delete."

--- a/collections/ansible_collections/netris/controller/roles/acl/tasks/create.yaml
+++ b/collections/ansible_collections/netris/controller/roles/acl/tasks/create.yaml
@@ -1,0 +1,92 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Build ACL rule body
+  ansible.builtin.set_fact:
+    _acl_body:
+      name: "{{ acl_name }}"
+      action: "{{ acl_action }}"
+      proto: "{{ acl_proto }}"
+      vpc:
+        id: "{{ acl_vpc_id | default(1) | int }}"
+      src_prefix: "{{ acl_src_prefix | default('0.0.0.0/0') }}"
+      dst_prefix: "{{ acl_dst_prefix | default('0.0.0.0/0') }}"
+      src_port_from: "{{ acl_src_port_from | default('1') | string }}"
+      src_port_to: "{{ acl_src_port_to | default('65535') | string }}"
+      src_port_group: 0
+      dst_port_from: "{{ acl_dst_port_from | default('1') | string }}"
+      dst_port_to: "{{ acl_dst_port_to | default('65535') | string }}"
+      dst_port_group: 0
+      icmp_type: "{{ acl_icmp_type | default(1) }}"
+      established: "{{ acl_established | default(1) }}"
+      reverse: "{{ acl_reverse | default('yes') }}"
+      comment: "{{ acl_comment | default('') }}"
+      valid_until: null
+
+- name: Display ACL rule body
+  ansible.builtin.debug:
+    var: _acl_body
+
+- name: Get existing ACL rules
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/acl"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _acl_list_resp
+  no_log: true
+
+- name: Find ACL rule by name
+  ansible.builtin.set_fact:
+    _existing_acl: "{{ (_acl_list_resp.json.data | default([])) | selectattr('name', 'equalto', acl_name) | list | first | default(none) }}"
+  when: _acl_list_resp.json is mapping
+
+- name: Set ACL facts from existing rule (skip creation)
+  ansible.builtin.set_fact:
+    acl_id: "{{ _existing_acl.id }}"
+    acl_already_existed: true
+  when: _existing_acl is defined and _existing_acl is not none
+
+- name: Create ACL rule
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/acl"
+    method: POST
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+      Content-Type: "application/json"
+    body_format: json
+    body: "{{ _acl_body }}"
+    return_content: true
+    status_code: [200, 201, 400, 500]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _acl_create_resp
+  when: _existing_acl is not defined or _existing_acl is none
+  no_log: true
+
+- name: Display ACL creation error
+  when:
+    - _acl_create_resp is defined
+    - _acl_create_resp is not skipped
+    - (_acl_create_resp.status | default(200)) not in [200, 201]
+  ansible.builtin.fail:
+    msg: >-
+      Failed to create ACL rule '{{ acl_name }}'.
+      Netris responded with status {{ _acl_create_resp.status }}: {{ _acl_create_resp.json.message | default(_acl_create_resp.content | default('unknown error')) }}
+
+- name: Set ACL facts from create response
+  ansible.builtin.set_fact:
+    acl_id: "{{ _acl_create_resp.json.data.id | default(_acl_create_resp.json.data) }}"
+    acl_already_existed: false
+  when:
+    - _existing_acl is not defined or _existing_acl is none
+    - _acl_create_resp is not skipped
+    - _acl_create_resp is changed or (_acl_create_resp.status | default(0)) in [200, 201]
+    - _acl_create_resp.json is mapping

--- a/collections/ansible_collections/netris/controller/roles/acl/tasks/delete.yaml
+++ b/collections/ansible_collections/netris/controller/roles/acl/tasks/delete.yaml
@@ -1,0 +1,40 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Get existing ACL rules
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/acl"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _acl_list_resp
+  no_log: true
+
+- name: Find ACL rule by name
+  ansible.builtin.set_fact:
+    _existing_acl: "{{ (_acl_list_resp.json.data | default([])) | selectattr('name', 'equalto', acl_name) | list | first | default(none) }}"
+  when: _acl_list_resp.json is mapping
+
+- name: Delete ACL rule
+  when: _existing_acl is defined and _existing_acl is not none
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/acl"
+    method: DELETE
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      id:
+        - "{{ _existing_acl.id }}"
+    status_code: [200, 204]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  no_log: true

--- a/collections/ansible_collections/netris/controller/roles/ipam/meta/argument_specs.yaml
+++ b/collections/ansible_collections/netris/controller/roles/ipam/meta/argument_specs.yaml
@@ -4,22 +4,55 @@ argument_specs:
     options:
       ipam_state:
         type: str
-        choices: [read]
+        choices: [read, create, delete]
         default: read
         description: "IPAM operation to perform."
 
   read:
     options:
-      ipam_site_id:
-        type: int
-        required: true
-        description: "Netris site ID to filter subnets by."
       ipam_purpose:
         type: str
-        default: nat
+        required: true
         description: "Subnet purpose to filter by."
         choices: [nat, load-balancer, common]
       ipam_count:
         type: int
         default: 1
         description: "Number of IPs to allocate. Must be >= 1."
+      ipam_site_id:
+        type: int
+        description: "Netris site ID to filter subnets by."
+
+  create:
+    options:
+      ipam_name:
+        type: str
+        required: true
+        description: "Name of the IPAM subnet."
+      ipam_cidr:
+        type: str
+        required: true
+        description: "CIDR prefix for the subnet (e.g. 198.51.100.0/28)."
+      ipam_purpose:
+        type: str
+        required: true
+        description: "Subnet purpose."
+        choices: [nat, load-balancer, common]
+      ipam_site_id:
+        type: int
+        required: true
+        description: "Netris site ID."
+      ipam_tenant_id:
+        type: int
+        required: true
+        description: "Netris tenant ID."
+      ipam_vpc_id:
+        type: int
+        description: "Netris VPC ID. Added to request body when defined."
+
+  delete:
+    options:
+      ipam_name:
+        type: str
+        required: true
+        description: "Name of the IPAM subnet to delete."

--- a/collections/ansible_collections/netris/controller/roles/ipam/tasks/create_allocation.yaml
+++ b/collections/ansible_collections/netris/controller/roles/ipam/tasks/create_allocation.yaml
@@ -1,0 +1,71 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Query existing IPAM tree
+  ansible.builtin.uri:
+    url: >-
+      {{ netris_controller_url }}/api/v2/ipam{{
+        ('?filterByVpc=' + (ipam_vpc_id | string)) if ipam_vpc_id is defined else ''
+      }}
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: [200]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _ipam_tree_resp
+  no_log: true
+
+- name: Find existing allocation by name
+  ansible.builtin.set_fact:
+    _existing_ipam_alloc: >-
+      {{ (_ipam_tree_resp.json.data | default([]))
+         | selectattr('name', 'equalto', ipam_name)
+         | list | first | default(none) }}
+  when: _ipam_tree_resp.json is mapping
+
+- name: Set IPAM facts from existing allocation (skip creation)
+  ansible.builtin.set_fact:
+    ipam_alloc_id: "{{ _existing_ipam_alloc.id }}"
+    ipam_already_existed: true
+  when: _existing_ipam_alloc is defined and _existing_ipam_alloc is not none
+
+- name: Create IPAM allocation
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/ipam/allocation"
+    method: POST
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+      Content-Type: "application/json"
+    body_format: json
+    body: >-
+      {{
+        {
+          'name': ipam_name,
+          'prefix': ipam_cidr,
+          'tenant': {'id': ipam_tenant_id | int}
+        }
+        | combine(
+            ({'vpc': {'id': ipam_vpc_id | int}} if ipam_vpc_id is defined else {})
+          )
+      }}
+    return_content: true
+    status_code: [200, 201]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _ipam_alloc_resp
+  when: _existing_ipam_alloc is not defined or _existing_ipam_alloc is none
+  no_log: true
+
+- name: Set IPAM allocation facts from response
+  ansible.builtin.set_fact:
+    ipam_alloc_id: "{{ _ipam_alloc_resp.json.data.id }}"
+    ipam_already_existed: false
+  when:
+    - _existing_ipam_alloc is not defined or _existing_ipam_alloc is none
+    - _ipam_alloc_resp is not skipped
+    - _ipam_alloc_resp.json is mapping

--- a/collections/ansible_collections/netris/controller/roles/ipam/tasks/create_subnet.yaml
+++ b/collections/ansible_collections/netris/controller/roles/ipam/tasks/create_subnet.yaml
@@ -1,0 +1,70 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Query existing IPAM subnets
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/ipam/subnets"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: [200]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _ipam_subnets_resp
+  no_log: true
+
+- name: Find IPAM subnet by name
+  ansible.builtin.set_fact:
+    _existing_ipam_subnet: >-
+      {{ (_ipam_subnets_resp.json.data | default([]))
+         | selectattr('name', 'equalto', ipam_name)
+         | list | first | default(none) }}
+
+- name: Set IPAM facts from existing subnet (skip creation)
+  ansible.builtin.set_fact:
+    ipam_subnet_id: "{{ _existing_ipam_subnet.id }}"
+    ipam_already_existed: true
+  when: _existing_ipam_subnet is not none
+
+- name: Create IPAM subnet
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/ipam/subnet"
+    method: POST
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+      Content-Type: "application/json"
+    body_format: json
+    body: >-
+      {{
+        {
+          'name': ipam_name,
+          'prefix': ipam_cidr,
+          'purpose': ipam_purpose,
+          'sites': [{'id': ipam_site_id | int}],
+          'tenant': {'id': ipam_tenant_id | int}
+        }
+        | combine(
+            ({'vpc': {'id': ipam_vpc_id | int}} if ipam_vpc_id is defined else {})
+          )
+      }}
+    return_content: true
+    status_code: [200, 201]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _ipam_create_resp
+  when: _existing_ipam_subnet is none
+  no_log: true
+
+- name: Set IPAM facts from create response
+  ansible.builtin.set_fact:
+    ipam_subnet_id: "{{ _ipam_create_resp.json.data.id | default(_ipam_create_resp.json.data) }}"
+    ipam_already_existed: false
+  when:
+    - _existing_ipam_subnet is none
+    - _ipam_create_resp is not skipped
+    - _ipam_create_resp is changed or (_ipam_create_resp.status | default(0)) in [200, 201]
+    - _ipam_create_resp.json is mapping

--- a/collections/ansible_collections/netris/controller/roles/ipam/tasks/delete_allocation.yaml
+++ b/collections/ansible_collections/netris/controller/roles/ipam/tasks/delete_allocation.yaml
@@ -1,0 +1,53 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Query IPAM tree
+  ansible.builtin.uri:
+    url: >-
+      {{ netris_controller_url }}/api/v2/ipam{{
+        ('?filterByVpc=' + (ipam_vpc_id | string)) if ipam_vpc_id is defined else ''
+      }}
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: [200]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _ipam_tree_resp
+  no_log: true
+
+- name: Find allocation by name
+  ansible.builtin.set_fact:
+    _existing_ipam_alloc: >-
+      {{ (_ipam_tree_resp.json.data | default([]))
+         | selectattr('name', 'equalto', ipam_name)
+         | list | first | default(none) }}
+  when: _ipam_tree_resp.json is mapping
+
+- name: Delete IPAM allocation
+  when: _existing_ipam_alloc is defined and _existing_ipam_alloc is not none
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/ipam/allocation/{{ _existing_ipam_alloc.id }}"
+    method: DELETE
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: [200, 204, 400]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _ipam_alloc_delete_resp
+  no_log: true
+
+- name: Fail if IPAM allocation deletion returned an error
+  when:
+    - _ipam_alloc_delete_resp is defined
+    - _ipam_alloc_delete_resp.status | default(200) == 400
+  ansible.builtin.fail:
+    msg: >-
+      Failed to delete IPAM allocation '{{ ipam_name }}' (ID: {{ _existing_ipam_alloc.id }}).
+      Netris responded with: {{ _ipam_alloc_delete_resp.json.message | default(_ipam_alloc_delete_resp.content | default('unknown error')) }}.
+      This usually means the allocation still has child subnets that must be deleted first.

--- a/collections/ansible_collections/netris/controller/roles/ipam/tasks/delete_subnet.yaml
+++ b/collections/ansible_collections/netris/controller/roles/ipam/tasks/delete_subnet.yaml
@@ -1,0 +1,48 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Query existing IPAM subnets
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/ipam/subnets"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: [200]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _ipam_subnets_resp
+  no_log: true
+
+- name: Find IPAM subnet by name
+  ansible.builtin.set_fact:
+    _existing_ipam_subnet: >-
+      {{ (_ipam_subnets_resp.json.data | default([]))
+         | selectattr('name', 'equalto', ipam_name)
+         | list | first | default(none) }}
+
+- name: Delete IPAM subnet
+  when: _existing_ipam_subnet is not none
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/ipam/subnet/{{ _existing_ipam_subnet.id }}"
+    method: DELETE
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: [200, 204, 400]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _ipam_subnet_delete_resp
+  no_log: true
+
+- name: Fail if IPAM subnet deletion returned an error
+  when:
+    - _ipam_subnet_delete_resp is defined
+    - _ipam_subnet_delete_resp.status | default(200) == 400
+  ansible.builtin.fail:
+    msg: >-
+      Failed to delete IPAM subnet '{{ ipam_name }}' (ID: {{ _existing_ipam_subnet.id }}).
+      Netris responded with: {{ _ipam_subnet_delete_resp.json.message | default(_ipam_subnet_delete_resp.content | default('unknown error')) }}.

--- a/collections/ansible_collections/netris/controller/roles/ipam/tasks/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/ipam/tasks/main.yaml
@@ -2,3 +2,19 @@
 - name: Read IPAM for available IPs
   ansible.builtin.include_tasks: read.yaml
   when: ipam_state == 'read'
+
+- name: Create IPAM allocation
+  ansible.builtin.include_tasks: create_allocation.yaml
+  when: ipam_state == 'create_allocation'
+
+- name: Create IPAM subnet
+  ansible.builtin.include_tasks: create_subnet.yaml
+  when: ipam_state == 'create_subnet'
+
+- name: Delete IPAM allocation
+  ansible.builtin.include_tasks: delete_allocation.yaml
+  when: ipam_state == 'delete_allocation'
+
+- name: Delete IPAM subnet
+  ansible.builtin.include_tasks: delete_subnet.yaml
+  when: ipam_state == 'delete_subnet'

--- a/collections/ansible_collections/netris/controller/roles/vnet/defaults/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/vnet/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+vnet_state: present
+vnet_vlan_id: auto

--- a/collections/ansible_collections/netris/controller/roles/vnet/meta/argument_specs.yaml
+++ b/collections/ansible_collections/netris/controller/roles/vnet/meta/argument_specs.yaml
@@ -1,0 +1,45 @@
+---
+argument_specs:
+  main:
+    options:
+      vnet_state:
+        type: str
+        choices: [present, absent]
+        default: present
+        description: "Whether to create or delete the V-Net."
+
+  create:
+    options:
+      vnet_name:
+        type: str
+        required: true
+        description: "Name of the V-Net."
+      vnet_vpc_id:
+        type: int
+        required: true
+        description: "Netris VPC ID the V-Net belongs to."
+      vnet_site_id:
+        type: int
+        required: true
+        description: "Netris site ID."
+      vnet_tenant_id:
+        type: int
+        description: "Netris tenant ID."
+      vnet_gateway:
+        type: str
+        description: "Gateway prefix (e.g. 10.0.0.1/24). Added to gateways list when defined."
+      vnet_vlan_id:
+        type: str
+        default: auto
+        description: "VLAN ID or 'auto' for automatic assignment."
+      vnet_ports:
+        type: list
+        elements: dict
+        description: "List of port objects to attach to the V-Net."
+
+  delete:
+    options:
+      vnet_name:
+        type: str
+        required: true
+        description: "Name of the V-Net to delete."

--- a/collections/ansible_collections/netris/controller/roles/vnet/tasks/create.yaml
+++ b/collections/ansible_collections/netris/controller/roles/vnet/tasks/create.yaml
@@ -1,0 +1,93 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Get existing V-Nets
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/vnet"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _vnet_list_resp
+  no_log: true
+
+- name: Find V-Net by name
+  ansible.builtin.set_fact:
+    _existing_vnet: >-
+      {{ (_vnet_list_resp.json.data | default([]))
+         | selectattr('name', 'equalto', vnet_name)
+         | list | first | default(none) }}
+  when: _vnet_list_resp.json is mapping
+
+- name: Set V-Net facts from existing V-Net (skip creation)
+  ansible.builtin.set_fact:
+    vnet_id: "{{ _existing_vnet.id }}"
+    vnet_already_existed: true
+  when: _existing_vnet is defined and _existing_vnet is not none
+
+- name: Build V-Net body
+  ansible.builtin.set_fact:
+    _vnet_body:
+      name: "{{ vnet_name }}"
+      vpc:
+        id: "{{ vnet_vpc_id }}"
+      sites:
+        - id: "{{ vnet_site_id }}"
+      state: active
+      vlan: "{{ vnet_vlan_id | default('auto') }}"
+      tenant:
+        id: "{{ vnet_tenant_id }}"
+  when: _existing_vnet is not defined or _existing_vnet is none
+
+- name: Add gateway to V-Net body
+  ansible.builtin.set_fact:
+    _vnet_body: >-
+      {{ _vnet_body | combine({
+        'gateways': [{'prefix': vnet_gateway}]
+      }) }}
+  when:
+    - _existing_vnet is not defined or _existing_vnet is none
+    - vnet_gateway is defined
+
+- name: Add ports to V-Net body
+  ansible.builtin.set_fact:
+    _vnet_body: >-
+      {{ _vnet_body | combine({
+        'ports': vnet_ports
+      }) }}
+  when:
+    - _existing_vnet is not defined or _existing_vnet is none
+    - vnet_ports is defined
+
+- name: Create V-Net
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/vnet"
+    method: POST
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+      Content-Type: "application/json"
+    body_format: json
+    body: "{{ _vnet_body }}"
+    return_content: true
+    status_code: [200, 201]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _vnet_create_resp
+  when: _existing_vnet is not defined or _existing_vnet is none
+  no_log: true
+
+- name: Set V-Net facts from create response
+  ansible.builtin.set_fact:
+    vnet_id: "{{ _vnet_create_resp.json.data.id | default(_vnet_create_resp.json.data) }}"
+    vnet_already_existed: false
+  when:
+    - _existing_vnet is not defined or _existing_vnet is none
+    - _vnet_create_resp is not skipped
+    - _vnet_create_resp is changed or (_vnet_create_resp.status | default(0)) in [200, 201]
+    - _vnet_create_resp.json is mapping

--- a/collections/ansible_collections/netris/controller/roles/vnet/tasks/delete.yaml
+++ b/collections/ansible_collections/netris/controller/roles/vnet/tasks/delete.yaml
@@ -1,0 +1,36 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Get existing V-Nets
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/vnet"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _vnet_list_resp
+  no_log: true
+
+- name: Find V-Net by name
+  ansible.builtin.set_fact:
+    _existing_vnet: >-
+      {{ (_vnet_list_resp.json.data | default([]))
+         | selectattr('name', 'equalto', vnet_name)
+         | list | first | default(none) }}
+  when: _vnet_list_resp.json is mapping
+
+- name: Delete V-Net
+  when: _existing_vnet is defined and _existing_vnet is not none
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/vnet/{{ _existing_vnet.id }}"
+    method: DELETE
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    status_code: [200, 204]
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  no_log: true

--- a/collections/ansible_collections/netris/controller/roles/vpc/defaults/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/vpc/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-vpc_state: absent
+vpc_state: present

--- a/collections/ansible_collections/netris/controller/roles/vpc/meta/argument_specs.yaml
+++ b/collections/ansible_collections/netris/controller/roles/vpc/meta/argument_specs.yaml
@@ -4,9 +4,24 @@ argument_specs:
     options:
       vpc_state:
         type: str
-        choices: [absent]
-        default: absent
-        description: "Whether to delete the VPC."
+        choices: [present, absent]
+        default: present
+        description: "Whether to create or delete the VPC."
+
+  create:
+    options:
+      vpc_name:
+        type: str
+        required: true
+        description: "Name of the VPC."
+      vpc_site_id:
+        type: int
+        required: true
+        description: "Netris site ID."
+      vpc_tenant_id:
+        type: int
+        required: true
+        description: "Netris tenant ID (admin)."
 
   delete:
     options:

--- a/collections/ansible_collections/netris/controller/roles/vpc/tasks/create.yaml
+++ b/collections/ansible_collections/netris/controller/roles/vpc/tasks/create.yaml
@@ -1,0 +1,59 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Get existing VPCs
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/vpc"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _vpc_list_resp
+  no_log: true
+
+- name: Find VPC by name
+  ansible.builtin.set_fact:
+    _existing_vpc: "{{ (_vpc_list_resp.json.data | default([])) | selectattr('name', 'equalto', vpc_name) | list | first | default(none) }}"
+  when: _vpc_list_resp.json is mapping
+
+- name: Set VPC facts from existing VPC (skip creation)
+  ansible.builtin.set_fact:
+    vpc_id: "{{ _existing_vpc.id }}"
+    vpc_already_existed: true
+  when: _existing_vpc is defined and _existing_vpc is not none
+
+- name: Create VPC
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/vpc"
+    method: POST
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      name: "{{ vpc_name }}"
+      adminTenant:
+        id: "{{ vpc_tenant_id }}"
+    return_content: true
+    status_code: [200, 201]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _vpc_create_resp
+  when: _existing_vpc is not defined or _existing_vpc is none
+  no_log: true
+
+- name: Set VPC facts from create response
+  ansible.builtin.set_fact:
+    vpc_id: "{{ _vpc_create_resp.json.data.id | default(_vpc_create_resp.json.data) }}"
+    vpc_already_existed: false
+  when:
+    - _existing_vpc is not defined or _existing_vpc is none
+    - _vpc_create_resp is not skipped
+    - _vpc_create_resp is changed or (_vpc_create_resp.status | default(0)) in [200, 201]
+    - _vpc_create_resp.json is mapping

--- a/collections/ansible_collections/netris/controller/roles/vpc/tasks/delete.yaml
+++ b/collections/ansible_collections/netris/controller/roles/vpc/tasks/delete.yaml
@@ -28,6 +28,18 @@
     method: DELETE
     headers:
       Cookie: "connect.sid={{ netris_session_cookie }}"
-    status_code: [200, 204]
+    return_content: true
+    status_code: [200, 204, 400]
     validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _vpc_delete_resp
   no_log: true
+
+- name: Fail if VPC deletion returned an error
+  when:
+    - _vpc_delete_resp is defined
+    - _vpc_delete_resp.status | default(200) == 400
+  ansible.builtin.fail:
+    msg: >-
+      Failed to delete VPC '{{ vpc_name }}' (ID: {{ _existing_vpc.id }}).
+      Netris responded with: {{ _vpc_delete_resp.json.message | default(_vpc_delete_resp.content | default('unknown error')) }}.
+      This usually means the VPC still has dependent resources (V-Nets, IPAM allocations, etc.).

--- a/collections/ansible_collections/netris/controller/roles/vpc/tasks/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/vpc/tasks/main.yaml
@@ -1,4 +1,8 @@
 ---
+- name: Create VPC
+  when: vpc_state == 'present'
+  ansible.builtin.include_tasks: create.yaml
+
 - name: Delete VPC
   when: vpc_state == 'absent'
   ansible.builtin.include_tasks: delete.yaml

--- a/collections/ansible_collections/netris/controller/roles/vpc/tests/test.yml
+++ b/collections/ansible_collections/netris/controller/roles/vpc/tests/test.yml
@@ -1,0 +1,157 @@
+---
+# Test playbook for netris.controller.vpc role.
+#
+# Tests create and delete of Netris VPC resources:
+#   - Create VPC with idempotency check (create twice, assert same ID)
+#   - Delete VPC with not-found tolerance (delete twice, no failure)
+#
+# Requires a running Netris controller with valid credentials.
+#
+# Environment variables:
+#   NETRIS_CONTROLLER_URL  - Netris controller URL (e.g. https://netris.example.com)
+#   NETRIS_USERNAME        - Netris username
+#   NETRIS_PASSWORD        - Netris password
+#   NETRIS_SITE_ID         - Netris site ID (integer)
+#   NETRIS_TENANT_ID       - Netris tenant ID (integer)
+#
+# Usage:
+#   # Run all tests in sequence
+#   ansible-playbook test.yml -v
+#
+#   # Run only create tests
+#   ansible-playbook test.yml -e run_create=true -e run_delete=false \
+#     -e run_delete_not_found=false -v
+#
+#   # Run only delete tests (VPC must already exist)
+#   ansible-playbook test.yml -e run_create=false -e run_delete=true \
+#     -e run_delete_not_found=false -v
+
+# ──────────────────────────────────────────────────────────────
+# Pre-flight: validate required environment variables
+# ──────────────────────────────────────────────────────────────
+- name: Validate VPC test environment
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Fail if required environment variables are missing
+      ansible.builtin.fail:
+        msg: >-
+          Missing required environment variable: {{ item }}.
+          Set NETRIS_CONTROLLER_URL, NETRIS_USERNAME, NETRIS_PASSWORD,
+          NETRIS_SITE_ID, and NETRIS_TENANT_ID before running tests.
+      when: lookup('env', item) | length == 0
+      loop:
+        - NETRIS_CONTROLLER_URL
+        - NETRIS_USERNAME
+        - NETRIS_PASSWORD
+        - NETRIS_SITE_ID
+        - NETRIS_TENANT_ID
+
+# ──────────────────────────────────────────────────────────────
+# Test: Create VPC with idempotency
+# Expected: VPC created on first call, same ID returned on second
+#   call with vpc_already_existed=true.
+# ──────────────────────────────────────────────────────────────
+- name: Test netris.controller.vpc -- create VPC with idempotency
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    test_vpc_name: "test-osac-vpc"
+    netris_controller_url: "{{ lookup('env', 'NETRIS_CONTROLLER_URL') }}"
+    netris_username: "{{ lookup('env', 'NETRIS_USERNAME') }}"
+    netris_password: "{{ lookup('env', 'NETRIS_PASSWORD') }}"
+    vpc_name: "{{ test_vpc_name }}"
+    vpc_site_id: "{{ lookup('env', 'NETRIS_SITE_ID') | int }}"
+    vpc_tenant_id: "{{ lookup('env', 'NETRIS_TENANT_ID') | int }}"
+
+  tasks:
+    - name: Run create tests
+      when: run_create | default(true) | bool
+      block:
+        - name: Create VPC (first call)
+          ansible.builtin.include_role:
+            name: netris.controller.vpc
+            tasks_from: create
+
+        - name: Save VPC ID from first create
+          ansible.builtin.set_fact:
+            _first_vpc_id: "{{ vpc_id }}"
+
+        - name: Assert VPC was newly created
+          ansible.builtin.assert:
+            that:
+              - vpc_id is defined
+              - vpc_id | int > 0
+              - vpc_already_existed == false
+            fail_msg: "VPC was not created correctly on first call"
+            success_msg: "VPC '{{ test_vpc_name }}' created with ID {{ vpc_id }}"
+
+        - name: Create VPC (second call -- idempotency check)
+          ansible.builtin.include_role:
+            name: netris.controller.vpc
+            tasks_from: create
+
+        - name: Assert idempotent create returned same ID
+          ansible.builtin.assert:
+            that:
+              - vpc_id == _first_vpc_id
+              - vpc_already_existed == true
+            fail_msg: "Idempotent create returned different ID or did not detect existing VPC"
+            success_msg: "Idempotent create correctly returned existing VPC ID {{ vpc_id }}"
+
+# ──────────────────────────────────────────────────────────────
+# Test: Delete VPC
+# Expected: VPC deleted successfully.
+# ──────────────────────────────────────────────────────────────
+- name: Test netris.controller.vpc -- delete VPC
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    test_vpc_name: "test-osac-vpc"
+    netris_controller_url: "{{ lookup('env', 'NETRIS_CONTROLLER_URL') }}"
+    netris_username: "{{ lookup('env', 'NETRIS_USERNAME') }}"
+    netris_password: "{{ lookup('env', 'NETRIS_PASSWORD') }}"
+    vpc_name: "{{ test_vpc_name }}"
+
+  tasks:
+    - name: Run delete tests
+      when: run_delete | default(true) | bool
+      block:
+        - name: Delete VPC
+          ansible.builtin.include_role:
+            name: netris.controller.vpc
+            tasks_from: delete
+
+        - name: Confirm VPC deleted
+          ansible.builtin.debug:
+            msg: "VPC '{{ test_vpc_name }}' successfully deleted"
+
+# ──────────────────────────────────────────────────────────────
+# Test: Delete VPC when already gone (NotFound handling)
+# Expected: No failure. The role tolerates already-deleted VPCs.
+# ──────────────────────────────────────────────────────────────
+- name: Test netris.controller.vpc -- delete tolerates NotFound
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    test_vpc_name: "test-osac-vpc"
+    netris_controller_url: "{{ lookup('env', 'NETRIS_CONTROLLER_URL') }}"
+    netris_username: "{{ lookup('env', 'NETRIS_USERNAME') }}"
+    netris_password: "{{ lookup('env', 'NETRIS_PASSWORD') }}"
+    vpc_name: "{{ test_vpc_name }}"
+
+  tasks:
+    - name: Run delete-not-found test
+      when: run_delete_not_found | default(true) | bool
+      block:
+        - name: Delete already-gone VPC (should not fail)
+          ansible.builtin.include_role:
+            name: netris.controller.vpc
+            tasks_from: delete
+
+        - name: Confirm no failure occurred
+          ansible.builtin.debug:
+            msg: "Delete-not-found test passed: role tolerated already-deleted VPC"

--- a/collections/ansible_collections/osac/templates/roles/netris/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+default_vnet_vlan_id: auto
+default_ipam_purpose_public: nat

--- a/collections/ansible_collections/osac/templates/roles/netris/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/meta/argument_specs.yaml
@@ -1,0 +1,96 @@
+---
+argument_specs:
+  create_virtual_network:
+    options:
+      virtual_network:
+        type: dict
+        required: true
+        description: VirtualNetwork CR from fulfillment-api via EDA payload
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}
+
+  delete_virtual_network:
+    options:
+      virtual_network:
+        type: dict
+        required: true
+        description: VirtualNetwork CR from fulfillment-api via EDA payload
+
+  create_subnet:
+    options:
+      subnet:
+        type: dict
+        required: true
+        description: Subnet CR from fulfillment-api via EDA payload
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}
+
+  delete_subnet:
+    options:
+      subnet:
+        type: dict
+        required: true
+        description: Subnet CR from fulfillment-api via EDA payload
+
+  create_security_group:
+    options:
+      security_group:
+        type: dict
+        required: true
+        description: SecurityGroup CR from fulfillment-api via EDA payload
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}
+
+  delete_security_group:
+    options:
+      security_group:
+        type: dict
+        required: true
+        description: SecurityGroup CR from fulfillment-api via EDA payload
+
+  create_public_ip_pool:
+    options:
+      public_ip_pool:
+        type: dict
+        required: true
+        description: PublicIPPool CR from fulfillment-api via EDA payload
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}
+
+  delete_public_ip_pool:
+    options:
+      public_ip_pool:
+        type: dict
+        required: true
+        description: PublicIPPool CR from fulfillment-api via EDA payload
+
+  create_public_ip:
+    options:
+      public_ip:
+        type: dict
+        required: true
+        description: PublicIP CR from fulfillment-api via EDA payload
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}
+
+  delete_public_ip:
+    options:
+      public_ip:
+        type: dict
+        required: true
+        description: PublicIP CR from fulfillment-api via EDA payload

--- a/collections/ansible_collections/osac/templates/roles/netris/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/meta/osac.yaml
@@ -1,0 +1,15 @@
+---
+title: Netris Network Implementation
+description: >
+  Provisions networking resources using Netris Controller API.
+  Maps VirtualNetwork to VPC, Subnet to V-Net (L2VPN),
+  SecurityGroup to ACL.
+
+template_type: network
+
+# NetworkClass registration fields
+implementation_strategy: netris
+capabilities:
+  supports_ipv4: true
+  supports_ipv6: false
+  supports_dual_stack: false

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_security_group.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_security_group.yaml
@@ -1,0 +1,106 @@
+---
+# SecurityGroup maps to Netris ACL rules (v1 API)
+# Creates permit ACL rules for each ingress and egress rule in the SecurityGroup CR
+
+- name: Extract SecurityGroup configuration
+  ansible.builtin.set_fact:
+    sg_name: "{{ security_group.metadata.name }}"
+    sg_virtual_network: "{{ security_group.spec.virtualNetwork | default('') }}"
+    ingress_rules: "{{ security_group.spec.ingressRules | default([]) }}"
+    egress_rules: "{{ security_group.spec.egressRules | default([]) }}"
+
+- name: Display SecurityGroup information
+  ansible.builtin.debug:
+    msg:
+      - "Creating Netris ACL rules for SecurityGroup '{{ sg_name }}'"
+      - "VirtualNetwork: {{ sg_virtual_network }}"
+      - "Ingress rules count: {{ ingress_rules | length }}"
+      - "Egress rules count: {{ egress_rules | length }}"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Look up VPC for VirtualNetwork
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/vpc"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _sg_vpc_list_resp
+  no_log: true
+  when: sg_virtual_network | length > 0
+
+- name: Resolve VirtualNetwork UUID to VPC ID
+  when: sg_virtual_network | length > 0
+  block:
+    - name: Look up VirtualNetwork CR by UUID label
+      kubernetes.core.k8s_info:
+        api_version: osac.openshift.io/v1alpha1
+        kind: VirtualNetwork
+        namespace: "{{ security_group.metadata.namespace }}"
+        label_selectors:
+          - "osac.openshift.io/virtualnetwork-uuid={{ sg_virtual_network }}"
+      register: _sg_vn_lookup
+
+    - name: Set VPC ID and VN CIDR from VirtualNetwork
+      ansible.builtin.set_fact:
+        _sg_vpc_id: >-
+          {{ ((_sg_vpc_list_resp.json.data | default([]))
+              | selectattr('name', 'equalto', _sg_vn_lookup.resources[0].metadata.name)
+              | map(attribute='id') | list | first | default(1)) }}
+        _sg_vn_cidr: "{{ _sg_vn_lookup.resources[0].spec.ipv4Cidr | default('') }}"
+      when: _sg_vn_lookup.resources | length > 0
+
+- name: Default VPC ID and VN CIDR if not resolved
+  ansible.builtin.set_fact:
+    _sg_vpc_id: "{{ _sg_vpc_id | default(1) }}"
+    _sg_vn_cidr: "{{ _sg_vn_cidr | default('') }}"
+
+- name: Create ACL rules for ingress
+  ansible.builtin.include_role:
+    name: netris.controller.acl
+    tasks_from: create
+  vars:
+    acl_name: "{{ sg_name }}-ingress-{{ idx }}"
+    acl_action: permit
+    acl_proto: "{{ item.protocol }}"
+    acl_vpc_id: "{{ _sg_vpc_id }}"
+    acl_src_prefix: "{{ item.sourceCidr | default(item.ipv4Cidr | default('0.0.0.0/0')) }}"
+    acl_dst_prefix: "{{ item.destinationCidr | default(_sg_vn_cidr if _sg_vn_cidr | length > 0 else '0.0.0.0/0') }}"
+    acl_dst_port_from: "{{ item.portFrom | default(none) }}"
+    acl_dst_port_to: "{{ item.portTo | default(item.portFrom) | default(none) }}"
+    acl_comment: "OSAC SG {{ sg_name }} ingress rule {{ idx }}"
+  loop: "{{ ingress_rules }}"
+  loop_control:
+    index_var: idx
+  when: ingress_rules | length > 0
+
+- name: Create ACL rules for egress
+  ansible.builtin.include_role:
+    name: netris.controller.acl
+    tasks_from: create
+  vars:
+    acl_name: "{{ sg_name }}-egress-{{ idx }}"
+    acl_action: permit
+    acl_proto: "{{ item.protocol }}"
+    acl_vpc_id: "{{ _sg_vpc_id }}"
+    acl_src_prefix: "{{ _sg_vn_cidr if _sg_vn_cidr | length > 0 else '0.0.0.0/0' }}"
+    acl_dst_prefix: "{{ item.sourceCidr | default(item.ipv4Cidr | default('0.0.0.0/0')) }}"
+    acl_dst_port_from: "{{ item.portFrom | default(none) }}"
+    acl_dst_port_to: "{{ item.portTo | default(item.portFrom) | default(none) }}"
+    acl_comment: "OSAC SG {{ sg_name }} egress rule {{ idx }}"
+  loop: "{{ egress_rules }}"
+  loop_control:
+    index_var: idx
+  when: egress_rules | length > 0
+
+- name: Display SecurityGroup creation result
+  ansible.builtin.debug:
+    msg: >-
+      ACL rules created for SecurityGroup '{{ sg_name }}':
+      {{ ingress_rules | length }} ingress, {{ egress_rules | length }} egress

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_subnet.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_subnet.yaml
@@ -1,0 +1,109 @@
+---
+# Subnet maps to a Netris IPAM subnet + V-Net
+# Creates an IPAM subnet under the parent VN's allocation, then a V-Net with gateway
+
+- name: Extract Subnet configuration
+  ansible.builtin.set_fact:
+    subnet_name: "{{ subnet.metadata.name }}"
+    subnet_ipv4_cidr: "{{ subnet.spec.ipv4Cidr | default('') }}"
+    subnet_virtual_network_id: "{{ subnet.spec.virtualNetwork | default('') }}"
+
+- name: Look up VirtualNetwork CR by UUID label
+  kubernetes.core.k8s_info:
+    api_version: osac.openshift.io/v1alpha1
+    kind: VirtualNetwork
+    namespace: "{{ subnet.metadata.namespace }}"
+    label_selectors:
+      - "osac.openshift.io/virtualnetwork-uuid={{ subnet_virtual_network_id }}"
+  register: _vn_lookup
+
+- name: Fail if VirtualNetwork CR not found
+  ansible.builtin.fail:
+    msg: >-
+      VirtualNetwork with UUID '{{ subnet_virtual_network_id }}' not found in namespace '{{ subnet.metadata.namespace }}'.
+  when: _vn_lookup.resources | length == 0
+
+- name: Set VirtualNetwork CR name
+  ansible.builtin.set_fact:
+    subnet_virtual_network_name: "{{ _vn_lookup.resources[0].metadata.name }}"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Look up parent VPC by name
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/vpc"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _vpc_lookup_resp
+  no_log: true
+
+- name: Find parent VPC matching VirtualNetwork name
+  ansible.builtin.set_fact:
+    _parent_vpc: >-
+      {{ (_vpc_lookup_resp.json.data | default([]))
+         | selectattr('name', 'equalto', subnet_virtual_network_name)
+         | list | first | default(none) }}
+
+- name: Fail if parent VPC not found
+  ansible.builtin.fail:
+    msg: >-
+      Parent VPC '{{ subnet_virtual_network_name }}' not found in Netris controller.
+      Ensure the VirtualNetwork has been created before creating a Subnet.
+  when: _parent_vpc is none
+
+- name: Compute gateway IP from subnet CIDR
+  ansible.builtin.set_fact:
+    _gateway_cidr: >-
+      {{ subnet_ipv4_cidr | ansible.utils.ipaddr('next_usable') }}/{{ subnet_ipv4_cidr | ansible.utils.ipaddr('prefix') }}
+  when: subnet_ipv4_cidr | length > 0
+
+- name: Display Subnet information
+  ansible.builtin.debug:
+    msg:
+      - "Creating Netris IPAM subnet + V-Net for Subnet '{{ subnet_name }}'"
+      - "VirtualNetwork: {{ subnet_virtual_network_name }} (VPC ID: {{ _parent_vpc.id }})"
+      - "IPv4 CIDR: {{ subnet_ipv4_cidr }}"
+      - "Gateway: {{ _gateway_cidr | default('none') }}"
+
+- name: Create IPAM subnet in Netris controller
+  ansible.builtin.include_role:
+    name: netris.controller.ipam
+    tasks_from: create_subnet
+  vars:
+    ipam_name: "{{ subnet_name }}"
+    ipam_cidr: "{{ subnet_ipv4_cidr }}"
+    ipam_purpose: "common"
+    ipam_site_id: "{{ netris_site_id }}"
+    ipam_tenant_id: "{{ netris_tenant_id }}"
+    ipam_vpc_id: "{{ _parent_vpc.id }}"
+
+- name: Display IPAM subnet creation result
+  ansible.builtin.debug:
+    msg: >-
+      IPAM subnet '{{ subnet_name }}' {{ (ipam_already_existed | default(false)) | ternary('already exists', 'created successfully') }}
+      (ID: {{ ipam_subnet_id | default('unknown') }})
+
+- name: Create V-Net in Netris controller
+  ansible.builtin.include_role:
+    name: netris.controller.vnet
+    tasks_from: create
+  vars:
+    vnet_name: "{{ subnet_name }}"
+    vnet_vpc_id: "{{ _parent_vpc.id }}"
+    vnet_site_id: "{{ netris_site_id }}"
+    vnet_tenant_id: "{{ netris_tenant_id }}"
+    vnet_gateway: "{{ _gateway_cidr | default(omit) }}"
+
+- name: Display V-Net creation result
+  ansible.builtin.debug:
+    msg: >-
+      V-Net '{{ subnet_name }}' {{ (vnet_already_existed | default(false)) | ternary('already exists', 'created successfully') }}
+      (ID: {{ vnet_id | default('unknown') }})

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_virtual_network.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_virtual_network.yaml
@@ -1,0 +1,57 @@
+---
+# VirtualNetwork maps to a Netris VPC + IPAM allocation
+# Creates a VPC (routing domain) and an IPAM allocation for the VN's CIDR
+
+- name: Extract VirtualNetwork configuration
+  ansible.builtin.set_fact:
+    vn_name: "{{ virtual_network.metadata.name }}"
+    vn_ipv4_cidr: "{{ virtual_network.spec.ipv4Cidr | default('') }}"
+    vn_region: "{{ virtual_network.spec.region }}"
+    vn_tenant_id: "{{ virtual_network.metadata.annotations['osac.openshift.io/tenant'] | default('') }}"
+
+- name: Resolve region to Netris site ID
+  ansible.builtin.set_fact:
+    vn_site_id: "{{ netris_region_site_map[vn_region] | default(netris_site_id) }}"
+
+- name: Display VirtualNetwork information
+  ansible.builtin.debug:
+    msg:
+      - "Creating Netris VPC + IPAM allocation for VirtualNetwork '{{ vn_name }}'"
+      - "Region: {{ vn_region }}"
+      - "Site ID: {{ vn_site_id }}"
+      - "IPv4 CIDR: {{ vn_ipv4_cidr | default('not configured') }}"
+
+- name: Create VPC in Netris controller
+  ansible.builtin.include_role:
+    name: netris.controller.vpc
+    tasks_from: create
+  vars:
+    vpc_name: "{{ vn_name }}"
+    vpc_site_id: "{{ vn_site_id }}"
+    vpc_tenant_id: "{{ netris_tenant_id }}"
+
+- name: Display VPC creation result
+  ansible.builtin.debug:
+    msg: >-
+      VPC '{{ vn_name }}' {{ (vpc_already_existed | default(false)) | ternary('already exists', 'created successfully') }}
+      (ID: {{ vpc_id | default('unknown') }})
+
+- name: Create IPAM allocation for VirtualNetwork CIDR
+  ansible.builtin.include_role:
+    name: netris.controller.ipam
+    tasks_from: create_allocation
+  vars:
+    ipam_name: "{{ vn_name }}"
+    ipam_cidr: "{{ vn_ipv4_cidr }}"
+    ipam_purpose: "common"
+    ipam_site_id: "{{ vn_site_id }}"
+    ipam_tenant_id: "{{ netris_tenant_id }}"
+    ipam_vpc_id: "{{ vpc_id }}"
+  when: vn_ipv4_cidr | length > 0
+
+- name: Display IPAM allocation result
+  ansible.builtin.debug:
+    msg: >-
+      IPAM allocation '{{ vn_name }}' {{ (ipam_already_existed | default(false)) | ternary('already exists', 'created successfully') }}
+      (ID: {{ ipam_subnet_id | default('unknown') }})
+  when: vn_ipv4_cidr | length > 0

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_security_group.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_security_group.yaml
@@ -1,0 +1,41 @@
+---
+# SecurityGroup deletion - removes the corresponding Netris ACL rules
+
+- name: Extract SecurityGroup configuration
+  ansible.builtin.set_fact:
+    sg_name: "{{ security_group.metadata.name }}"
+    ingress_rules: "{{ security_group.spec.ingressRules | default([]) }}"
+    egress_rules: "{{ security_group.spec.egressRules | default([]) }}"
+
+- name: Display deletion information
+  ansible.builtin.debug:
+    msg:
+      - "Deleting Netris ACL rules for SecurityGroup '{{ sg_name }}'"
+      - "Ingress rules to delete: {{ ingress_rules | length }}"
+      - "Egress rules to delete: {{ egress_rules | length }}"
+
+- name: Delete ACL rules for ingress
+  ansible.builtin.include_role:
+    name: netris.controller.acl
+    tasks_from: delete
+  vars:
+    acl_name: "{{ sg_name }}-ingress-{{ idx }}"
+  loop: "{{ ingress_rules }}"
+  loop_control:
+    index_var: idx
+  when: ingress_rules | length > 0
+
+- name: Delete ACL rules for egress
+  ansible.builtin.include_role:
+    name: netris.controller.acl
+    tasks_from: delete
+  vars:
+    acl_name: "{{ sg_name }}-egress-{{ idx }}"
+  loop: "{{ egress_rules }}"
+  loop_control:
+    index_var: idx
+  when: egress_rules | length > 0
+
+- name: Display SecurityGroup deletion result
+  ansible.builtin.debug:
+    msg: "ACL rules deletion completed for SecurityGroup '{{ sg_name }}'"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_subnet.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_subnet.yaml
@@ -1,0 +1,28 @@
+---
+# Subnet deletion - removes V-Net first, then IPAM subnet
+
+- name: Extract Subnet name
+  ansible.builtin.set_fact:
+    subnet_name: "{{ subnet.metadata.name }}"
+
+- name: Display deletion information
+  ansible.builtin.debug:
+    msg: "Deleting Netris V-Net + IPAM subnet for Subnet '{{ subnet_name }}'"
+
+- name: Delete V-Net from Netris controller
+  ansible.builtin.include_role:
+    name: netris.controller.vnet
+    tasks_from: delete
+  vars:
+    vnet_name: "{{ subnet_name }}"
+
+- name: Delete IPAM subnet from Netris controller
+  ansible.builtin.include_role:
+    name: netris.controller.ipam
+    tasks_from: delete_subnet
+  vars:
+    ipam_name: "{{ subnet_name }}"
+
+- name: Display deletion result
+  ansible.builtin.debug:
+    msg: "V-Net + IPAM subnet '{{ subnet_name }}' deletion completed"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_virtual_network.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_virtual_network.yaml
@@ -1,0 +1,54 @@
+---
+# VirtualNetwork deletion - removes IPAM allocation first, then VPC
+
+- name: Extract VirtualNetwork name
+  ansible.builtin.set_fact:
+    vn_name: "{{ virtual_network.metadata.name }}"
+
+- name: Display VirtualNetwork deletion info
+  ansible.builtin.debug:
+    msg: "Deleting Netris VPC + IPAM allocation for VirtualNetwork '{{ vn_name }}'"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Look up VPC by name
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/vpc"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: 200
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _vn_vpc_list_resp
+  no_log: true
+
+- name: Find VPC ID
+  ansible.builtin.set_fact:
+    _vn_vpc_id: >-
+      {{ ((_vn_vpc_list_resp.json.data | default([]))
+          | selectattr('name', 'equalto', vn_name)
+          | map(attribute='id') | list | first | default('')) }}
+
+- name: Delete IPAM allocation from Netris controller
+  ansible.builtin.include_role:
+    name: netris.controller.ipam
+    tasks_from: delete_allocation
+  vars:
+    ipam_name: "{{ vn_name }}"
+    ipam_vpc_id: "{{ _vn_vpc_id }}"
+  when: _vn_vpc_id | string | length > 0
+
+- name: Delete VPC from Netris controller
+  ansible.builtin.include_role:
+    name: netris.controller.vpc
+    tasks_from: delete
+  vars:
+    vpc_name: "{{ vn_name }}"
+
+- name: Display deletion result
+  ansible.builtin.debug:
+    msg: "VPC + IPAM allocation '{{ vn_name }}' deletion completed"

--- a/docs/netris-integration.md
+++ b/docs/netris-integration.md
@@ -49,9 +49,10 @@ osac.service.external_access
 
 | Collection | Purpose |
 |------------|---------|
-| `netris.controller` | Low-level Netris API roles: `auth`, `server_cluster`, `server_cluster_template`, `nat`, `ipam`, `l4lb`, `vpc` |
+| `netris.controller` | Low-level Netris API roles: `auth`, `server_cluster`, `server_cluster_template`, `nat`, `ipam`, `l4lb`, `vpc`, `vnet`, `acl` |
 | `netris.steps` | High-level orchestration: `cluster_infra` and `external_access` roles that compose `netris.controller` roles |
 | `osac.service` | Generic service roles that delegate to `netris.steps` |
+| `osac.templates` | Template roles including `netris` (Netris network class for OSAC networking API) |
 
 ### Template Integration
 
@@ -306,3 +307,32 @@ All Netris resources created by the playbooks follow this naming convention:
 | Ingress HTTP DNAT | `<cluster-name>-ingress-http-dnat` |
 | Ingress HTTPS DNAT | `<cluster-name>-ingress-https-dnat` |
 | DNS records | `api.<cluster-name>.<domain>`, `api-int.<cluster-name>.<domain>`, `*.apps.<cluster-name>.<domain>` |
+
+## Netris Network Class (`netris`)
+
+In addition to the CaaS cluster networking above, the `netris` network class
+implements the OSAC Networking API by translating its resources into Netris
+primitives:
+
+| OSAC Resource | Netris Primitive | API |
+|---------------|-----------------|-----|
+| VirtualNetwork | VPC + V-Net | `POST /api/v2/vpc`, `POST /api/v2/vnet` |
+| Subnet | IPAM allocation + subnet | `POST /api/v2/ipam/allocation`, `POST /api/v2/ipam/subnet` |
+| SecurityGroup | ACL rules | `POST /api/acl` (v1 API) |
+| PublicIPPool | IPAM allocation + subnet (purpose=nat) | `POST /api/v2/ipam/allocation`, `POST /api/v2/ipam/subnet` |
+| PublicIP | IPAM IP allocation | Read from existing IPAM pool |
+
+The template role is at `collections/ansible_collections/osac/templates/roles/netris/`.
+It is auto-discovered by the `publish_templates` playbook via `meta/osac.yaml`
+and registered as a NetworkClass in the fulfillment service.
+
+### Networking Instance Group
+
+The networking operations jobs run on the `networking-operations-ig` instance
+group, which mounts the `network-fulfillment-ig` ConfigMap and Secret for Netris
+credentials:
+
+| Resource | Keys |
+|----------|------|
+| ConfigMap `network-fulfillment-ig` | `NETRIS_CONTROLLER_URL`, `NETRIS_USERNAME`, `NETRIS_SITE_ID`, `NETRIS_TENANT_ID`, `NETRIS_TENANT_NAME` |
+| Secret `network-fulfillment-ig` | `NETRIS_PASSWORD` |


### PR DESCRIPTION
Implements Netris translation layer for the OSAC Networking API resources:
- VirtualNetwork -> Netris VPC + IPAM allocation
- Subnet -> Netris IPAM subnet + V-Net (vlan auto-assigned)
- SecurityGroup -> Netris ACL rules (v1 API)

New controller roles: `netris.controller.vnet, netris.controller.acl`
Extended roles: `netris.controller.vpc` (create/delete), `netris.controller.ipam` (create/delete)
New template role: `osac.templates.netris_net`
New instance group: `networking-operations-ig` with `network-fulfillment-ig` `configmap/secret`

All endpoints verified against live Netris controller.

needs -

- https://github.com/osac-project/osac-installer/pull/91
- https://github.com/osac-project/osac-aap/pull/288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ACL role for creating/deleting network rules; VNet role with VLAN/port support
  * IPAM role extended to full CRUD (allocations & subnets)
  * OSAC "Netris Network" template with PublicIP/Pool and SecurityGroup plumbing
  * Test playbook to validate VPC create/delete idempotency

* **Improvements**
  * VPC role now defaults to ensure/present
  * Added sensible defaults for ACL and VNet inputs; expanded documentation and metadata
<!-- end of auto-generated comment: release notes by coderabbit.ai -->