### PR TITLE
OSAC-780: do not require spec.computeInstance for PublicIP detach

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -29,7 +29,7 @@
     detach_pool_name: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicippool-name'] }}
     detach_compute_instance_uuid: >-
-      {{ (public_ip.spec.computeInstance | default('')) | trim }}
+      {{ ((public_ip.spec | default({})).computeInstance | default('')) | trim }}
 
 - name: Fetch ComputeInstance CR
   kubernetes.core.k8s_info:

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -15,12 +15,9 @@
       - public_ip.metadata.annotations is defined
       - "'osac.openshift.io/publicippool-name' in public_ip.metadata.annotations"
       - "'osac.openshift.io/publicip-target-namespace' in public_ip.metadata.annotations"
-      - public_ip.spec is defined
-      - public_ip.spec.computeInstance is defined
-      - public_ip.spec.computeInstance | length > 0
     fail_msg: >-
       PublicIP is missing required fields/annotations:
-      metadata.name, metadata.namespace, and spec.computeInstance must be set,
+      metadata.name and metadata.namespace must be set,
       and annotations osac.openshift.io/publicippool-name and
       osac.openshift.io/publicip-target-namespace must both be present.
 
@@ -31,6 +28,8 @@
       {{ public_ip.metadata.annotations['osac.openshift.io/publicip-target-namespace'] }}
     detach_pool_name: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicippool-name'] }}
+    detach_compute_instance_uuid: >-
+      {{ (public_ip.spec.computeInstance | default('')) | trim }}
 
 - name: Fetch ComputeInstance CR
   kubernetes.core.k8s_info:
@@ -39,19 +38,16 @@
     kind: ComputeInstance
     namespace: "{{ public_ip.metadata.namespace }}"
     label_selectors:
-      - "osac.openshift.io/computeinstance-uuid={{ public_ip.spec.computeInstance }}"
+      - "osac.openshift.io/computeinstance-uuid={{ detach_compute_instance_uuid }}"
   register: detach_ci_lookup
-
-- name: Fail if ComputeInstance not found
-  ansible.builtin.fail:
-    msg: >-
-      ComputeInstance with uuid '{{ public_ip.spec.computeInstance }}' not found
-      in namespace '{{ public_ip.metadata.namespace }}'.
-  when: detach_ci_lookup.resources | length == 0
+  when: detach_compute_instance_uuid | length > 0
 
 - name: Extract ComputeInstance name from fetched CR
   ansible.builtin.set_fact:
     detach_compute_instance_name: "{{ detach_ci_lookup.resources[0].metadata.name }}"
+  when:
+    - detach_ci_lookup is not skipped
+    - detach_ci_lookup.resources | default([]) | length > 0
 
 # Read the IP from the VM namespace LB Service before deleting it.
 - name: Read IP from VM namespace LoadBalancer Service
@@ -72,9 +68,18 @@
     lb_service_info.resources | length == 0 or
     lb_service_info.resources[0].status.loadBalancer.ingress | default([]) | length == 0
 
-- name: Extract IP address from VM namespace LB Service
+- name: Extract IP address and VM name from VM namespace LB Service
   ansible.builtin.set_fact:
     detach_ip_address: "{{ lb_service_info.resources[0].status.loadBalancer.ingress[0].ip }}"
+    detach_vm_name_from_svc: >-
+      {{ (lb_service_info.resources[0].spec.selector | default({}))['vm.kubevirt.io/name'] | default('') }}
+
+- name: Set ComputeInstance name from LB Service selector if not already known
+  ansible.builtin.set_fact:
+    detach_compute_instance_name: "{{ detach_vm_name_from_svc }}"
+  when:
+    - detach_compute_instance_name is not defined
+    - detach_vm_name_from_svc | length > 0
 
 - name: Display PublicIP detach information
   ansible.builtin.debug:
@@ -83,7 +88,7 @@
       - "IP address: {{ detach_ip_address }} (read from VM namespace LB Service)"
       - "Pool: {{ detach_pool_name }}"
       - "VM namespace: {{ detach_vm_namespace }}"
-      - "ComputeInstance: {{ detach_compute_instance_name }} ({{ public_ip.metadata.namespace }})"
+      - "ComputeInstance: {{ detach_compute_instance_name | default('not available') }}"
 
 # Delete the LB Service, clear the annotation, and restore the placeholder atomically.
 # The rescue restores the LB Service if placeholder re-creation fails so the IP
@@ -178,7 +183,9 @@
                 port: 22
                 targetPort: 22
                 protocol: TCP
-      when: lb_service_delete_result.changed | default(false)
+      when:
+        - lb_service_delete_result.changed | default(false)
+        - detach_compute_instance_name is defined
       register: rescue_lb_result
       retries: 3
       delay: 5
@@ -200,6 +207,7 @@
     name: "{{ detach_compute_instance_name }}"
     namespace: "{{ public_ip.metadata.namespace }}"
   register: ci_info
+  when: detach_compute_instance_name is defined
 
 - name: Remove public-ip-address annotation from ComputeInstance CR
   kubernetes.core.k8s_json_patch:
@@ -212,21 +220,26 @@
       - op: remove
         path: /metadata/annotations/osac.openshift.io~1public-ip-address
   register: ci_patch_result
-  when: >-
-    ci_info.resources | length > 0 and
-    (ci_info.resources[0].metadata.annotations | default({}))
-    ['osac.openshift.io/public-ip-address'] is defined
+  when:
+    - detach_compute_instance_name is defined
+    - ci_info is not skipped
+    - ci_info.resources | length > 0
+    - (ci_info.resources[0].metadata.annotations | default({}))
+      ['osac.openshift.io/public-ip-address'] is defined
 
 - name: Display ComputeInstance annotation removal result
   ansible.builtin.debug:
     msg:
       - "ComputeInstance '{{ detach_compute_instance_name }}': public-ip-address annotation removed"
       - "Changed: {{ ci_patch_result.changed | default(false) }}"
-  when: ci_patch_result is defined and ci_patch_result is not skipped
+  when:
+    - detach_compute_instance_name is defined
+    - ci_patch_result is defined
+    - ci_patch_result is not skipped
 
-- name: Display ComputeInstance annotation already absent
+- name: Display ComputeInstance annotation cleanup skipped
   ansible.builtin.debug:
     msg: >-
-      ComputeInstance '{{ detach_compute_instance_name }}':
-      public-ip-address annotation not present, nothing to remove
-  when: ci_patch_result is defined and ci_patch_result is skipped
+      ComputeInstance annotation cleanup skipped
+      (spec.computeInstance was not available during detach)
+  when: detach_compute_instance_name is not defined

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -932,3 +932,170 @@
             name: "{{ test_vm_namespace }}"
             state: absent
           ignore_errors: true
+
+# ──────────────────────────────────────────────────────────────
+# Test: Detach PublicIP without spec.computeInstance
+# Expected:
+#   - Detach succeeds using LB Service selector to resolve VM name
+#   - LoadBalancer Service removed from VM namespace
+#   - Parking Service re-created in metallb-system with the same IP
+#   - CI annotation cleanup skipped (CI not identifiable)
+# This covers the normal operator flow where spec.computeInstance
+# is cleared before the AAP detach job runs.
+# Prerequisites:
+#   - ComputeInstance CRD installed (osac.openshift.io/v1alpha1)
+# ──────────────────────────────────────────────────────────────
+- name: Test metallb_l2 role -- detach PublicIP without spec.computeInstance
+  hosts: localhost
+  gather_facts: false
+  environment:
+    K8S_AUTH_IMPERSONATE_USER: "{{ test_impersonate_user | default('') }}"
+
+  vars:
+    test_ip_name: "test-publicip-no-ci"
+    test_pool_name: "test-metallb-pool"
+    test_vm_namespace: "test-publicip-vm-ns-no-ci"
+    test_vm_name: "test-vm-for-detach"
+    public_ip:
+      metadata:
+        name: "{{ test_ip_name }}"
+        namespace: "default"
+        annotations:
+          osac.openshift.io/publicippool-name: "{{ test_pool_name }}"
+          osac.openshift.io/publicip-target-namespace: "{{ test_vm_namespace }}"
+      spec: {}
+
+  tasks:
+    - name: Run detach-without-computeInstance tests
+      when: run_detach_no_ci | default(true) | bool
+      block:
+        - name: Create VM target namespace
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Namespace
+              metadata:
+                name: "{{ test_vm_namespace }}"
+
+        - name: Create LB Service in VM namespace (simulate attached state)
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: "osac-pip-{{ test_ip_name }}-ingress"
+                namespace: "{{ test_vm_namespace }}"
+                annotations:
+                  metallb.universe.tf/address-pool: "{{ test_pool_name }}"
+                  metallb.universe.tf/loadBalancerIPs: "192.168.100.10"
+                labels:
+                  osac.openshift.io/publicip: "{{ test_ip_name }}"
+                  osac.io/managed-by: osac-fulfillment
+              spec:
+                type: LoadBalancer
+                selector:
+                  vm.kubevirt.io/name: "{{ test_vm_name }}"
+                ports:
+                  - name: ssh
+                    port: 22
+                    targetPort: 22
+                    protocol: TCP
+          register: lb_svc_create
+          retries: 60
+          delay: 10
+          until: lb_svc_create is successful
+
+        - name: Wait for MetalLB to assign IP to LB Service
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-pip-{{ test_ip_name }}-ingress"
+            namespace: "{{ test_vm_namespace }}"
+          register: lb_svc_info
+          retries: 60
+          delay: 10
+          until: >-
+            lb_svc_info.resources | length > 0 and
+            lb_svc_info.resources[0].status.loadBalancer.ingress | default([]) | length > 0
+
+        - name: Record IP assigned to LB Service
+          ansible.builtin.set_fact:
+            pre_detach_ip: "{{ lb_svc_info.resources[0].status.loadBalancer.ingress[0].ip }}"
+
+        - name: Run detach_public_ip role (without spec.computeInstance)
+          ansible.builtin.include_role:
+            name: osac.templates.metallb_l2
+            tasks_from: detach_public_ip
+
+        - name: Verify LB Service deleted from VM namespace
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-pip-{{ test_ip_name }}-ingress"
+            namespace: "{{ test_vm_namespace }}"
+          register: lb_svc_after_detach
+
+        - name: Assert LB Service is gone from VM namespace
+          ansible.builtin.assert:
+            that:
+              - lb_svc_after_detach.resources | length == 0
+            fail_msg: "LB Service still exists in VM namespace after detach (no-CI path)"
+            success_msg: "LB Service correctly removed from '{{ test_vm_namespace }}' (no-CI path)"
+
+        - name: Wait for parking Service to be re-created in metallb-system
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Service
+            name: "osac-pip-{{ test_ip_name }}"
+            namespace: metallb-system
+          register: parking_svc_after_detach
+          retries: 60
+          delay: 10
+          until: >-
+            parking_svc_after_detach.resources | length > 0 and
+            parking_svc_after_detach.resources[0].status.loadBalancer.ingress | default([]) | length > 0
+
+        - name: Verify parking Service is a placeholder (empty selector)
+          ansible.builtin.assert:
+            that:
+              - parking_svc_after_detach.resources[0].spec.type == "LoadBalancer"
+              - parking_svc_after_detach.resources[0].spec.selector | default({}) | length == 0
+            fail_msg: "Re-created parking Service has incorrect spec after detach (no-CI path)"
+            success_msg: "Parking Service re-created with correct placeholder spec (no-CI path)"
+
+        - name: Verify parking Service preserves the same IP
+          ansible.builtin.assert:
+            that:
+              - parking_svc_after_detach.resources[0].status.loadBalancer.ingress[0].ip == pre_detach_ip
+            fail_msg: >-
+              Parking Service IP does not match the original IP '{{ pre_detach_ip }}'
+            success_msg: "Parking Service correctly preserved IP '{{ pre_detach_ip }}' (no-CI path)"
+
+      always:
+        - name: Clean up parking Service from metallb-system
+          kubernetes.core.k8s:
+            api_version: v1
+            kind: Service
+            name: "osac-pip-{{ test_ip_name }}"
+            namespace: metallb-system
+            state: absent
+          ignore_errors: true
+
+        - name: Clean up LB Service from VM namespace
+          kubernetes.core.k8s:
+            api_version: v1
+            kind: Service
+            name: "osac-pip-{{ test_ip_name }}-ingress"
+            namespace: "{{ test_vm_namespace }}"
+            state: absent
+          ignore_errors: true
+
+        - name: Clean up VM target namespace
+          kubernetes.core.k8s:
+            api_version: v1
+            kind: Namespace
+            name: "{{ test_vm_namespace }}"
+            state: absent
+          ignore_errors: true


### PR DESCRIPTION
## Summary

[OSAC-780](https://redhat.atlassian.net/browse/OSAC-780): Relaxes the metallb_l2 detach playbook validation to not require
`spec.computeInstance`. The field is empty by the time the AAP job runs because
the operator clears it to trigger detach.

## Why

The detach flow is: operator clears `spec.computeInstance` on the CR, which triggers
the ATTACHED -> RELEASING state transition, which triggers the AAP detach job. By the
time the playbook runs, `spec.computeInstance` is already empty.

The core detach operation (delete LB Service from VM namespace, re-create placeholder
in metallb-system) only needs the target namespace annotation and the PublicIP name.
It does not need the CI UUID.

The ComputeInstance name (needed for rescue rollback and CI annotation cleanup) is now
resolved from the LB Service selector (`vm.kubevirt.io/name`) as a fallback. CI-specific
cleanup steps are conditional on the CI being identifiable.

## Testing

```bash
# Lint
ansible-lint collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
# Passed (production profile)

# Unit tests (run against edge22 with KUBECONFIG)
KUBECONFIG=edge22-kubeconfig K8S_AUTH_IMPERSONATE_USER=system:admin \
  uv run ansible-playbook collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml \
    -e run_create=true -e run_create_ip=false -e run_delete_ip=false \
    -e run_delete_ip_not_found=false -e run_delete=false -e run_delete_not_found=false \
    -e run_attach=false -e run_detach=false -e run_detach_no_ci=true -v

# Result: ok=44, changed=8, failed=0
# - Pool create: IPAddressPool + L2Advertisement created with correct spec
# - Detach without spec.computeInstance:
#   - LB Service removed from VM namespace
#   - Parking Service re-created in metallb-system with correct placeholder spec
#   - IP preserved (192.168.100.10)
#   - CI annotation cleanup correctly skipped
#   - All resources cleaned up
```

E2E verified on edge22: full attach -> detach -> delete lifecycle completed successfully
with this playbook change deployed via AAP project sync.

## Related PRs

- osac-operator PR #236: fixes annotation preservation and feedback controller DELETING state
- fulfillment-service PR #515 (merged): added PUBLIC_IP_STATE_DELETING

## Ticket

[OSAC-780](https://redhat.atlassian.net/browse/OSAC-780)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detach flow now tolerates missing compute-instance info: operations no longer fail, fallback logging is used, and cleanup steps run conditionally when instance details are available.
  * Rollback and service restoration only occur when actual changes happened; annotation cleanup is skipped if instance name isn’t known.

* **Tests**
  * Added end-to-end test covering detach when compute instance spec is absent, validating service deletion, parking service recreation, IP preservation, and cleanup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-aap/pull/293)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->