### PR TITLE
OSAC-855: add auto-bump workflow for osac-installer submodule

### DIFF
--- a/.github/workflows/bump-osac-installer.yaml
+++ b/.github/workflows/bump-osac-installer.yaml
@@ -50,14 +50,15 @@ jobs:
           git checkout -b "$BRANCH"
           git commit -m "Bump ${SUBMODULE_NAME}: ${PR_TITLE}"
           git push origin "$BRANCH"
+          PR_BODY="Bumps \`${SUBMODULE_NAME}\` submodule.
+
+          Original PR: ${PR_URL}
+          Author: @${PR_AUTHOR}
+          Merge commit: \`${MERGE_SHA}\`"
           gh pr create \
             --repo osac-project/osac-installer \
             --base main \
             --head "$BRANCH" \
             --title "Bump ${SUBMODULE_NAME}: ${PR_TITLE}" \
-            --body "Bumps \`${SUBMODULE_NAME}\` submodule.
-
-Original PR: ${PR_URL}
-Author: @${PR_AUTHOR}
-Merge commit: \`${MERGE_SHA}\`" \
+            --body "$PR_BODY" \
             --assignee "$PR_AUTHOR"

--- a/.github/workflows/bump-osac-installer.yaml
+++ b/.github/workflows/bump-osac-installer.yaml
@@ -1,32 +1,53 @@
 name: Bump submodule in osac-installer
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
 
 jobs:
   bump:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
       SUBMODULE_PATH: base/osac-aap
       SUBMODULE_NAME: osac-aap
     steps:
+      - name: Find merged PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
+        run: |
+          PR_JSON=$(gh api \
+            "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '[.[] | select(.merged_at != null)] | .[0]' 2>/dev/null) || PR_JSON="null"
+          if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
+            echo "No PR found for commit ${{ github.sha }}, skipping"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "number=$(echo "$PR_JSON" | jq -r '.number')" >> "$GITHUB_OUTPUT"
+          echo "title=$(echo "$PR_JSON" | jq -r '.title')" >> "$GITHUB_OUTPUT"
+          echo "url=$(echo "$PR_JSON" | jq -r '.html_url')" >> "$GITHUB_OUTPUT"
+          echo "author=$(echo "$PR_JSON" | jq -r '.user.login')" >> "$GITHUB_OUTPUT"
+          echo "author_id=$(echo "$PR_JSON" | jq -r '.user.id')" >> "$GITHUB_OUTPUT"
+
       - name: Checkout osac-installer
+        if: steps.pr.outputs.found == 'true'
         uses: actions/checkout@v4
         with:
           repository: osac-project/osac-installer
           token: ${{ secrets.OSAC_BOT_PAT }}
 
       - name: Update submodule pointer
+        if: steps.pr.outputs.found == 'true'
         id: update
         run: |
           git submodule update --init "$SUBMODULE_PATH"
           cd "$SUBMODULE_PATH"
           git fetch origin
-          git checkout ${{ github.event.pull_request.merge_commit_sha }}
-          cd ../..
+          git cat-file -t "${{ github.sha }}" 2>/dev/null || { sleep 5; git fetch origin; }
+          git checkout "${{ github.sha }}"
+          cd "$GITHUB_WORKSPACE"
           git add "$SUBMODULE_PATH"
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -35,15 +56,15 @@ jobs:
           fi
 
       - name: Create bump PR
-        if: steps.update.outputs.changed == 'true'
+        if: steps.pr.outputs.found == 'true' && steps.update.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
-          BRANCH: bump/${{ env.SUBMODULE_NAME }}/pr-${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
-          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          BRANCH: bump/${{ env.SUBMODULE_NAME }}/pr-${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author }}
+          PR_AUTHOR_ID: ${{ steps.pr.outputs.author_id }}
+          MERGE_SHA: ${{ github.sha }}
         run: |
           git config user.name "$PR_AUTHOR"
           git config user.email "${PR_AUTHOR_ID}+${PR_AUTHOR}@users.noreply.github.com"
@@ -64,4 +85,9 @@ jobs:
               --title "Bump ${SUBMODULE_NAME}: ${PR_TITLE}" \
               --body "$PR_BODY" \
               --assignee "$PR_AUTHOR"
+          else
+            gh pr edit "$EXISTING" \
+              --repo osac-project/osac-installer \
+              --title "Bump ${SUBMODULE_NAME}: ${PR_TITLE}" \
+              --body "$PR_BODY"
           fi

--- a/.github/workflows/bump-osac-installer.yaml
+++ b/.github/workflows/bump-osac-installer.yaml
@@ -49,16 +49,19 @@ jobs:
           git config user.email "${PR_AUTHOR_ID}+${PR_AUTHOR}@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git commit -m "Bump ${SUBMODULE_NAME}: ${PR_TITLE}"
-          git push origin "$BRANCH"
+          git push --force origin "$BRANCH"
           PR_BODY="Bumps \`${SUBMODULE_NAME}\` submodule.
 
           Original PR: ${PR_URL}
           Author: @${PR_AUTHOR}
           Merge commit: \`${MERGE_SHA}\`"
-          gh pr create \
-            --repo osac-project/osac-installer \
-            --base main \
-            --head "$BRANCH" \
-            --title "Bump ${SUBMODULE_NAME}: ${PR_TITLE}" \
-            --body "$PR_BODY" \
-            --assignee "$PR_AUTHOR"
+          EXISTING=$(gh pr list --repo osac-project/osac-installer --head "$BRANCH" --json number --jq '.[0].number')
+          if [ -z "$EXISTING" ]; then
+            gh pr create \
+              --repo osac-project/osac-installer \
+              --base main \
+              --head "$BRANCH" \
+              --title "Bump ${SUBMODULE_NAME}: ${PR_TITLE}" \
+              --body "$PR_BODY" \
+              --assignee "$PR_AUTHOR"
+          fi

--- a/.github/workflows/bump-osac-installer.yaml
+++ b/.github/workflows/bump-osac-installer.yaml
@@ -1,0 +1,63 @@
+name: Bump submodule in osac-installer
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      SUBMODULE_PATH: base/osac-aap
+      SUBMODULE_NAME: osac-aap
+    steps:
+      - name: Checkout osac-installer
+        uses: actions/checkout@v4
+        with:
+          repository: osac-project/osac-installer
+          token: ${{ secrets.OSAC_BOT_PAT }}
+
+      - name: Update submodule pointer
+        id: update
+        run: |
+          git submodule update --init "$SUBMODULE_PATH"
+          cd "$SUBMODULE_PATH"
+          git fetch origin
+          git checkout ${{ github.event.pull_request.merge_commit_sha }}
+          cd ../..
+          git add "$SUBMODULE_PATH"
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create bump PR
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.OSAC_BOT_PAT }}
+          BRANCH: bump/${{ env.SUBMODULE_NAME }}/pr-${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_ID: ${{ github.event.pull_request.user.id }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          git config user.name "$PR_AUTHOR"
+          git config user.email "${PR_AUTHOR_ID}+${PR_AUTHOR}@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -m "Bump ${SUBMODULE_NAME}: ${PR_TITLE}"
+          git push origin "$BRANCH"
+          gh pr create \
+            --repo osac-project/osac-installer \
+            --base main \
+            --head "$BRANCH" \
+            --title "Bump ${SUBMODULE_NAME}: ${PR_TITLE}" \
+            --body "Bumps \`${SUBMODULE_NAME}\` submodule.
+
+Original PR: ${PR_URL}
+Author: @${PR_AUTHOR}
+Merge commit: \`${MERGE_SHA}\`" \
+            --assignee "$PR_AUTHOR"


### PR DESCRIPTION
When a PR merges to main, this workflow automatically creates a PR on osac-installer
bumping the osac-aap submodule pointer to the new merge commit.

The bump PR is assigned to the original PR author so the responsibility chain is clear:
merging to the component repo is not done until the submodule is bumped in osac-installer.

Requires `OSAC_BOT_PAT` org secret (osac-dev-bot fine-grained PAT with contents + pull-requests write access).