### PR TITLE
MGMT-24320: fix metallb_ingress FQCN in external_access

### DIFF
--- a/collections/ansible_collections/massopencloud/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/massopencloud/steps/roles/external_access/tasks/create.yaml
@@ -129,7 +129,7 @@
 
 - name: Configure metallb for ingress
   ansible.builtin.include_role:
-    name: metallb_ingress
+    name: osac.service.metallb_ingress
     tasks_from: configure_metallb_ingress
   vars:
     metallb_ingress_admin_kubeconfig: "{{ admin_kubeconfig }}"


### PR DESCRIPTION
## Summary
- Use FQCN `osac.service.metallb_ingress` instead of short name `metallb_ingress` in `massopencloud/steps/roles/external_access/tasks/create.yaml`
- Same class of bug as #282 (`manage_agents` FQCN fix)
- `netris` and `nico` variants already use the correct FQCN — only `massopencloud` was affected
- Delete path does not reference `metallb_ingress` — no fix needed there

## Test plan
- [ ] Deploy fix to vmaas-dev and retry demo cluster creation
- [ ] Verify AAP job passes the `Configure metallb for ingress` step

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MetalLB ingress configuration to use a properly scoped role reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->