### PR TITLE
fix: use FQCN for manage_agents role in cluster_infra

### DIFF
--- a/collections/ansible_collections/massopencloud/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/massopencloud/steps/roles/cluster_infra/tasks/create.yaml
@@ -58,7 +58,7 @@
 
 - name: Wait for the Agents to be removed from the cluster
   ansible.builtin.include_role:
-    name: manage_agents
+    name: osac.service.manage_agents
     tasks_from: wait_for_agents_to_be_removed
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
@@ -68,14 +68,14 @@
 
 - name: Detach agents from cluster
   ansible.builtin.include_role:
-    name: manage_agents
+    name: osac.service.manage_agents
     tasks_from: detach_and_unlabel_all_removed_agents
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
 
 - name: Select and label new Agent resources
   ansible.builtin.include_role:
-    name: manage_agents
+    name: osac.service.manage_agents
     tasks_from: select_and_label_new_agents
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
@@ -85,7 +85,7 @@
 
 - name: Attach agents to cluster network and approve them
   ansible.builtin.include_role:
-    name: manage_agents
+    name: osac.service.manage_agents
     tasks_from: attach_and_approve_all_new_agents
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
@@ -93,7 +93,7 @@
 
 - name: Approve agents assigned to the cluster
   ansible.builtin.include_role:
-    name: manage_agents
+    name: osac.service.manage_agents
     tasks_from: attach_and_approve_all_new_agents
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"

--- a/collections/ansible_collections/massopencloud/steps/roles/cluster_infra/tasks/delete.yaml
+++ b/collections/ansible_collections/massopencloud/steps/roles/cluster_infra/tasks/delete.yaml
@@ -1,6 +1,6 @@
 - name: Detach agents from cluster
   ansible.builtin.include_role:
-    name: manage_agents
+    name: osac.service.manage_agents
     tasks_from: detach_and_unlabel_all_removed_agents
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"


### PR DESCRIPTION
## Summary

- Use `osac.service.manage_agents` instead of `manage_agents` in `massopencloud.steps.cluster_infra` (create + delete)

## Problem

Cluster provisioning fails at the agent management step with:

```
the role 'manage_agents' was not found in massopencloud.steps:ansible.builtin:...
```

The `manage_agents` role was originally a top-level role (`roles/manage_agents/`), then moved to the `osac.service` collection in c79991f. When [MGMT-23420](https://redhat.atlassian.net/browse/MGMT-23420) introduced the `massopencloud.steps.cluster_infra` role, it referenced `manage_agents` by short name. Ansible can only resolve short role names within the same collection or on `ANSIBLE_ROLES_PATH` — since `manage_agents` is in `osac.service`, the cross-collection reference fails.

## Test plan

- [ ] Deploy to vmaas-dev, trigger cluster provisioning, verify agent management step succeeds

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster infrastructure automation to use updated agent-management role references
  * Reorganized agent detachment task structure in cluster creation workflow
  * Enhanced parameter handling for cluster network configuration during agent attachment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->