### PR TITLE
fix: HyperConverged GPU passthrough path for `hco.kubevirt.io/v1`

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/meta/argument_specs.yaml
@@ -17,7 +17,8 @@ argument_specs:
           in the KubeVirt domain devices spec, and will also ensure that the
           `HyperConverged` CR (`kubevirt-hyperconverged` in the `openshift-cnv`
           namespace) permits these host devices under
-          `spec.permittedHostDevices.pciHostDevices`.
+          `spec.virtualization.permittedHostDevices.pciHostDevices` (v1) or
+          `spec.permittedHostDevices.pciHostDevices` (v1beta1).
 
           The PCI vendor and product ID for a given GPU can be found by running
           `lspci -nn | grep -i nvidia` on a node that has the device.

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/configure_permitted_host_devices.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/configure_permitted_host_devices.yaml
@@ -17,6 +17,7 @@
     name: kubevirt-hyperconverged
     namespace: openshift-cnv
   register: hyperconverged_cr_v1
+  ignore_errors: true
   when: gpu_devices | default([]) | length > 0
 
 - name: Read current HyperConverged CR (v1beta1 fallback)
@@ -29,21 +30,25 @@
   register: hyperconverged_cr_v1beta1
   when:
     - gpu_devices | default([]) | length > 0
-    - hyperconverged_cr_v1.resources | default([]) | length == 0
+    - hyperconverged_cr_v1 is failed or (hyperconverged_cr_v1.resources | default([]) | length == 0)
 
 - name: Select HyperConverged CR read result
   ansible.builtin.set_fact:
     hyperconverged_cr: >-
       {{ hyperconverged_cr_v1
-         if (hyperconverged_cr_v1.resources | default([]) | length > 0)
+         if not (hyperconverged_cr_v1 is failed)
+           and (hyperconverged_cr_v1.resources | default([]) | length > 0)
          else hyperconverged_cr_v1beta1 }}
     hyperconverged_api_version: >-
       {{ 'hco.kubevirt.io/v1'
-         if (hyperconverged_cr_v1.resources | default([]) | length > 0)
+         if not (hyperconverged_cr_v1 is failed)
+           and (hyperconverged_cr_v1.resources | default([]) | length > 0)
          else 'hco.kubevirt.io/v1beta1' }}
     hyperconverged_pci_devices_use_virtualization: >-
-      {{ (hyperconverged_cr_v1.resources | default([]) | length > 0)
-         or (hyperconverged_cr_v1beta1.resources[0].spec.virtualization is defined) }}
+      {{ (hyperconverged_cr_v1.resources[0].spec.virtualization is defined)
+         if not (hyperconverged_cr_v1 is failed)
+           and (hyperconverged_cr_v1.resources | default([]) | length > 0)
+         else (hyperconverged_cr_v1beta1.resources[0].spec.virtualization is defined) }}
   when: gpu_devices | default([]) | length > 0
 
 - name: Compute merged pciHostDevices preserving existing entries
@@ -64,10 +69,10 @@
          | list }}
   when: gpu_devices | default([]) | length > 0
 
-- name: Patch HyperConverged CR with merged pciHostDevices (v1)
+- name: Patch HyperConverged CR with merged pciHostDevices (virtualization path)
   kubernetes.core.k8s:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
-    api_version: hco.kubevirt.io/v1
+    api_version: "{{ hyperconverged_api_version }}"
     kind: HyperConverged
     name: kubevirt-hyperconverged
     namespace: openshift-cnv
@@ -81,10 +86,10 @@
     - gpu_devices | default([]) | length > 0
     - hyperconverged_pci_devices_use_virtualization | bool
 
-- name: Patch HyperConverged CR with merged pciHostDevices (v1beta1)
+- name: Patch HyperConverged CR with merged pciHostDevices (legacy path)
   kubernetes.core.k8s:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
-    api_version: hco.kubevirt.io/v1beta1
+    api_version: "{{ hyperconverged_api_version }}"
     kind: HyperConverged
     name: kubevirt-hyperconverged
     namespace: openshift-cnv

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/configure_permitted_host_devices.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/configure_permitted_host_devices.yaml
@@ -9,32 +9,79 @@
       {% endfor %}]
   when: gpu_devices | default([]) | length > 0
 
-- name: Read current HyperConverged CR
+- name: Read current HyperConverged CR (v1)
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: hco.kubevirt.io/v1
+    kind: HyperConverged
+    name: kubevirt-hyperconverged
+    namespace: openshift-cnv
+  register: hyperconverged_cr_v1
+  when: gpu_devices | default([]) | length > 0
+
+- name: Read current HyperConverged CR (v1beta1 fallback)
   kubernetes.core.k8s_info:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: hco.kubevirt.io/v1beta1
     kind: HyperConverged
     name: kubevirt-hyperconverged
     namespace: openshift-cnv
-  register: hyperconverged_cr
+  register: hyperconverged_cr_v1beta1
+  when:
+    - gpu_devices | default([]) | length > 0
+    - hyperconverged_cr_v1.resources | default([]) | length == 0
+
+- name: Select HyperConverged CR read result
+  ansible.builtin.set_fact:
+    hyperconverged_cr: >-
+      {{ hyperconverged_cr_v1
+         if (hyperconverged_cr_v1.resources | default([]) | length > 0)
+         else hyperconverged_cr_v1beta1 }}
+    hyperconverged_api_version: >-
+      {{ 'hco.kubevirt.io/v1'
+         if (hyperconverged_cr_v1.resources | default([]) | length > 0)
+         else 'hco.kubevirt.io/v1beta1' }}
+    hyperconverged_pci_devices_use_virtualization: >-
+      {{ (hyperconverged_cr_v1.resources | default([]) | length > 0)
+         or (hyperconverged_cr_v1beta1.resources[0].spec.virtualization is defined) }}
   when: gpu_devices | default([]) | length > 0
 
 - name: Compute merged pciHostDevices preserving existing entries
   ansible.builtin.set_fact:
-    merged_pci_host_devices: "{{ _existing + _new_only }}"
+    merged_pci_host_devices: "{{ _existing_pci_host_devices + _new_only }}"
   vars:
-    _existing: >-
-      {{ hyperconverged_cr.resources[0].spec.permittedHostDevices.pciHostDevices
-         | default([]) }}
-    _existing_selectors: >-
-      {{ _existing | map(attribute='pciDeviceSelector') | list }}
+    _hc_spec: "{{ hyperconverged_cr.resources[0].spec }}"
+    _existing_pci_host_devices: >-
+      {{
+        (_hc_spec.virtualization.permittedHostDevices.pciHostDevices | default([]))
+        if hyperconverged_pci_devices_use_virtualization | bool
+        else (_hc_spec.permittedHostDevices.pciHostDevices | default([]))
+      }}
+    _existing_selectors: "{{ _existing_pci_host_devices | map(attribute='pciDeviceSelector') | list }}"
     _new_only: >-
       {{ desired_pci_host_devices
          | rejectattr('pciDeviceSelector', 'in', _existing_selectors)
          | list }}
   when: gpu_devices | default([]) | length > 0
 
-- name: Patch HyperConverged CR with merged pciHostDevices
+- name: Patch HyperConverged CR with merged pciHostDevices (v1)
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: hco.kubevirt.io/v1
+    kind: HyperConverged
+    name: kubevirt-hyperconverged
+    namespace: openshift-cnv
+    state: patched
+    definition:
+      spec:
+        virtualization:
+          permittedHostDevices:
+            pciHostDevices: "{{ merged_pci_host_devices }}"
+  when:
+    - gpu_devices | default([]) | length > 0
+    - hyperconverged_pci_devices_use_virtualization | bool
+
+- name: Patch HyperConverged CR with merged pciHostDevices (v1beta1)
   kubernetes.core.k8s:
     kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
     api_version: hco.kubevirt.io/v1beta1
@@ -46,4 +93,6 @@
       spec:
         permittedHostDevices:
           pciHostDevices: "{{ merged_pci_host_devices }}"
-  when: gpu_devices | default([]) | length > 0
+  when:
+    - gpu_devices | default([]) | length > 0
+    - not hyperconverged_pci_devices_use_virtualization | bool

--- a/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
+++ b/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
@@ -51,6 +51,12 @@
         namespace: openshift-cnv
       register: hc_cr
 
+    - name: Ensure HyperConverged CR exists
+      ansible.builtin.assert:
+        that:
+          - hc_cr.resources | length == 1
+        fail_msg: "Expected exactly one HyperConverged CR, got: {{ hc_cr.resources | default([]) | length }}"
+
     - name: Resolve pciHostDevices from HyperConverged CR
       ansible.builtin.set_fact:
         hc_pci_host_devices: >-
@@ -60,11 +66,18 @@
             else (hc_cr.resources[0].spec.permittedHostDevices.pciHostDevices | default([]))
           }}
 
+    - name: Find matching GPU host device entries
+      ansible.builtin.set_fact:
+        hc_matching_gpu_devices: >-
+          {{
+            hc_pci_host_devices
+            | selectattr('pciDeviceSelector', 'equalto', '10DE:2901')
+            | selectattr('resourceName', 'equalto', 'nvidia.com/GB100')
+            | list
+          }}
+
     - name: Verify GPU device was registered in HyperConverged CR
       ansible.builtin.assert:
         that:
-          - hc_cr.resources | length == 1
-          - hc_pci_host_devices | length >= 1
-          - hc_pci_host_devices | selectattr('pciDeviceSelector', 'equalto', '10DE:2901') | list | length == 1
-          - hc_pci_host_devices | selectattr('resourceName', 'equalto', 'nvidia.com/GB100') | list | length == 1
+          - hc_matching_gpu_devices | length == 1
         fail_msg: "GPU device not registered in HyperConverged CR: {{ hc_cr.resources }}"

--- a/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
+++ b/tests/integration/targets/compute_instance_with_gpu_create/tasks/baseline.yml
@@ -45,18 +45,26 @@
 
     - name: Read HyperConverged CR
       kubernetes.core.k8s_info:
-        api_version: hco.kubevirt.io/v1beta1
+        api_version: hco.kubevirt.io/v1
         kind: HyperConverged
         name: kubevirt-hyperconverged
         namespace: openshift-cnv
       register: hc_cr
 
+    - name: Resolve pciHostDevices from HyperConverged CR
+      ansible.builtin.set_fact:
+        hc_pci_host_devices: >-
+          {{
+            (hc_cr.resources[0].spec.virtualization.permittedHostDevices.pciHostDevices | default([]))
+            if hc_cr.resources[0].spec.virtualization is defined
+            else (hc_cr.resources[0].spec.permittedHostDevices.pciHostDevices | default([]))
+          }}
+
     - name: Verify GPU device was registered in HyperConverged CR
       ansible.builtin.assert:
         that:
           - hc_cr.resources | length == 1
-          - hc_cr.resources[0].spec.permittedHostDevices.pciHostDevices is defined
-          - hc_cr.resources[0].spec.permittedHostDevices.pciHostDevices | length == 1
-          - hc_cr.resources[0].spec.permittedHostDevices.pciHostDevices[0].pciDeviceSelector == '10DE:2901'
-          - hc_cr.resources[0].spec.permittedHostDevices.pciHostDevices[0].resourceName == 'nvidia.com/GB100'
+          - hc_pci_host_devices | length >= 1
+          - hc_pci_host_devices | selectattr('pciDeviceSelector', 'equalto', '10DE:2901') | list | length == 1
+          - hc_pci_host_devices | selectattr('resourceName', 'equalto', 'nvidia.com/GB100') | list | length == 1
         fail_msg: "GPU device not registered in HyperConverged CR: {{ hc_cr.resources }}"


### PR DESCRIPTION
## Summary

- Fixes GPU passthrough registration on clusters using HyperConverged `hco.kubevirt.io/v1`, where `permittedHostDevices` lives under `spec.virtualization` instead of `spec.permittedHostDevices`.
- Updates `configure_permitted_host_devices.yaml` to read/patch the v1 path with a v1beta1 fallback for older CNV installs.
- Updates the `compute_instance_with_gpu_create` integration test to read the v1 CR and assert against the resolved `pciHostDevices` list.

_failure example - https://github.com/osac-project/osac-aap/actions/runs/26055118992/job/76601196240_

## Background

PR #258 added automatic HyperConverged registration of permitted PCI host devices for GPU passthrough. The role and integration test assumed the `v1beta1` schema. Current HCO CRDs (including the kind test cluster) store `HyperConverged` as `v1`, so patches targeted the wrong field and `compute_instance_with_gpu_create:baseline` failed even though VM `hostDevices` were configured correctly.