### PR TITLE
OSAC-506: Use public-ip-address annotation instead of floating-ip-address annotation

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
@@ -193,8 +193,8 @@
           'osac-pip-{{ public_ip_name }}' in metallb-system has been restored
           if it had been deleted. Check the preceding error for details.
 
-# Annotate the ComputeInstance CR with the assigned floating IP.
-- name: Annotate ComputeInstance with floating-ip-address
+# Annotate the ComputeInstance CR with the assigned public IP.
+- name: Annotate ComputeInstance with public-ip-address
   kubernetes.core.k8s:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: osac.openshift.io/v1alpha1
@@ -205,11 +205,11 @@
     definition:
       metadata:
         annotations:
-          osac.openshift.io/floating-ip-address: "{{ attach_ip_address }}"
+          osac.openshift.io/public-ip-address: "{{ attach_ip_address }}"
   register: ci_annotate_result
 
 - name: Display ComputeInstance annotation result
   ansible.builtin.debug:
     msg:
-      - "ComputeInstance '{{ attach_compute_instance_name }}' annotated with floating-ip-address '{{ attach_ip_address }}'"
+      - "ComputeInstance '{{ attach_compute_instance_name }}' annotated with public-ip-address '{{ attach_ip_address }}'"
       - "Changed: {{ ci_annotate_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -191,7 +191,7 @@
           'osac-pip-{{ public_ip_name }}-ingress' in '{{ detach_vm_namespace }}' has been restored
           if it had been deleted. Check the preceding error for details.
 
-# Remove the floating-ip-address annotation from the ComputeInstance CR.
+# Remove the public-ip-address annotation from the ComputeInstance CR.
 - name: Fetch ComputeInstance to inspect annotations
   kubernetes.core.k8s_info:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
@@ -201,7 +201,7 @@
     namespace: "{{ public_ip.metadata.namespace }}"
   register: ci_info
 
-- name: Remove floating-ip-address annotation from ComputeInstance CR
+- name: Remove public-ip-address annotation from ComputeInstance CR
   kubernetes.core.k8s_json_patch:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: osac.openshift.io/v1alpha1
@@ -210,17 +210,17 @@
     namespace: "{{ public_ip.metadata.namespace }}"
     patch:
       - op: remove
-        path: /metadata/annotations/osac.openshift.io~1floating-ip-address
+        path: /metadata/annotations/osac.openshift.io~1public-ip-address
   register: ci_patch_result
   when: >-
     ci_info.resources | length > 0 and
     (ci_info.resources[0].metadata.annotations | default({}))
-    ['osac.openshift.io/floating-ip-address'] is defined
+    ['osac.openshift.io/public-ip-address'] is defined
 
 - name: Display ComputeInstance annotation removal result
   ansible.builtin.debug:
     msg:
-      - "ComputeInstance '{{ detach_compute_instance_name }}': floating-ip-address annotation removed"
+      - "ComputeInstance '{{ detach_compute_instance_name }}': public-ip-address annotation removed"
       - "Changed: {{ ci_patch_result.changed | default(false) }}"
   when: ci_patch_result is defined and ci_patch_result is not skipped
 
@@ -228,5 +228,5 @@
   ansible.builtin.debug:
     msg: >-
       ComputeInstance '{{ detach_compute_instance_name }}':
-      floating-ip-address annotation not present, nothing to remove
+      public-ip-address annotation not present, nothing to remove
   when: ci_patch_result is defined and ci_patch_result is skipped

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -537,7 +537,7 @@
 #   - Parking Service deleted from metallb-system
 #   - LoadBalancer Service created in VM namespace with correct
 #     selector, labels, annotations, and the reserved IP
-#   - ComputeInstance annotated with floating-ip-address
+#   - ComputeInstance annotated with public-ip-address
 # Prerequisites:
 #   - IPAddressPool exists (run pool create first or run all tests)
 #   - ComputeInstance CRD installed (osac.openshift.io/v1alpha1)
@@ -730,15 +730,15 @@
             namespace: "{{ test_ci_namespace }}"
           register: ci_after_attach
 
-        - name: Verify ComputeInstance annotated with floating-ip-address
+        - name: Verify ComputeInstance annotated with public-ip-address
           ansible.builtin.assert:
             that:
               - ci_after_attach.resources | length == 1
-              - (ci_after_attach.resources[0].metadata.annotations | default({}))['osac.openshift.io/floating-ip-address'] == pre_attach_ip
-            fail_msg: "ComputeInstance not annotated with floating-ip-address after attach"
+              - (ci_after_attach.resources[0].metadata.annotations | default({}))['osac.openshift.io/public-ip-address'] == pre_attach_ip
+            fail_msg: "ComputeInstance not annotated with public-ip-address after attach"
             success_msg: >-
               ComputeInstance '{{ test_ci_name }}' annotated with
-              floating-ip-address='{{ pre_attach_ip }}'
+              public-ip-address='{{ pre_attach_ip }}'
 
       always:
         - name: Clean up LB Service from VM namespace on failure
@@ -775,7 +775,7 @@
 # Test: Detach PublicIP from a ComputeInstance
 # Expected:
 #   - LoadBalancer Service removed from VM namespace
-#   - floating-ip-address annotation removed from ComputeInstance
+#   - public-ip-address annotation removed from ComputeInstance
 #   - Parking Service re-created in metallb-system with the same IP
 # Prerequisites:
 #   - attach test must have run (or LB Service + annotated ComputeInstance
@@ -858,15 +858,15 @@
             namespace: "{{ test_ci_namespace }}"
           register: ci_after_detach
 
-        - name: Assert floating-ip-address annotation removed from ComputeInstance
+        - name: Assert public-ip-address annotation removed from ComputeInstance
           ansible.builtin.assert:
             that:
               - ci_after_detach.resources | length == 1
               - >-
                 (ci_after_detach.resources[0].metadata.annotations | default({}))
-                ['osac.openshift.io/floating-ip-address'] is not defined
-            fail_msg: "floating-ip-address annotation still present on ComputeInstance after detach"
-            success_msg: "floating-ip-address annotation correctly removed from ComputeInstance '{{ test_ci_name }}'"
+                ['osac.openshift.io/public-ip-address'] is not defined
+            fail_msg: "public-ip-address annotation still present on ComputeInstance after detach"
+            success_msg: "public-ip-address annotation correctly removed from ComputeInstance '{{ test_ci_name }}'"
 
         - name: Wait for parking Service to be re-created in metallb-system
           kubernetes.core.k8s_info:


### PR DESCRIPTION
This replaces references to the `floating-ip-address` annotation with a more explicit `public-ip-address` annotation.

Related operator PR: https://github.com/osac-project/osac-operator/pull/227