### PR TITLE
OSAC-480: add security group job templates and dedicated networking-operations-ig pod spec

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/roles/aap/templates/networking-operations-ig.j2
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/templates/networking-operations-ig.j2
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    ansible_job: ''
+spec:
+  serviceAccountName: osac-sa
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: ansible_job
+                  operator: Exists
+            topologyKey: kubernetes.io/hostname
+  containers:
+    - image: >-
+        {{ aap_ee_image }}
+      name: worker
+      imagePullPolicy: Always
+      args:
+        - ansible-runner
+        - worker
+        - '--private-data-dir=/runner'
+      volumeMounts:
+        - name: kube-api-access
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+{% if remote_cluster_kubeconfig_secret_name %}
+        - name: remote-cluster-kubeconfig
+          mountPath: /etc/osac
+          readOnly: true
+{% endif %}
+      envFrom:
+        - configMapRef:
+            name: network-fulfillment-ig
+            optional: true
+        - secretRef:
+            name: network-fulfillment-ig
+      env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+{% if remote_cluster_kubeconfig_secret_name %}
+        - name: OSAC_REMOTE_CLUSTER_KUBECONFIG
+          value: /etc/osac/remote-cluster-kubeconfig
+{% endif %}
+  volumes:
+    - name: kube-api-access
+      projected:
+        sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 3600
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+                - key: ca.crt
+                  path: ca.crt
+          - downwardAPI:
+              items:
+                - path: namespace
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+          - configMap:
+              name: openshift-service-ca.crt
+              items:
+                - key: service-ca.crt
+                  path: service-ca.crt
+        defaultMode: 420
+{% if remote_cluster_kubeconfig_secret_name %}
+    - name: remote-cluster-kubeconfig
+      secret:
+        secretName: {{ remote_cluster_kubeconfig_secret_name }}
+        items:
+          - key: {{ remote_cluster_kubeconfig_secret_key }}
+            path: remote-cluster-kubeconfig
+        defaultMode: 420
+{% endif %}

--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -243,6 +243,30 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-create-security-group"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_create_security_group.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+  - name: "{{ aap_prefix }}-delete-security-group"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_delete_security_group.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
   - name: "{{ aap_prefix }}-import-agents"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"
@@ -663,4 +687,4 @@ controller_instance_groups: # noqa: var-naming[no-role-prefix]
 
   - name: "{{ aap_prefix }}-networking-operations-ig"
     is_container_group: true
-    pod_spec_override: "{{ lookup('ansible.builtin.template', 'compute-instance-operations-ig.j2') }}"
+    pod_spec_override: "{{ lookup('ansible.builtin.template', 'networking-operations-ig.j2') }}"


### PR DESCRIPTION
## Summary
- Adds `create-security-group` and `delete-security-group` AAP job templates (playbooks existed but were not registered in config-as-code)
- Replaces the shared `compute-instance-operations-ig.j2` template reference for `networking-operations-ig` with a dedicated inline pod spec
- The new pod spec mounts `network-fulfillment-ig` ConfigMap and Secret instead of `cluster-fulfillment-ig`, giving networking jobs their own credential source

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two new job templates for security group create and delete operations, now available in Ansible Automation Platform with networking operations instance group support.

* **Improvements**
  * Corrected networking operations instance group configuration for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->