### PR TITLE
OSAC-175, OSAC-176: Tier-aware StorageClass role and template-driven selection

### DIFF
--- a/collections/ansible_collections/osac/service/roles/tenant_storage_class/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/service/roles/tenant_storage_class/meta/argument_specs.yaml
@@ -1,6 +1,12 @@
 argument_specs:
   main:
     options:
+      tenant_storage_class_tenant_name:
+        type: str
+        required: true
+        description: >-
+          Tenant name, used in error messages to identify which tenant
+          has a storage tier resolution failure.
       tenant_storage_class_storage_classes:
         type: list
         elements: dict

--- a/collections/ansible_collections/osac/service/roles/tenant_storage_class/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/service/roles/tenant_storage_class/meta/argument_specs.yaml
@@ -1,11 +1,19 @@
 argument_specs:
   main:
     options:
-      tenant_storage_class_tenant_name:
+      tenant_storage_class_storage_classes:
+        type: list
+        elements: dict
+        required: true
+        description: >-
+          Resolved storageClasses list injected via extra_vars by the
+          ComputeInstance controller. Each entry has 'name' (K8s StorageClass
+          name) and 'tier' (storage tier label value).
+      tenant_storage_class_storage_tier:
         type: str
         required: true
-        description: "Tenant name (e.g. from compute_instance.status.tenantReference.name) used to look up the Tenant CR."
-      tenant_namespace:
-        type: str
-        required: true
-        description: "Namespace of the Tenant CR on the management cluster (e.g. from compute_instance.status.tenantReference.namespace)."
+        description: >-
+          Storage tier to resolve (e.g. "default", "fast", "archival").
+          The role matches this against the tier field in the injected
+          storageClasses list and fails if no matching tier is found,
+          listing the available tiers.

--- a/collections/ansible_collections/osac/service/roles/tenant_storage_class/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/tenant_storage_class/tasks/main.yaml
@@ -9,9 +9,10 @@
 - name: Fail if storageClasses list is empty
   ansible.builtin.fail:
     msg: >-
-      No resolved storage tiers available. The storageClasses list injected
-      by the ComputeInstance controller is empty. Check the Tenant
-      StorageClassReady condition.
+      No resolved storage tiers available for tenant
+      "{{ tenant_storage_class_tenant_name }}". The storageClasses list
+      injected by the ComputeInstance controller is empty. Check the
+      Tenant StorageClassReady condition.
   when: tenant_storage_class_storage_classes | length == 0
 
 - name: Resolve StorageClass for requested tier
@@ -22,7 +23,8 @@
 - name: Fail if requested tier is not available
   ansible.builtin.fail:
     msg: >-
-      Storage tier "{{ tenant_storage_class_storage_tier }}" is not available.
+      Storage tier "{{ tenant_storage_class_storage_tier }}" is not available
+      for tenant "{{ tenant_storage_class_tenant_name }}".
       Available tiers: {{ _tenant_sc_available_tiers }}.
   when: _tenant_sc_match | length == 0
 

--- a/collections/ansible_collections/osac/service/roles/tenant_storage_class/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/tenant_storage_class/tasks/main.yaml
@@ -1,38 +1,31 @@
 ---
-# Discover the StorageClass to use for a tenant by reading tenant.status.storageClass.
-# The osac-operator Tenant controller is the single source of truth for StorageClass
-# validation (duplicate detection, fallback to Default). This role reads the already-
-# resolved result instead of re-implementing the same logic independently.
+# Resolve a StorageClass for a specific storage tier from the pre-resolved
+# storageClasses list injected via extra_vars by the ComputeInstance controller.
+# The Tenant controller is the single source of truth for StorageClass
+# resolution (per-tier duplicate detection, tenant vs shared Default fallback).
+# This role performs tier selection only.
 # Sets tenant_storage_class_name or fails.
 
-- name: Retrieve tenant
-  kubernetes.core.k8s_info:
-    api_version: osac.openshift.io/v1alpha1
-    kind: Tenant
-    name: "{{ tenant_storage_class_tenant_name }}"
-    namespace: "{{ tenant_namespace }}"
-  register: tenant_storage_class_tenant_result
-
-- name: Fail if tenant not found
-  ansible.builtin.fail:
-    msg: "Tenant '{{ tenant_storage_class_tenant_name }}' not found in namespace '{{ tenant_namespace }}'."
-  when: tenant_storage_class_tenant_result.resources | length != 1
-
-- name: Fail if tenant not ready
+- name: Fail if storageClasses list is empty
   ansible.builtin.fail:
     msg: >-
-      Tenant '{{ tenant_storage_class_tenant_name }}' is not ready
-      (phase: {{ tenant_storage_class_tenant_result.resources[0].status.phase | default('unknown') }}).
-      Check Tenant conditions for details.
-  when: tenant_storage_class_tenant_result.resources[0].status.phase | default('') != "Ready"
+      No resolved storage tiers available. The storageClasses list injected
+      by the ComputeInstance controller is empty. Check the Tenant
+      StorageClassReady condition.
+  when: tenant_storage_class_storage_classes | length == 0
 
-- name: Fail if tenant storageClass is empty
-  ansible.builtin.fail:
-    msg: >-
-      Tenant '{{ tenant_storage_class_tenant_name }}' is ready but status.storageClass is empty.
-      This is unexpected; check the Tenant StorageClassReady condition.
-  when: tenant_storage_class_tenant_result.resources[0].status.storageClass | default('') | length == 0
-
-- name: Set StorageClass name from tenant status
+- name: Resolve StorageClass for requested tier
   ansible.builtin.set_fact:
-    tenant_storage_class_name: "{{ tenant_storage_class_tenant_result.resources[0].status.storageClass }}"
+    _tenant_sc_match: "{{ tenant_storage_class_storage_classes | selectattr('tier', 'equalto', tenant_storage_class_storage_tier) | list }}"
+    _tenant_sc_available_tiers: "{{ tenant_storage_class_storage_classes | map(attribute='tier') | sort | join(', ') }}"
+
+- name: Fail if requested tier is not available
+  ansible.builtin.fail:
+    msg: >-
+      Storage tier "{{ tenant_storage_class_storage_tier }}" is not available.
+      Available tiers: {{ _tenant_sc_available_tiers }}.
+  when: _tenant_sc_match | length == 0
+
+- name: Set StorageClass name from resolved tier
+  ansible.builtin.set_fact:
+    tenant_storage_class_name: "{{ _tenant_sc_match[0].name }}"

--- a/collections/ansible_collections/osac/service/roles/tenant_storage_class/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/tenant_storage_class/tasks/main.yaml
@@ -17,7 +17,7 @@
 - name: Resolve StorageClass for requested tier
   ansible.builtin.set_fact:
     _tenant_sc_match: "{{ tenant_storage_class_storage_classes | selectattr('tier', 'equalto', tenant_storage_class_storage_tier) | list }}"
-    _tenant_sc_available_tiers: "{{ tenant_storage_class_storage_classes | map(attribute='tier') | sort | join(', ') }}"
+    _tenant_sc_available_tiers: "{{ tenant_storage_class_storage_classes | map(attribute='tier') | unique | sort | join(', ') }}"
 
 - name: Fail if requested tier is not available
   ansible.builtin.fail:

--- a/collections/ansible_collections/osac/service/roles/tenant_storage_class/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/tenant_storage_class/tests/test.yml
@@ -3,155 +3,112 @@
 # Each play is guarded by a `when` condition -- only the play whose controlling
 # variable is defined will run. Pass exactly one variable per invocation.
 #
-# All tests require the management cluster context to be active (kubeconfig for
-# the management cluster, not the VM cluster). The role reads from Tenant status,
-# which lives on the management cluster.
+# The role receives a pre-resolved storageClasses list (injected via extra_vars
+# by the ComputeInstance controller) and selects a StorageClass by tier.
+# No K8s API calls are made.
 #
-# Required variables for every test:
-#   test_tenant_name|test_tenant_name_*:  The Tenant name to look up.
-#   test_tenant_namespace:                The namespace of the Tenant CR.
+#   Test 1 (happy path -- resolve "fast" tier):
+#     ansible-playbook ... -e test_happy_path=true
 #
-#   Test 1 (tenant Ready with storageClass set):
-#     Prerequisites: Tenant exists, phase=Ready, status.storageClass is set
-#     ansible-playbook ... -e test_tenant_name=tenant-akshay -e test_tenant_namespace=osac
+#   Test 2 (requested tier not available):
+#     ansible-playbook ... -e test_tier_not_available=true
 #
-#   Test 2 (tenant not ready -- Progressing phase):
-#     Prerequisites: Tenant exists but phase != Ready (e.g. duplicate SCs configured)
-#     ansible-playbook ... -e test_tenant_name_not_ready=tenant-akshay -e test_tenant_namespace=osac
-#
-#   Test 3 (tenant not found):
-#     Prerequisites: Tenant with the given name does not exist in the namespace
-#     ansible-playbook ... -e test_tenant_name_missing=tenant-nonexistent -e test_tenant_namespace=osac
-#
-#   Test 4 (tenant ready but storageClass empty -- unexpected edge case):
-#     Prerequisites: Tenant phase=Ready but status.storageClass is empty (misconfigured)
-#     ansible-playbook ... -e test_tenant_name_no_sc=tenant-akshay -e test_tenant_namespace=osac
+#   Test 3 (empty storageClasses list):
+#     ansible-playbook ... -e test_empty_list=true
 
 # ──────────────────────────────────────────────────────────────
-# Test 1: Tenant ready with storageClass set (happy path)
-# Expected: role succeeds, tenant_storage_class_name set to the SC name from tenant status
+# Test 1: Resolve requested tier (happy path)
+# Expected: role succeeds, tenant_storage_class_name set
 # ──────────────────────────────────────────────────────────────
-- name: Test tenant_storage_class role -- tenant ready with storageClass
+- name: Test tenant_storage_class role -- resolve tier (happy path)
   hosts: localhost
   gather_facts: false
 
   tasks:
-    - name: Discover StorageClass for ready tenant
+    - name: Discover StorageClass for requested tier
       ansible.builtin.include_role:
         name: osac.service.tenant_storage_class
       vars:
-        tenant_storage_class_tenant_name: "{{ test_tenant_name }}"
-        tenant_namespace: "{{ test_tenant_namespace }}"
-      when:
-        - test_tenant_name is defined
-        - test_tenant_namespace is defined
+        tenant_storage_class_storage_classes:
+          - name: "ceph-acme-default"
+            tier: "default"
+          - name: "ceph-acme-fast"
+            tier: "fast"
+        tenant_storage_class_storage_tier: "fast"
+      when: test_happy_path | default(false) | bool
 
     - name: Verify discovered StorageClass name is set
       ansible.builtin.assert:
         that:
           - tenant_storage_class_name is defined
-          - tenant_storage_class_name | length > 0
-        fail_msg: "Role did not set tenant_storage_class_name"
+          - tenant_storage_class_name == "ceph-acme-fast"
+        fail_msg: "Expected 'ceph-acme-fast' but got '{{ tenant_storage_class_name | default('undefined') }}'"
         success_msg: "Discovered StorageClass: {{ tenant_storage_class_name }}"
-      when:
-        - test_tenant_name is defined
-        - test_tenant_namespace is defined
+      when: test_happy_path | default(false) | bool
 
 # ──────────────────────────────────────────────────────────────
-# Test 2: Tenant not ready (Progressing phase) -- error path
-# Expected: role fails with "not ready" message including phase
+# Test 2: Requested tier not available -- error path
+# Expected: role fails with message listing available tiers
 # ──────────────────────────────────────────────────────────────
-- name: Test tenant_storage_class role -- tenant not ready (should fail)
+- name: Test tenant_storage_class role -- tier not available (should fail)
   hosts: localhost
   gather_facts: false
 
   tasks:
-    - name: Run not-ready failure test
-      when:
-        - test_tenant_name_not_ready is defined
-        - test_tenant_namespace is defined
+    - name: Run tier-not-available failure test
+      when: test_tier_not_available | default(false) | bool
       block:
-        - name: Attempt to discover StorageClass for not-ready tenant (expected to fail)
+        - name: Attempt to discover StorageClass for unavailable tier (expected to fail)
           ansible.builtin.include_role:
             name: osac.service.tenant_storage_class
           vars:
-            tenant_storage_class_tenant_name: "{{ test_tenant_name_not_ready }}"
-            tenant_namespace: "{{ test_tenant_namespace }}"
+            tenant_storage_class_storage_classes:
+              - name: "ceph-acme-default"
+                tier: "default"
+              - name: "ceph-acme-standard"
+                tier: "standard"
+            tenant_storage_class_storage_tier: "gpu"
 
         - name: This task should not be reached -- role should have failed
           ansible.builtin.fail:
-            msg: "Role did not fail as expected when tenant is not ready"
+            msg: "Role did not fail as expected when tier is not available"
 
       rescue:
-        - name: Verify role failed with expected not-ready message
+        - name: Verify role failed with expected tier-not-available message
           ansible.builtin.assert:
             that:
-              - "'is not ready' in ansible_failed_result.msg"
+              - "'is not available' in ansible_failed_result.msg"
+              - "'Available tiers' in ansible_failed_result.msg"
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg }}"
             success_msg: "Role failed as expected: {{ ansible_failed_result.msg }}"
 
 # ──────────────────────────────────────────────────────────────
-# Test 3: Tenant not found -- error path
-# Expected: role fails with "not found" message
+# Test 3: Empty storageClasses list -- error path
+# Expected: role fails with "empty" message
 # ──────────────────────────────────────────────────────────────
-- name: Test tenant_storage_class role -- tenant not found (should fail)
+- name: Test tenant_storage_class role -- empty storageClasses (should fail)
   hosts: localhost
   gather_facts: false
 
   tasks:
-    - name: Run tenant-not-found failure test
-      when:
-        - test_tenant_name_missing is defined
-        - test_tenant_namespace is defined
+    - name: Run empty-storageClasses failure test
+      when: test_empty_list | default(false) | bool
       block:
-        - name: Attempt to discover StorageClass for missing tenant (expected to fail)
+        - name: Attempt to discover StorageClass when storageClasses is empty (expected to fail)
           ansible.builtin.include_role:
             name: osac.service.tenant_storage_class
           vars:
-            tenant_storage_class_tenant_name: "{{ test_tenant_name_missing }}"
-            tenant_namespace: "{{ test_tenant_namespace }}"
+            tenant_storage_class_storage_classes: []
+            tenant_storage_class_storage_tier: "default"
 
         - name: This task should not be reached -- role should have failed
           ansible.builtin.fail:
-            msg: "Role did not fail as expected when tenant is not found"
+            msg: "Role did not fail as expected when storageClasses is empty"
 
       rescue:
-        - name: Verify role failed with expected not-found message
+        - name: Verify role failed with expected empty message
           ansible.builtin.assert:
             that:
-              - "'not found' in ansible_failed_result.msg"
-            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg }}"
-            success_msg: "Role failed as expected: {{ ansible_failed_result.msg }}"
-
-# ──────────────────────────────────────────────────────────────
-# Test 4: Tenant ready but storageClass empty -- error path
-# Expected: role fails with "storageClass is empty" message
-# ──────────────────────────────────────────────────────────────
-- name: Test tenant_storage_class role -- tenant ready but storageClass empty (should fail)
-  hosts: localhost
-  gather_facts: false
-
-  tasks:
-    - name: Run empty-storageClass failure test
-      when:
-        - test_tenant_name_no_sc is defined
-        - test_tenant_namespace is defined
-      block:
-        - name: Attempt to discover StorageClass when tenant storageClass is empty (expected to fail)
-          ansible.builtin.include_role:
-            name: osac.service.tenant_storage_class
-          vars:
-            tenant_storage_class_tenant_name: "{{ test_tenant_name_no_sc }}"
-            tenant_namespace: "{{ test_tenant_namespace }}"
-
-        - name: This task should not be reached -- role should have failed
-          ansible.builtin.fail:
-            msg: "Role did not fail as expected when tenant storageClass is empty"
-
-      rescue:
-        - name: Verify role failed with expected empty-storageClass message
-          ansible.builtin.assert:
-            that:
-              - "'storageClass is empty' in ansible_failed_result.msg"
+              - "'empty' in ansible_failed_result.msg"
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg }}"
             success_msg: "Role failed as expected: {{ ansible_failed_result.msg }}"

--- a/collections/ansible_collections/osac/service/roles/tenant_storage_class/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/tenant_storage_class/tests/test.yml
@@ -112,3 +112,33 @@
               - "'empty' in ansible_failed_result.msg"
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg }}"
             success_msg: "Role failed as expected: {{ ansible_failed_result.msg }}"
+
+# ──────────────────────────────────────────────────────────────
+# Test 4: Duplicate tiers in list -- first-match semantics
+# Expected: role returns the first matching entry
+# ──────────────────────────────────────────────────────────────
+- name: Test tenant_storage_class role -- duplicate tiers (first-match)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Resolve StorageClass when duplicate tiers exist
+      ansible.builtin.include_role:
+        name: osac.service.tenant_storage_class
+      vars:
+        tenant_storage_class_storage_classes:
+          - name: "ceph-fast-primary"
+            tier: "fast"
+          - name: "ceph-fast-secondary"
+            tier: "fast"
+        tenant_storage_class_storage_tier: "fast"
+      when: test_duplicate_tier | default(false) | bool
+
+    - name: Verify first match is returned
+      ansible.builtin.assert:
+        that:
+          - tenant_storage_class_name is defined
+          - tenant_storage_class_name == "ceph-fast-primary"
+        fail_msg: "Expected 'ceph-fast-primary' but got '{{ tenant_storage_class_name | default('undefined') }}'"
+        success_msg: "First-match semantics confirmed: {{ tenant_storage_class_name }}"
+      when: test_duplicate_tier | default(false) | bool

--- a/collections/ansible_collections/osac/service/roles/tenant_storage_class/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/tenant_storage_class/tests/test.yml
@@ -15,6 +15,9 @@
 #
 #   Test 3 (empty storageClasses list):
 #     ansible-playbook ... -e test_empty_list=true
+#
+#   Test 4 (duplicate tiers -- first-match semantics):
+#     ansible-playbook ... -e test_duplicate_tier=true
 
 # ──────────────────────────────────────────────────────────────
 # Test 1: Resolve requested tier (happy path)
@@ -29,6 +32,7 @@
       ansible.builtin.include_role:
         name: osac.service.tenant_storage_class
       vars:
+        tenant_storage_class_tenant_name: "tenant-acme"
         tenant_storage_class_storage_classes:
           - name: "ceph-acme-default"
             tier: "default"
@@ -48,7 +52,7 @@
 
 # ──────────────────────────────────────────────────────────────
 # Test 2: Requested tier not available -- error path
-# Expected: role fails with message listing available tiers
+# Expected: role fails with message listing available tiers and tenant name
 # ──────────────────────────────────────────────────────────────
 - name: Test tenant_storage_class role -- tier not available (should fail)
   hosts: localhost
@@ -62,6 +66,7 @@
           ansible.builtin.include_role:
             name: osac.service.tenant_storage_class
           vars:
+            tenant_storage_class_tenant_name: "tenant-acme"
             tenant_storage_class_storage_classes:
               - name: "ceph-acme-default"
                 tier: "default"
@@ -78,13 +83,14 @@
           ansible.builtin.assert:
             that:
               - "'is not available' in ansible_failed_result.msg"
+              - "'tenant-acme' in ansible_failed_result.msg"
               - "'Available tiers' in ansible_failed_result.msg"
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg }}"
             success_msg: "Role failed as expected: {{ ansible_failed_result.msg }}"
 
 # ──────────────────────────────────────────────────────────────
 # Test 3: Empty storageClasses list -- error path
-# Expected: role fails with "empty" message
+# Expected: role fails with "empty" message including tenant name
 # ──────────────────────────────────────────────────────────────
 - name: Test tenant_storage_class role -- empty storageClasses (should fail)
   hosts: localhost
@@ -98,6 +104,7 @@
           ansible.builtin.include_role:
             name: osac.service.tenant_storage_class
           vars:
+            tenant_storage_class_tenant_name: "tenant-acme"
             tenant_storage_class_storage_classes: []
             tenant_storage_class_storage_tier: "default"
 
@@ -110,6 +117,7 @@
           ansible.builtin.assert:
             that:
               - "'empty' in ansible_failed_result.msg"
+              - "'tenant-acme' in ansible_failed_result.msg"
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg }}"
             success_msg: "Role failed as expected: {{ ansible_failed_result.msg }}"
 
@@ -126,6 +134,7 @@
       ansible.builtin.include_role:
         name: osac.service.tenant_storage_class
       vars:
+        tenant_storage_class_tenant_name: "tenant-acme"
         tenant_storage_class_storage_classes:
           - name: "ceph-fast-primary"
             tier: "fast"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_resources.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_resources.yaml
@@ -1,11 +1,9 @@
 ---
-- name: Require non-empty tenant StorageClass
-  ansible.builtin.assert:
-    that: tenant_storage_class_name | length > 0
-    fail_msg: >-
-      ComputeInstance provisioning requires a StorageClass for the tenant.
-      tenant_storage_class_name is set but empty.
-    success_msg: "Using tenant StorageClass: {{ tenant_storage_class_name }}"
+- name: Resolve StorageClass for this template's storage tier
+  ansible.builtin.include_role:
+    name: osac.service.tenant_storage_class
+  vars:
+    tenant_storage_class_storage_tier: "default"
 
 - name: Set storage_class from tenant StorageClass
   ansible.builtin.set_fact:

--- a/playbook_osac_create_compute_instance.yml
+++ b/playbook_osac_create_compute_instance.yml
@@ -27,9 +27,7 @@
           ComputeInstance '{{ compute_instance_name }}' has no tenant_storage_classes
           in extra_vars. The osac-operator CI controller should inject the resolved
           storageClasses list before triggering provisioning.
-      when: >-
-        tenant_storage_classes is not defined or
-        tenant_storage_classes | length == 0
+      when: tenant_storage_classes | length == 0
 
     - name: Set storage classes list for downstream roles
       ansible.builtin.set_fact:

--- a/playbook_osac_create_compute_instance.yml
+++ b/playbook_osac_create_compute_instance.yml
@@ -29,9 +29,10 @@
           storageClasses list before triggering provisioning.
       when: tenant_storage_classes | length == 0
 
-    - name: Set storage classes list for downstream roles
+    - name: Set storage classes context for downstream roles
       ansible.builtin.set_fact:
         tenant_storage_class_storage_classes: "{{ tenant_storage_classes }}"
+        tenant_storage_class_tenant_name: "{{ compute_instance.status.tenantReference.name }}"
 
   tasks:
 

--- a/playbook_osac_create_compute_instance.yml
+++ b/playbook_osac_create_compute_instance.yml
@@ -8,6 +8,7 @@
     compute_instance_name: "{{ ansible_eda.event.payload.metadata.name }}"
     template_id: "{{ ansible_eda.event.payload.spec.templateID }}"
     template_parameters: {}
+    tenant_storage_classes: "{{ ansible_eda.event.tenant_storage_classes | default([]) }}"
 
   pre_tasks:
     - name: Show EDA Event
@@ -20,25 +21,19 @@
       ansible.builtin.include_role:
         name: osac.service.tenant_target_namespace
 
-    # Discover tenant StorageClass from Tenant status; sets tenant_storage_class_name
-    - name: Fail if tenant reference is missing
+    - name: Fail if tenant storage classes not injected
       ansible.builtin.fail:
         msg: >-
-          ComputeInstance '{{ compute_instance_name }}' has no tenantReference in status.
-          The osac-operator CI controller should set this before triggering provisioning.
+          ComputeInstance '{{ compute_instance_name }}' has no tenant_storage_classes
+          in extra_vars. The osac-operator CI controller should inject the resolved
+          storageClasses list before triggering provisioning.
       when: >-
-        compute_instance.status.tenantReference is not defined or
-        compute_instance.status.tenantReference.name is not defined or
-        compute_instance.status.tenantReference.name | length == 0 or
-        compute_instance.status.tenantReference.namespace is not defined or
-        compute_instance.status.tenantReference.namespace | length == 0
+        tenant_storage_classes is not defined or
+        tenant_storage_classes | length == 0
 
-    - name: Discover tenant StorageClass from Tenant status
-      ansible.builtin.include_role:
-        name: osac.service.tenant_storage_class
-      vars:
-        tenant_storage_class_tenant_name: "{{ compute_instance.status.tenantReference.name }}"
-        tenant_namespace: "{{ compute_instance.status.tenantReference.namespace }}"
+    - name: Set storage classes list for downstream roles
+      ansible.builtin.set_fact:
+        tenant_storage_class_storage_classes: "{{ tenant_storage_classes }}"
 
   tasks:
 


### PR DESCRIPTION
## Summary

- Update `tenant_storage_class` role to read the resolved `storageClasses` list from extra_vars (injected by the CI controller) instead of querying the Tenant CR via `k8s_info`
- Require `tenant_storage_class_storage_tier` parameter with no default value — templates must be explicit about which tier they need
- Move `tenant_storage_class` role invocation from playbook `pre_tasks` into the `ocp_virt_vm` template role, which passes `tier: "default"`
- Playbook extracts `tenant_storage_classes` from `ansible_eda.event.tenant_storage_classes` and sets it as a fact for downstream roles

Per the [Tenant Storage Tiers](https://github.com/osac-project/enhancement-proposals/blob/main/enhancements/tenant-storage-tiers/README.md) enhancement proposal, templates use template-driven tier selection: each template hardcodes which tier its disks need, and the user doesn't need to know about storage tiers.

### Flow

```
CI controller injects tenant_storage_classes into extra_vars (OSAC-687)
  → Playbook extracts it as a variable
  → Template role (ocp_virt_vm) calls tenant_storage_class with tier: "default"
  → Role matches tier in the list → sets tenant_storage_class_name
  → Template uses it for DataVolume creation
```

## Test plan

- [x] `ansible-lint` passes
- [x] Role tests are self-contained (no cluster needed): happy path, tier not available, empty list, duplicate tier first-match

Jira: [OSAC-175](https://redhat.atlassian.net/browse/OSAC-175), [OSAC-176](https://redhat.atlassian.net/browse/OSAC-176)

**Companion PR:** [osac-operator#229](https://github.com/osac-project/osac-operator/pull/229) (OSAC-687) injects `tenant_storage_classes` into extra_vars from the CI controller.