### PR TITLE
fix: drop duplicate attach_and_approve_all_new_agents task

### DIFF
--- a/collections/ansible_collections/massopencloud/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/massopencloud/steps/roles/cluster_infra/tasks/create.yaml
@@ -90,11 +90,3 @@
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
     manage_agents_cluster_network: "{{ cluster_infra_network_name }}"
-
-- name: Approve agents assigned to the cluster
-  ansible.builtin.include_role:
-    name: osac.service.manage_agents
-    tasks_from: attach_and_approve_all_new_agents
-  vars:
-    manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
-    manage_agents_cluster_network: "{{ cluster_infra_network_name | default(omit) }}"


### PR DESCRIPTION
## Summary

- Remove duplicate `attach_and_approve_all_new_agents` include in `cluster_infra/tasks/create.yaml`
- The second call ("Approve agents assigned to the cluster") was identical to the first ("Attach agents to cluster network and approve them") — same role, same `tasks_from`, same effective vars (`cluster_infra_network_name` is always defined, making `default(omit)` a no-op)
- Confirmed with original author ([Slack thread](https://redhat-internal.slack.com/archives/C08ESMFV85Q/p1777884852986999)) that this was an accidental leftover from a prior refactor

## Test plan

- [x] Verify `ansible-lint --offline` passes (only pre-existing `var-naming` warnings)
- [ ] Confirm cluster create flow still attaches and approves agents correctly

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster network configuration consistency by ensuring agent attachment and approval operations always receive the required network assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->