### PR TITLE
Enforce avoidBuggyIPs: true in MetalLB IPAddressPool

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip_pool.yaml
@@ -1,6 +1,6 @@
 ---
 # Create MetalLB IPAddressPool and L2Advertisement for PublicIPPool
-# 1. Creates IPAddressPool with autoAssign: false and addresses from CR spec.cidrs
+# 1. Creates IPAddressPool with autoAssign: false, avoidBuggyIPs: true, and addresses from CR spec.cidrs
 # 2. Creates L2Advertisement referencing the IPAddressPool by name
 
 - name: Include get remote cluster kubeconfig
@@ -34,6 +34,7 @@
           osac.io/managed-by: osac-fulfillment
       spec:
         autoAssign: false
+        avoidBuggyIPs: true  # skip .0 and .255
         addresses: "{{ pool_cidrs }}"
   register: ipaddresspool_result
 


### PR DESCRIPTION
Set `avoidBuggyIPs: true` in the IPAddressPool created by the `metallb_l2` role when provisioning a PublicIPPool CR.

## Why
MetalLB will otherwise assign IPs ending in `.0` or `.255` from a given CIDR, which are network/broadcast addresses in standard IPv4 and can cause connectivity issues with some network equipment. This aligns the behaviour with how major cloud providers handle CIDR ranges.

## Changes
- `roles/metallb_l2/tasks/create_public_ip_pool.yaml`
  - Added `avoidBuggyIPs: true` to the IPAddressPool spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MetalLB IP address pool configuration to prevent allocation of buggy IP addresses. Updates add protective safeguards during IP pool creation while preserving all existing settings for auto-assignment behavior, L2 advertisement functionality, and comprehensive deployment retry mechanisms to maintain reliable and stable cluster networking operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-aap/pull/299)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->