### PR TITLE
Add HostLease playbooks, bm_host_agent_provisioning role, and AAP config

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -279,6 +279,30 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: false
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-create-host-lease"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_create_host_lease.yml"
+    inventory: "{{ aap_prefix }}-bare-metal-fulfillment"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-bare-metal-fulfillment-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+  - name: "{{ aap_prefix }}-delete-host-lease"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_delete_host_lease.yml"
+    inventory: "{{ aap_prefix }}-bare-metal-fulfillment"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-bare-metal-fulfillment-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
 
 controller_job_template_surveys: # noqa: var-naming[no-role-prefix]
   - name: "{{ aap_prefix }}-create-hosted-cluster-post-install"
@@ -380,6 +404,9 @@ controller_inventories: # noqa: var-naming[no-role-prefix]
   - name: "{{ aap_prefix }}-networking-operations"
     description: "Networking Operational Inventory"
     organization: "{{ aap_organization_name }}"
+  - name: "{{ aap_prefix }}-bare-metal-fulfillment"
+    description: "Bare Metal Fulfillment Inventory"
+    organization: "{{ aap_organization_name }}"
 
 controller_inventory_sources: # noqa: var-naming[no-role-prefix]
   - name: "{{ aap_prefix }}-cluster-fulfillment-is"
@@ -424,6 +451,15 @@ controller_inventory_sources: # noqa: var-naming[no-role-prefix]
     source_project: "{{ aap_prefix }}"
     source_path: "inventory/localhost.yml"
     inventory: "{{ aap_prefix }}-networking-operations"
+    overwrite: true
+    overwrite_vars: true
+    update_cache_timeout: 0
+  - name: "{{ aap_prefix }}-bare-metal-fulfillment-is"
+    organization: "{{ aap_organization_name }}"
+    source: scm
+    source_project: "{{ aap_prefix }}"
+    source_path: "inventory/localhost.yml"
+    inventory: "{{ aap_prefix }}-bare-metal-fulfillment"
     overwrite: true
     overwrite_vars: true
     update_cache_timeout: 0
@@ -688,3 +724,81 @@ controller_instance_groups: # noqa: var-naming[no-role-prefix]
   - name: "{{ aap_prefix }}-networking-operations-ig"
     is_container_group: true
     pod_spec_override: "{{ lookup('ansible.builtin.template', 'networking-operations-ig.j2') }}"
+
+  - name: "{{ aap_prefix }}-bare-metal-fulfillment-ig"
+    is_container_group: true
+    pod_spec_override: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        labels:
+          ansible_job: ''
+      spec:
+        serviceAccountName: osac-sa
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                      - key: ansible_job
+                        operator: Exists
+                  topologyKey: kubernetes.io/hostname
+        containers:
+          - image: >-
+              registry.redhat.io/ansible-automation-platform-25/ee-supported-rhel8@sha256:d8400a472e769d0f3d591dafaad318522009c583b08e881c23b6d57a27cc10ed
+            name: worker
+            args:
+              - ansible-runner
+              - worker
+              - '--private-data-dir=/runner'
+            volumeMounts:
+              - name: kube-api-access
+                mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+                readOnly: true
+              - name: os-clouds
+                mountPath: /etc/openstack
+                readOnly: true
+            env:
+              - name: POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
+              - name: OS_CLIENT_CONFIG_FILE
+                value: /etc/openstack/clouds.yaml
+            envFrom:
+              - secretRef:
+                  name: bare-metal-fulfillment-ig
+                  optional: true
+        volumes:
+          - name: kube-api-access
+            projected:
+              sources:
+                - serviceAccountToken:
+                    path: token
+                    expirationSeconds: 3600
+                - configMap:
+                    name: kube-root-ca.crt
+                    items:
+                      - key: ca.crt
+                        path: ca.crt
+                - downwardAPI:
+                    items:
+                      - path: namespace
+                        fieldRef:
+                          apiVersion: v1
+                          fieldPath: metadata.namespace
+                - configMap:
+                    name: openshift-service-ca.crt
+                    items:
+                      - key: service-ca.crt
+                        path: service-ca.crt
+              defaultMode: 420
+          - name: os-clouds
+            secret:
+              secretName: osac-os-clouds
+              items:
+                - key: clouds.yaml
+                  path: clouds.yaml
+              defaultMode: 420

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/create.yaml
@@ -1,0 +1,4 @@
+---
+- name: No-op for bm_host_agent_deprovisioning create
+  ansible.builtin.debug:
+    msg: "bm_host_agent_deprovisioning does not handle creation"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/delete.yaml
@@ -1,0 +1,24 @@
+---
+- name: Fail if host class is not openstack
+  ansible.builtin.fail:
+    msg: "bm_host_agent_deprovisioning requires hostClass 'openstack', got '{{ host_lease.spec.hostClass | default('') }}'"
+  when: host_lease.spec.hostClass | default('') != "openstack"
+
+- name: Detach all networks and delete neutron ports
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l2
+    tasks_from: set_networks_for_node
+  vars:
+    node: "{{ host_lease.spec.externalHostID }}"
+    networks: []
+
+- name: Undeploy bare metal node
+  openstack.cloud.baremetal_node_action:
+    name: "{{ host_lease.spec.externalHostID }}"
+    state: absent
+    deploy: false
+    wait: true
+
+- name: Image deprovisioning initiated
+  ansible.builtin.debug:
+    msg: "Image deprovisioning initiated for node {{ host_lease.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
@@ -1,0 +1,119 @@
+---
+- name: Fail if host class is not openstack
+  ansible.builtin.fail:
+    msg: "bm_host_agent_provisioning requires hostClass 'openstack', got '{{ host_lease.spec.hostClass | default('') }}'"
+  when: host_lease.spec.hostClass | default('') != "openstack"
+
+- name: Parse template parameters
+  ansible.builtin.set_fact:
+    template_params: "{{ host_lease.spec.templateParameters | from_json }}"
+
+- name: Get bare metal node information
+  openstack.cloud.baremetal_node_info:
+    name: "{{ host_lease.spec.externalHostID }}"
+  register: baremetal_node_result
+
+- name: Fail if node not found
+  ansible.builtin.fail:
+    msg: "Bare metal node '{{ host_lease.spec.externalHostID }}' not found in OpenStack"
+  when: baremetal_node_result.nodes | length == 0
+
+- name: Extract node info
+  ansible.builtin.set_fact:
+    node_info: "{{ baremetal_node_result.nodes[0] }}"
+
+- name: Display current node state
+  ansible.builtin.debug:
+    msg:
+      - "Node: {{ node_info.name }}"
+      - "Provision State: {{ node_info.provision_state }}"
+
+- name: Fail if image URL is missing
+  ansible.builtin.fail:
+    msg: "templateParameters.imageURL is required for image provisioning"
+  when: template_params.imageURL | default('') | length == 0
+
+- name: Handle already-active node
+  when: node_info.provision_state == "active"
+  block:
+    - name: Check if node already has the desired image
+      ansible.builtin.set_fact:
+        node_already_has_image: "{{ (node_info.instance_info.boot_iso | default('')) == template_params.imageURL }}"
+
+    - name: Skip provisioning when node already has the desired image
+      when: node_already_has_image
+      ansible.builtin.debug:
+        msg: "Node {{ node_info.name }} is already provisioned with the desired image, skipping"
+
+    - name: Undeploy and refresh node for re-provisioning
+      when: not node_already_has_image
+      block:
+        - name: Undeploy node to re-provision with new image
+          openstack.cloud.baremetal_node_action:
+            name: "{{ host_lease.spec.externalHostID }}"
+            undeploy: true
+            wait: true
+
+        - name: Refresh node info after undeploy
+          openstack.cloud.baremetal_node_info:
+            name: "{{ host_lease.spec.externalHostID }}"
+          register: baremetal_node_result
+
+        - name: Update node info after undeploy
+          ansible.builtin.set_fact:
+            node_info: "{{ baremetal_node_result.nodes[0] }}"
+
+- name: Transition node to available and deploy
+  when: not (node_already_has_image | default(false))
+  block:
+    - name: Move node to manageable state
+      when: node_info.provision_state not in ['manageable', 'available']
+      openstack.cloud.baremetal_node_action:
+        name: "{{ host_lease.spec.externalHostID }}"
+        manage: true
+        wait: true
+
+    - name: Move node to available state
+      when: node_info.provision_state != 'available'
+      openstack.cloud.baremetal_node_action:
+        name: "{{ host_lease.spec.externalHostID }}"
+        provide: true
+        wait: true
+
+    - name: Set provisioning network for node
+      ansible.builtin.include_role:
+        name: massopencloud.esi.l2
+        tasks_from: set_networks_for_node
+      vars:
+        node: "{{ host_lease.spec.externalHostID }}"
+        networks: "{{ [template_params.provisioningNetwork | default('provisioning')] }}"
+
+    - name: Build instance_info for ramdisk deploy
+      ansible.builtin.set_fact:
+        node_instance_info: >-
+          {{
+            {'boot_iso': template_params.imageURL, 'image_source': '', 'image_checksum': ''}
+            | combine(
+                (node_info.deploy_interface | default('') != 'ramdisk')
+                | ternary({'deploy_interface': 'ramdisk'}, {})
+              )
+          }}
+
+    - name: Deploy bare metal node with ramdisk image
+      openstack.cloud.baremetal_node_action:
+        name: "{{ host_lease.spec.externalHostID }}"
+        instance_info: "{{ node_instance_info }}"
+        deploy: true
+        wait: true
+
+- name: Ensure node is on agent private network
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l2
+    tasks_from: set_networks_for_node
+  vars:
+    node: "{{ host_lease.spec.externalHostID }}"
+    networks: "{{ [template_params.agentPrivateNetwork] }}"
+
+- name: Image provisioning completed
+  ansible.builtin.debug:
+    msg: "Image provisioning completed for node {{ host_lease.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/delete.yaml
@@ -1,0 +1,4 @@
+---
+- name: No-op for bm_host_agent_provisioning delete
+  ansible.builtin.debug:
+    msg: "bm_host_agent_provisioning does not handle deletion"

--- a/playbook_osac_create_host_lease.yml
+++ b/playbook_osac_create_host_lease.yml
@@ -1,0 +1,20 @@
+---
+- name: Configure a HostLease resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    host_lease: "{{ ansible_eda.event.payload }}"
+
+  pre_tasks:
+    - name: Display host lease information
+      ansible.builtin.debug:
+        msg:
+          - "Host: {{ host_lease.metadata.name }} ({{ host_lease.metadata.namespace }})"
+          - "External Host ID: {{ host_lease.spec.externalHostID }}"
+
+  tasks:
+    - name: Call the selected host lease template
+      ansible.builtin.include_role:
+        name: "osac.templates.{{ host_lease.spec.templateID }}"
+        tasks_from: create

--- a/playbook_osac_delete_host_lease.yml
+++ b/playbook_osac_delete_host_lease.yml
@@ -1,0 +1,20 @@
+---
+- name: Deconfigure a HostLease resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    host_lease: "{{ ansible_eda.event.payload }}"
+
+  pre_tasks:
+    - name: Display host lease information
+      ansible.builtin.debug:
+        msg:
+          - "Host: {{ host_lease.metadata.name }} ({{ host_lease.metadata.namespace }})"
+          - "External Host ID: {{ host_lease.spec.externalHostID }}"
+
+  tasks:
+    - name: Call the selected host lease template for deletion
+      ansible.builtin.include_role:
+        name: "osac.templates.{{ host_lease.spec.templateID }}"
+        tasks_from: delete


### PR DESCRIPTION
  ## Summary

   - Add `bm_host_agent_provisioning` and `bm_host_agent_deprovisioning` template roles that provision bare metal nodes via OpenStack Ironic ramdisk deploy (create), detach neutron ports and undeploy them on deletion (delete)
   - Add `playbook_osac_create_host_lease.yml` and `playbook_osac_delete_host_lease.yml` that extract HostLease CR fields and delegate to the template role based on `spec.templateID`
   - Register AAP config-as-code resources: bare-metal-fulfillment inventory, inventory source, instance group (with
    OpenStack `clouds.yaml` mount), and job templates for create/delete

   ## Details

   - The provisioning role uses `openstack.cloud.baremetal_node_action` to deploy nodes with a `boot_iso` via the
   ramdisk deploy interface
   - The deprovisioning role detaches all neutron ports via `massopencloud.esi.l2` before undeploying the node
   - The instance group pod spec mounts `osac-os-clouds` secret at `/etc/openstack/clouds.yaml` and sets
   `OS_CLIENT_CONFIG_FILE` so the OpenStack SDK can authenticate to Ironic
   - Environment variables from `bare-metal-fulfillment-ig` secret are injected via `envFrom`