### PR TITLE
OSAC-739: Fix security group label not propagated to VM pods

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/cudn_net/README.md
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/README.md
@@ -42,7 +42,7 @@ SecurityGroups translate to Kubernetes NetworkPolicy resources that enforce netw
 **Key behaviors:**
 - One NetworkPolicy per SecurityGroup (named `sg-{security-group-name}`)
 - NetworkPolicies are deployed to all Subnet namespaces associated with the SecurityGroup's parent VirtualNetwork
-- Pod selection uses label `osac.openshift.io/securitygroup-{sg-name}: ""`
+- Pod selection uses label `osac.openshift.io/{sg-name}: ""` (where `{sg-name}` is the SecurityGroup resource name, e.g. `securitygroup-4p49v`)
 - Multiple SecurityGroups are additive: pods can have multiple SG labels, and traffic is allowed if ANY NetworkPolicy allows it
 - Empty ingress/egress rule arrays result in deny-all for that direction
 
@@ -64,8 +64,8 @@ Pods can have multiple SecurityGroup associations:
 ```yaml
 metadata:
   labels:
-    osac.openshift.io/securitygroup-web-sg: ""
-    osac.openshift.io/securitygroup-db-sg: ""
+    osac.openshift.io/securitygroup-4p49v: ""
+    osac.openshift.io/securitygroup-7x2km: ""
 ```
 Each SecurityGroup creates its own NetworkPolicy, and Kubernetes applies them additively (traffic allowed if ANY policy allows).
 

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/README.md
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/README.md
@@ -42,7 +42,7 @@ SecurityGroups translate to Kubernetes NetworkPolicy resources that enforce netw
 **Key behaviors:**
 - One NetworkPolicy per SecurityGroup (named `sg-{security-group-name}`)
 - NetworkPolicies are deployed to all Subnet namespaces associated with the SecurityGroup's parent VirtualNetwork
-- Pod selection uses label `security-group.osac.openshift.io/{sg-name}: ""`
+- Pod selection uses label `osac.openshift.io/securitygroup-{sg-name}: ""`
 - Multiple SecurityGroups are additive: pods can have multiple SG labels, and traffic is allowed if ANY NetworkPolicy allows it
 - Empty ingress/egress rule arrays result in deny-all for that direction
 
@@ -64,8 +64,8 @@ Pods can have multiple SecurityGroup associations:
 ```yaml
 metadata:
   labels:
-    security-group.osac.openshift.io/web-sg: ""
-    security-group.osac.openshift.io/db-sg: ""
+    osac.openshift.io/securitygroup-web-sg: ""
+    osac.openshift.io/securitygroup-db-sg: ""
 ```
 Each SecurityGroup creates its own NetworkPolicy, and Kubernetes applies them additively (traffic allowed if ANY policy allows).
 

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/tasks/create_security_group.yaml
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/tasks/create_security_group.yaml
@@ -84,7 +84,7 @@
 
 - name: Build pod selector label for NetworkPolicy
   ansible.builtin.set_fact:
-    sg_pod_selector_labels: "{{ {'osac.openshift.io/securitygroup-' ~ sg_name: ''} }}"
+    sg_pod_selector_labels: "{{ {'osac.openshift.io/' ~ sg_name: ''} }}"
 
 - name: Create NetworkPolicy in target namespaces
   when: target_namespaces | default([]) | length > 0

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/tasks/create_security_group.yaml
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/tasks/create_security_group.yaml
@@ -82,6 +82,10 @@
         )
       }}
 
+- name: Build pod selector label for NetworkPolicy
+  ansible.builtin.set_fact:
+    sg_pod_selector_labels: "{{ {'osac.openshift.io/securitygroup-' ~ sg_name: ''} }}"
+
 - name: Create NetworkPolicy in target namespaces
   when: target_namespaces | default([]) | length > 0
   block:
@@ -97,12 +101,11 @@
             namespace: "{{ item }}"
             labels:
               osac.openshift.io/managed-by: osac-fulfillment
-              osac.openshift.io/security-group: "{{ sg_name }}"
+              osac.openshift.io/securitygroup: "{{ sg_name }}"
               osac.openshift.io/virtual-network: "{{ sg_virtual_network }}"
           spec:
             podSelector:
-              matchLabels:
-                osac.openshift.io/security-group: "{{ sg_name }}"
+              matchLabels: "{{ sg_pod_selector_labels }}"
             policyTypes: "{{ policy_types }}"
             ingress: "{{ ingress_policy_rules }}"
             egress: "{{ egress_policy_rules }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_validate.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_validate.yaml
@@ -19,7 +19,13 @@
     vm_ssh_key: "{{ compute_instance.spec.sshKey | default('') }}"
     vm_user_data_secret_ref: "{{ (compute_instance.spec.userDataSecretRef | default({})).name | default('') }}"
     vm_additional_disks: "{{ compute_instance.spec.additionalDisks | default([]) }}"
-    vm_security_groups: "{{ compute_instance.spec.securityGroups | default([]) }}"
+    vm_security_groups: >-
+      {{
+        compute_instance.spec.networkAttachments
+        | default([])
+        | map(attribute='securityGroupRefs', default=[])
+        | flatten
+      }}
 
 - name: Require explicit Windows container disk (no vendor default image)
   ansible.builtin.assert:

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_validate.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_validate.yaml
@@ -85,9 +85,9 @@
 
 - name: Build per-SG pod labels for VM
   ansible.builtin.set_fact:
-    vm_sg_labels: "{{ vm_sg_labels | combine({'osac.openshift.io/securitygroup-' ~ item: ''}) }}"
+    vm_sg_labels: "{{ vm_sg_labels | combine({'osac.openshift.io/' ~ item: ''}) }}"
   loop: "{{ vm_security_groups }}"
 
-- name: Override default VM labels to include per-SG labels
+- name: Merge security group labels into default VM labels
   ansible.builtin.set_fact:
     default_vm_labels: "{{ default_vm_labels | combine(vm_sg_labels) }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_validate.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_validate.yaml
@@ -19,6 +19,7 @@
     vm_ssh_key: "{{ compute_instance.spec.sshKey | default('') }}"
     vm_user_data_secret_ref: "{{ (compute_instance.spec.userDataSecretRef | default({})).name | default('') }}"
     vm_additional_disks: "{{ compute_instance.spec.additionalDisks | default([]) }}"
+    vm_security_groups: "{{ compute_instance.spec.securityGroups | default([]) }}"
 
 - name: Require explicit Windows container disk (no vendor default image)
   ansible.builtin.assert:
@@ -71,3 +72,16 @@
   loop: "{{ params.exposed_ports.split(',') }}"
   loop_control:
     label: "{{ item.split('/')[0] }}"
+
+- name: Initialize security group labels accumulator
+  ansible.builtin.set_fact:
+    vm_sg_labels: {}
+
+- name: Build per-SG pod labels for VM
+  ansible.builtin.set_fact:
+    vm_sg_labels: "{{ vm_sg_labels | combine({'osac.openshift.io/securitygroup-' ~ item: ''}) }}"
+  loop: "{{ vm_security_groups }}"
+
+- name: Override default VM labels to include per-SG labels
+  ansible.builtin.set_fact:
+    default_vm_labels: "{{ default_vm_labels | combine(vm_sg_labels) }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-with-security-groups.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-with-security-groups.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: osac-system
 spec:
   templateID: osac.templates.ocp_virt_vm
-  securityGroups:
-    - web-sg
-    - db-sg
+  networkAttachments:
+    - subnetRef: test-subnet
+      securityGroupRefs:
+        - web-sg
+        - db-sg
 status:
   desiredConfigVersion: "1"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-with-security-groups.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-with-security-groups.yaml
@@ -9,7 +9,10 @@ spec:
   networkAttachments:
     - subnetRef: test-subnet
       securityGroupRefs:
-        - web-sg
-        - db-sg
+        - securitygroup-web01
+        - securitygroup-db01
+    - subnetRef: monitoring-subnet
+      securityGroupRefs:
+        - securitygroup-mon01
 status:
   desiredConfigVersion: "1"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-with-security-groups.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-with-security-groups.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: osac.openshift.io/v1alpha1
+kind: ComputeInstance
+metadata:
+  name: test-vm-sgs
+  namespace: osac-system
+spec:
+  templateID: osac.templates.ocp_virt_vm
+  securityGroups:
+    - web-sg
+    - db-sg
+status:
+  desiredConfigVersion: "1"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/test.yml
@@ -33,12 +33,19 @@
   collections:
     - osac.templates
 
+  vars:
+    compute_instance_label: "osac.openshift.io/computeinstance"
+
   tasks:
     - when: test_create_defaults | default(false) | bool
       block:
         - name: Read minimal ComputeInstance fixture (no spec fields)
           ansible.builtin.set_fact:
             compute_instance: "{{ lookup('file', 'fixtures/computeinstance-defaults-test.yaml') | from_yaml }}"
+
+        - name: Set compute instance name
+          ansible.builtin.set_fact:
+            compute_instance_name: "{{ compute_instance.metadata.name }}"
 
         - name: Run create_validate to merge defaults and extract VM config
           ansible.builtin.include_role:
@@ -96,12 +103,19 @@
   collections:
     - osac.templates
 
+  vars:
+    compute_instance_label: "osac.openshift.io/computeinstance"
+
   tasks:
     - when: test_create_validation_valid | default(false) | bool
       block:
         - name: Read minimal ComputeInstance fixture
           ansible.builtin.set_fact:
             compute_instance: "{{ lookup('file', 'fixtures/computeinstance-defaults-test.yaml') | from_yaml }}"
+
+        - name: Set compute instance name
+          ansible.builtin.set_fact:
+            compute_instance_name: "{{ compute_instance.metadata.name }}"
 
         - name: Set template parameters with valid exposed_ports
           ansible.builtin.set_fact:
@@ -159,6 +173,9 @@
   collections:
     - osac.templates
 
+  vars:
+    compute_instance_label: "osac.openshift.io/computeinstance"
+
   tasks:
     - when: test_windows_requires_image | default(false) | bool
       block:
@@ -173,6 +190,10 @@
             default_spec: "{{ _guest_os_windows_default_spec }}"
             default_arg_specs: "{{ _guest_os_windows_default_arg_specs }}"
             template_parameters: {}
+
+        - name: Set compute instance name
+          ansible.builtin.set_fact:
+            compute_instance_name: "{{ compute_instance.metadata.name }}"
 
         - name: Run create_validate (expect failure — no Windows container disk)
           block:
@@ -209,6 +230,9 @@
   collections:
     - osac.templates
 
+  vars:
+    compute_instance_label: "osac.openshift.io/computeinstance"
+
   tasks:
     - when: test_windows_with_image | default(false) | bool
       block:
@@ -224,6 +248,10 @@
             default_arg_specs: "{{ _guest_os_windows_default_arg_specs }}"
             template_parameters: {}
 
+        - name: Set compute instance name
+          ansible.builtin.set_fact:
+            compute_instance_name: "{{ compute_instance.metadata.name }}"
+
         - name: Run create_validate
           ansible.builtin.include_role:
             name: osac.templates.ocp_virt_vm
@@ -237,8 +265,8 @@
 
 # ──────────────────────────────────────────────────────────────
 # Test 6: Security group labels are propagated to default_vm_labels
-# Expected: default_vm_labels includes osac.openshift.io/securitygroup-<sg-name>: ""
-#           for each SecurityGroup in spec.securityGroups
+# Expected: default_vm_labels includes osac.openshift.io/<sg-ref>: ""
+#           for each securityGroupRef across all spec.networkAttachments
 # ──────────────────────────────────────────────────────────────
 - name: "Test ocp_virt_vm -- security group labels propagated to VM"
   hosts: localhost
@@ -256,6 +284,10 @@
           ansible.builtin.set_fact:
             compute_instance: "{{ lookup('file', 'fixtures/computeinstance-with-security-groups.yaml') | from_yaml }}"
 
+        - name: Set compute instance name
+          ansible.builtin.set_fact:
+            compute_instance_name: "{{ compute_instance.metadata.name }}"
+
         - name: Run create_validate to extract VM config and build labels
           ansible.builtin.include_role:
             name: osac.templates.ocp_virt_vm
@@ -270,28 +302,37 @@
               Expected default_vm_labels to contain osac.openshift.io/computeinstance=test-vm-sgs,
               got {{ default_vm_labels | default('undefined') }}
 
-        - name: Verify web-sg label is present in VM labels
+        - name: Verify securitygroup-web01 label is present in VM labels
           ansible.builtin.assert:
             that:
-              - "'osac.openshift.io/securitygroup-web-sg' in default_vm_labels"
-              - default_vm_labels['osac.openshift.io/securitygroup-web-sg'] == ''
+              - "'osac.openshift.io/securitygroup-web01' in default_vm_labels"
+              - default_vm_labels['osac.openshift.io/securitygroup-web01'] == ''
             fail_msg: >-
-              Expected default_vm_labels to contain osac.openshift.io/securitygroup-web-sg='',
+              Expected default_vm_labels to contain osac.openshift.io/securitygroup-web01='',
               got {{ default_vm_labels | default('undefined') }}
 
-        - name: Verify db-sg label is present in VM labels
+        - name: Verify securitygroup-db01 label is present in VM labels
           ansible.builtin.assert:
             that:
-              - "'osac.openshift.io/securitygroup-db-sg' in default_vm_labels"
-              - default_vm_labels['osac.openshift.io/securitygroup-db-sg'] == ''
+              - "'osac.openshift.io/securitygroup-db01' in default_vm_labels"
+              - default_vm_labels['osac.openshift.io/securitygroup-db01'] == ''
             fail_msg: >-
-              Expected default_vm_labels to contain osac.openshift.io/securitygroup-db-sg='',
+              Expected default_vm_labels to contain osac.openshift.io/securitygroup-db01='',
               got {{ default_vm_labels | default('undefined') }}
 
-        - name: Verify exactly 3 labels are set (computeinstance + 2 SGs)
+        - name: Verify securitygroup-mon01 label is present in VM labels
           ansible.builtin.assert:
             that:
-              - default_vm_labels | length == 3
+              - "'osac.openshift.io/securitygroup-mon01' in default_vm_labels"
+              - default_vm_labels['osac.openshift.io/securitygroup-mon01'] == ''
             fail_msg: >-
-              Expected 3 labels in default_vm_labels (1 base + 2 SGs),
+              Expected default_vm_labels to contain osac.openshift.io/securitygroup-mon01='',
+              got {{ default_vm_labels | default('undefined') }}
+
+        - name: Verify exactly 4 labels are set (computeinstance + 3 SGs)
+          ansible.builtin.assert:
+            that:
+              - default_vm_labels | length == 4
+            fail_msg: >-
+              Expected 4 labels in default_vm_labels (1 base + 3 SGs),
               got {{ default_vm_labels | length }}: {{ default_vm_labels | default('undefined') }}

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/test.yml
@@ -19,6 +19,9 @@
 #
 #   Test 5 (Windows with explicit image accepted):
 #     ansible-playbook ... -e test_windows_with_image=true
+#
+#   Test 6 (security group labels propagated to VM):
+#     ansible-playbook ... -e test_create_sg_labels=true
 
 # ──────────────────────────────────────────────────────────────
 # Test 1: Verify spec defaults are merged into a minimal fixture
@@ -231,3 +234,64 @@
             that:
               - vm_image_source == "registry.example.com/osac/windows-golden:ltsc2022"
             fail_msg: "Expected vm_image_source from spec, got {{ vm_image_source | default('undefined') }}"
+
+# ──────────────────────────────────────────────────────────────
+# Test 6: Security group labels are propagated to default_vm_labels
+# Expected: default_vm_labels includes osac.openshift.io/securitygroup-<sg-name>: ""
+#           for each SecurityGroup in spec.securityGroups
+# ──────────────────────────────────────────────────────────────
+- name: "Test ocp_virt_vm -- security group labels propagated to VM"
+  hosts: localhost
+
+  collections:
+    - osac.templates
+
+  vars:
+    compute_instance_label: "osac.openshift.io/computeinstance"
+
+  tasks:
+    - when: test_create_sg_labels | default(false) | bool
+      block:
+        - name: Read ComputeInstance fixture with security groups
+          ansible.builtin.set_fact:
+            compute_instance: "{{ lookup('file', 'fixtures/computeinstance-with-security-groups.yaml') | from_yaml }}"
+
+        - name: Run create_validate to extract VM config and build labels
+          ansible.builtin.include_role:
+            name: osac.templates.ocp_virt_vm
+            tasks_from: create_validate.yaml
+
+        - name: Verify compute instance base label is present
+          ansible.builtin.assert:
+            that:
+              - default_vm_labels is defined
+              - default_vm_labels['osac.openshift.io/computeinstance'] == 'test-vm-sgs'
+            fail_msg: >-
+              Expected default_vm_labels to contain osac.openshift.io/computeinstance=test-vm-sgs,
+              got {{ default_vm_labels | default('undefined') }}
+
+        - name: Verify web-sg label is present in VM labels
+          ansible.builtin.assert:
+            that:
+              - "'osac.openshift.io/securitygroup-web-sg' in default_vm_labels"
+              - default_vm_labels['osac.openshift.io/securitygroup-web-sg'] == ''
+            fail_msg: >-
+              Expected default_vm_labels to contain osac.openshift.io/securitygroup-web-sg='',
+              got {{ default_vm_labels | default('undefined') }}
+
+        - name: Verify db-sg label is present in VM labels
+          ansible.builtin.assert:
+            that:
+              - "'osac.openshift.io/securitygroup-db-sg' in default_vm_labels"
+              - default_vm_labels['osac.openshift.io/securitygroup-db-sg'] == ''
+            fail_msg: >-
+              Expected default_vm_labels to contain osac.openshift.io/securitygroup-db-sg='',
+              got {{ default_vm_labels | default('undefined') }}
+
+        - name: Verify exactly 3 labels are set (computeinstance + 2 SGs)
+          ansible.builtin.assert:
+            that:
+              - default_vm_labels | length == 3
+            fail_msg: >-
+              Expected 3 labels in default_vm_labels (1 base + 2 SGs),
+              got {{ default_vm_labels | length }}: {{ default_vm_labels | default('undefined') }}


### PR DESCRIPTION
### Problem
When a ComputeInstance references SecurityGroups, VM pods were never labelled with security-group.osac.io/<sg-name>: "". The NetworkPolicy created by cudn_net selected pods by that label, so with no pods carrying it the policy matched nothing and all traffic passed unfiltered.
Two root causes:
ocp_virt_vm/create_validate.yaml never read spec.securityGroups — default_vm_labels (stamped onto the pod template) only ever contained osac.openshift.io/computeinstance.
cudn_net/create_security_group.yaml used osac.io/security-group: <name> (single key, one value) as the podSelector — incompatible with multiple SGs per VM and misaligned with the per-SG key scheme documented in the README.

### Changes

- ocp_virt_vm/tasks/create_validate.yaml:	Read spec.securityGroups, loop to build security-group.osac.io/<sg-name>: "" per SG, merge into default_vm_labels
- cudn_net/tasks/create_security_group.yaml:	Changed podSelector.matchLabels from osac.io/security-group: <name> → security-group.osac.io/<name>: ""

### Tests
- Added Test  to tests/test.yml (-e test_create_sg_labels=true) — runs create_validate.yaml against the fixture and asserts that default_vm_labels contains security-group.osac.io/web-sg: "", security-group.osac.io/db-sg: "", and the base computeinstance label

### Manual testing
- Verified the VM was stamped with the expected label:  security-group.osac.io/securitygroup-4p49v: ""
- Confirmed the security group label is present on both the VM metadata and pod template, matching the updated NetworkPolicy selector scheme.

- Created a security group with only ICMP ingress/egress rules for 192.168.1.10/32:
```
osac create securitygroup --name norules --virtual-network \
  --ingress protocol=icmp,ipv4-cidr=192.168.1.10/32 \
  --egress protocol=icmp,ipv4-cidr=192.168.1.10/32
```

- Verified enforcement from inside the VM console:

1. - ping 8.8.8.8 failed as expected (traffic denied).
2. - ping 192.168.1.30 succeeded as expected (allowed traffic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VMs now get security-group labels derived from network attachments; NetworkPolicies match pods using the new osac.openshift.io/securitygroup label format and support multiple groups.

* **Tests**
  * Added an offline test and fixture verifying security-group labels are propagated to virtual machines.

* **Documentation**
  * Updated README examples to show the new single- and multi–security-group label keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->