### PR TITLE
OSAC-501: Create osac-aap Helm chart

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -1,0 +1,25 @@
+name: Helm Lint
+
+on:
+  pull_request:
+    paths:
+      - 'charts/**'
+
+jobs:
+  helm-lint:
+    name: Lint Helm charts
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: v3.17.0
+
+    - name: Lint aap chart
+      run: helm lint charts/aap/
+
+    - name: Template aap chart
+      run: helm template test charts/aap/ > /dev/null

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -1,0 +1,48 @@
+name: Publish Helm Charts
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  CHARTS_REPO: ${{ github.repository_owner }}/charts
+
+jobs:
+  publish-aap-chart:
+    name: Publish osac-aap chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: v3.17.0
+
+    - name: Log in to GHCR
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+
+    - name: Extract version from tag
+      id: version
+      run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+    - name: Update image tag in values.yaml
+      run: |
+        sed -i "s|image: ghcr.io/osac-project/osac-aap:latest|image: ghcr.io/osac-project/osac-aap:v${{ steps.version.outputs.version }}|" charts/aap/values.yaml
+
+    - name: Package chart
+      run: |
+        helm package charts/aap/ \
+          --version "${{ steps.version.outputs.version }}" \
+          --app-version "${{ steps.version.outputs.version }}"
+
+    - name: Push chart to GHCR
+      run: |
+        helm push osac-aap-${{ steps.version.outputs.version }}.tgz \
+          oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,4 +18,4 @@ repos:
       files: \.(yaml|yml)$
       types: [file, yaml]
       entry: yamllint --strict
-exclude: 'vendor/.*'
+exclude: '(vendor|charts)/.*'

--- a/charts/aap/Chart.yaml
+++ b/charts/aap/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: osac-aap
+description: OSAC AAP integration - bootstrap and configuration
+type: application
+version: 0.0.0

--- a/charts/aap/templates/_helpers.tpl
+++ b/charts/aap/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "osac-aap.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "osac-aap.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "osac-aap.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "osac-aap.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+AAP instance name
+*/}}
+{{- define "osac-aap.instanceName" -}}
+{{- .Values.aap.instance.name }}
+{{- end }}
+
+{{/*
+AAP gateway hostname (service name)
+*/}}
+{{- define "osac-aap.gatewayHostname" -}}
+{{- include "osac-aap.instanceName" . }}
+{{- end }}
+
+{{/*
+AAP EDA hostname
+*/}}
+{{- define "osac-aap.edaHostname" -}}
+{{- printf "%s-eda-api" (include "osac-aap.instanceName" .) }}
+{{- end }}
+
+{{/*
+AAP controller hostname
+*/}}
+{{- define "osac-aap.controllerHostname" -}}
+{{- printf "%s-controller-service" (include "osac-aap.instanceName" .) }}
+{{- end }}

--- a/charts/aap/templates/aap.yaml
+++ b/charts/aap/templates/aap.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.aap.instance.enabled }}
+apiVersion: aap.ansible.com/v1alpha1
+kind: AnsibleAutomationPlatform
+metadata:
+  name: {{ include "osac-aap.instanceName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-aap.labels" . | nindent 4 }}
+spec:
+  controller:
+    disabled: {{ .Values.aap.instance.controller.disabled }}
+  eda:
+    disabled: {{ .Values.aap.instance.eda.disabled }}
+  hub:
+    disabled: {{ .Values.aap.instance.hub.disabled }}
+  lightspeed:
+    disabled: {{ .Values.aap.instance.lightspeed.disabled }}
+  image_pull_policy: {{ .Values.aap.instance.imagePullPolicy }}
+  no_log: true
+  redis_mode: {{ .Values.aap.instance.redisMode }}
+  route_tls_termination_mechanism: {{ .Values.aap.instance.routeTlsTerminationMechanism }}
+{{- end }}

--- a/charts/aap/templates/bootstrap-job.yaml
+++ b/charts/aap/templates/bootstrap-job.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.bootstrap.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "osac-aap.fullname" . }}-bootstrap
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-aap.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: {{ .Values.bootstrap.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "osac-aap.labels" . | nindent 8 }}
+    spec:
+      initContainers:
+      - name: wait-for-aap
+        image: {{ .Values.bootstrap.cliImage }}
+        command:
+          - /bin/bash
+          - -c
+          - |
+            echo "Gateway: ${AAP_GATEWAY_HOSTNAME}"
+            echo "Waiting for AAP controller to be ready..."
+            for i in {1..60}; do
+              echo "Attempt $i: Checking AAP controller readiness..."
+              curl -skf http://${AAP_GATEWAY_HOSTNAME}/api/gateway/v1/ping/ \
+                | grep -q 'good';
+              GATEWAY=$?
+              echo "GATEWAY exit code: $GATEWAY"
+
+              curl -skf \
+                -u "${AAP_EDA_ADMIN}:${AAP_EDA_PASSWORD}" \
+              http://${AAP_EDA_HOSTNAME}:8000/api/eda/v1/status/ | grep -qi 'good';
+              EDA_GATEWAY=$?
+              echo "EDA_GATEWAY exit code: $EDA_GATEWAY"
+
+              curl -skf http://${AAP_CONTROLLER_GATEWAY_HOSTNAME}/api/v2/ping/ \
+                | grep -q 'version';
+              CONTROLLER_GATEWAY=$?
+              echo "CONTROLLER_GATEWAY exit code: $CONTROLLER_GATEWAY"
+
+              auth_code=$(curl -sk -o /dev/null -w "%{http_code}" -X POST \
+                http://${AAP_GATEWAY_HOSTNAME}/api/gateway/v1/tokens/ \
+                -d "username=admin&password=dummy" 2>/dev/null)
+              [ "$auth_code" != "503" ] && [ "$auth_code" != "000" ];
+              AUTH_UPSTREAM=$?
+              echo "AUTH_UPSTREAM exit code: $AUTH_UPSTREAM (HTTP $auth_code)"
+
+              if [ $GATEWAY -eq 0 ] && [ $EDA_GATEWAY -eq 0 ] && [ $CONTROLLER_GATEWAY -eq 0 ] && [ $AUTH_UPSTREAM -eq 0 ];
+              then
+                echo "AAP controller is ready!"
+                exit 0
+              fi
+              echo "AAP is not ready, waiting 60 seconds..."
+              sleep 60
+            done
+            echo "Timeout waiting for AAP."
+            exit 1
+        env:
+        - name: AAP_GATEWAY_HOSTNAME
+          value: {{ include "osac-aap.gatewayHostname" . | quote }}
+        - name: AAP_EDA_HOSTNAME
+          value: {{ include "osac-aap.edaHostname" . | quote }}
+        - name: AAP_EDA_ADMIN
+          value: "admin"
+        - name: AAP_EDA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "osac-aap.instanceName" . }}-eda-admin-password
+              key: password
+        - name: AAP_CONTROLLER_GATEWAY_HOSTNAME
+          value: {{ include "osac-aap.controllerHostname" . | quote }}
+      containers:
+      - name: bootstrap
+        image: {{ .Values.bootstrap.image }}
+        args:
+        - ansible-playbook
+        - osac.config_as_code.subscription
+        - osac.config_as_code.configure
+        envFrom:
+        - secretRef:
+            name: {{ .Values.configAsCode.secret }}
+            optional: true
+        env:
+        - name: AAP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "osac-aap.instanceName" . }}-admin-password
+              key: password
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: config-as-code-manifest-volume
+          mountPath: /var/secrets/config-as-code-manifest
+          readOnly: true
+      volumes:
+      - name: config-as-code-manifest-volume
+        secret:
+          secretName: {{ .Values.configAsCode.manifestSecret }}
+      restartPolicy: Never
+{{- end }}

--- a/charts/aap/templates/osac-sa.yaml
+++ b/charts/aap/templates/osac-sa.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "osac-aap.fullname" . }}-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-aap.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "osac-aap.fullname" . }}-sa
+  labels:
+    {{- include "osac-aap.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "osac-aap.fullname" . }}-sa
+    namespace: {{ .Release.Namespace }}

--- a/charts/aap/templates/template-publisher.yaml
+++ b/charts/aap/templates/template-publisher.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "osac-aap.fullname" . }}-template-publisher
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-aap.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "osac-aap.fullname" . }}-create-controller-token
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-aap.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    resourceNames: ["{{ include "osac-aap.fullname" . }}-template-publisher"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "osac-aap.fullname" . }}-template-publisher
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-aap.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "osac-aap.fullname" . }}-create-controller-token
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "osac-aap.fullname" . }}-template-publisher
+    namespace: {{ .Release.Namespace }}

--- a/charts/aap/values.yaml
+++ b/charts/aap/values.yaml
@@ -1,0 +1,25 @@
+aap:
+  instance:
+    enabled: true
+    name: "osac-aap"
+    controller:
+      disabled: false
+    eda:
+      disabled: false
+    hub:
+      disabled: true
+    lightspeed:
+      disabled: true
+    redisMode: standalone
+    routeTlsTerminationMechanism: Edge
+    imagePullPolicy: IfNotPresent
+
+bootstrap:
+  enabled: true
+  image: ghcr.io/osac-project/osac-aap:latest
+  cliImage: quay.io/openshift/origin-cli:4.20.0
+  backoffLimit: 15
+
+configAsCode:
+  manifestSecret: "config-as-code-manifest-ig"
+  secret: "config-as-code-ig"


### PR DESCRIPTION
## Motivation
OSAC is transitioning from Kustomize to Helm for installation. This PR adds the AAP Helm chart so it can be consumed by the umbrella installer chart.

## Summary
- Add `charts/aap/` Helm chart translating Kustomize manifests from `config/base/` into Helm templates
- Conditional AAP instance CR via `aap.instance.enabled` toggle
- Bootstrap Job as post-install/post-upgrade Helm hook with wait-for-aap init container
- ServiceAccount with ClusterRoleBinding and template-publisher RBAC
- Add CI workflows for helm lint on PRs and chart publishing to OCI registry on version tags

## Test plan
- [ ] `helm lint charts/aap/` passes
- [ ] `helm template test charts/aap/` renders AAP CR, bootstrap Job, service accounts, RBAC
- [ ] `helm template test charts/aap/ --set aap.instance.enabled=false` skips AAP CR
- [ ] `helm template test charts/aap/ --set bootstrap.enabled=false` skips bootstrap Job
- [ ] Bootstrap job has correct Helm hook annotations
- [ ] Deploy to kind cluster and verify resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm chart for deploying and configuring Ansible Automation Platform with support for bootstrap automation and service account management.

* **Chores**
  * Added automated validation of Helm charts on pull requests.
  * Added automated publishing of Helm charts to container registry on version release tags.
  * Updated pre-commit configuration to exclude charts from YAML linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->