### PR TITLE
OSAC-483: Add .ai-bot/ configuration for AI bug fix bot

### DIFF
--- a/.ai-bot/config.yaml
+++ b/.ai-bot/config.yaml
@@ -1,0 +1,24 @@
+# .ai-bot/config.yaml — osac-aap
+#
+# Configuration for the jira-ai-issue-solver bot.
+# See docs/repo-configuration.md in the bot repo for field reference.
+
+# Auxiliary repositories cloned into the workspace before AI execution.
+imports:
+  - repo: https://github.com/flightctl/ai-workflows
+    path: .ai-workflows
+    ref: main
+    install: .ai-workflows/install.sh
+
+# Shell commands the AI can use for validation.
+# These are hints — the AI decides when and how to use them.
+validation_commands:
+  - uv run ansible-lint
+  - pre-commit run --all-files
+
+# Pull request creation settings.
+pr:
+  draft: true
+  title_prefix: "[AI]"
+  labels:
+    - ai-pr

--- a/.ai-bot/container.json
+++ b/.ai-bot/container.json
@@ -1,0 +1,3 @@
+{
+  "image": "quay.io/rh-ee-andalton/osac-ai:latest"
+}

--- a/.ai-bot/feedback-workflow.md
+++ b/.ai-bot/feedback-workflow.md
@@ -1,0 +1,116 @@
+# osac-aap: PR Feedback Workflow
+
+## Overview
+
+Address PR review feedback on Ansible automation code. This workflow handles
+reviewer comments, implements changes, validates with ansible-lint, and
+updates session artifacts for multi-round review continuity.
+
+## Workflow
+
+Read and execute `.ai-workflows/bugfix/skills/feedback.md` with the
+settings below.
+
+### Settings
+
+```
+lint_command: uv run ansible-lint
+```
+
+### Artifact Paths
+
+All artifact paths (`.artifacts/bugfix/{issue}/`) should use `.ai-bot/`
+instead.
+
+## Process
+
+### Step 1: Gather Review Comments
+
+Retrieve comments from the PR. Sources (in priority order):
+1. Task file with structured comments (if provided by orchestrator)
+2. PR number via `gh api repos/{owner}/{repo}/pulls/{pr_number}/comments`
+3. User-provided context
+
+### Step 2: Recover Prior Context
+
+Read these files from `.ai-bot/` if they exist:
+- `session-context.md` -- original implementation decisions
+- `implementation-notes.md` -- file-by-file rationale
+- `root-cause.md` -- original root cause analysis
+
+### Step 3: Understand the Feedback
+
+For each comment, determine:
+- Is it a code change request, test addition, explanation, or design
+  challenge?
+- Does it conflict with the original design decisions?
+- Does it involve cross-repo coordination (osac-operator,
+  fulfillment-service)?
+
+### Step 4: Implement Changes
+
+Apply changes following the Ansible conventions:
+- FQCN for all modules
+- `name:` on every task
+- Underscores in role names
+- Include `osac.service.common` for remote K8s operations
+
+If a reviewer suggests something that contradicts the project conventions
+(e.g., using bare module names, hyphenated role names), explain the
+convention rather than adopting the suggestion.
+
+### Step 5: Validate
+
+```bash
+# Mandatory
+uv run ansible-lint
+
+# Syntax check modified playbooks
+ansible-playbook --syntax-check playbook_osac_<modified>.yml
+
+# Pre-commit
+pre-commit run --all-files
+
+# Helm (if charts/ changed)
+helm lint charts/aap/
+```
+
+### Step 6: Update Session Context
+
+Append a feedback round section to `.ai-bot/session-context.md`:
+
+```markdown
+## Feedback Round N
+**Comments addressed**: [@reviewer on file:line, ...]
+**Changes made**:
+- [Description] (file:line) -- [why this approach]
+**Suggestions declined**:
+- [@reviewer on file:line]: [reason]
+**Tests updated**: [list changes or "no test changes needed"]
+```
+
+### Step 7: Write Comment Responses
+
+Write `.ai-bot/comment-responses.json` mapping each comment to a response:
+
+```json
+[
+  {"comment_id": 123, "response": "Applied FQCN as suggested."},
+  {"comment_id": 456, "response": "Kept underscore naming per project convention."}
+]
+```
+
+## Common Review Feedback Patterns
+
+These are frequently seen in osac-aap reviews and how to handle them:
+
+| Feedback | Action |
+|----------|--------|
+| "Use FQCN" | Replace bare module with `ansible.builtin.*` or `kubernetes.core.*` |
+| "Missing task name" | Add descriptive `name:` field |
+| "Use underscores" | Rename to underscores in role dir, `meta/osac.yaml`, and strategy |
+| "Missing kubeconfig" | Add `osac.service.common` include before remote K8s ops |
+| "Update meta/osac.yaml" | Ensure `implementation_strategy` matches role directory name |
+| "Cross-repo needed" | Document in PR description, do not attempt changes in other repos |
+| "Add to ansible-lint-ignore" | Only if genuinely unavoidable; explain in PR comment |
+| "Stale vendor" | Run `rm -rf vendor && ansible-galaxy collection install -r collections/requirements.yml` |

--- a/.ai-bot/feedback-workflow.md
+++ b/.ai-bot/feedback-workflow.md
@@ -13,7 +13,7 @@ settings below.
 
 ### Settings
 
-```
+```yaml
 lint_command: uv run ansible-lint
 ```
 
@@ -113,4 +113,4 @@ These are frequently seen in osac-aap reviews and how to handle them:
 | "Update meta/osac.yaml" | Ensure `implementation_strategy` matches role directory name |
 | "Cross-repo needed" | Document in PR description, do not attempt changes in other repos |
 | "Add to ansible-lint-ignore" | Only if genuinely unavoidable; explain in PR comment |
-| "Stale vendor" | Run `rm -rf vendor && ansible-galaxy collection install -r collections/requirements.yml` |
+| "Stale vendor" | Flag for human review; do not modify `vendor/` automatically |

--- a/.ai-bot/instructions.md
+++ b/.ai-bot/instructions.md
@@ -1,0 +1,155 @@
+# osac-aap: AI Bot Instructions
+
+## Project Overview
+
+This is an Ansible automation repository for provisioning OSAC (Open Sovereign
+AI Cloud) infrastructure. It contains playbooks, four Ansible collections
+(`osac.service`, `osac.templates`, `osac.workflows`, `osac.config_as_code`),
+integration tests, Helm charts, and an Execution Environment definition.
+
+The project uses **uv** for Python dependency management (Python 3.13),
+**ansible-lint** for linting, **pre-commit** for formatting checks, and
+**kind** clusters for integration testing.
+
+## Critical Ansible Conventions
+
+These rules are non-negotiable. Violations will fail lint and/or break
+runtime behavior:
+
+1. **Use FQCN for all modules**: `ansible.builtin.debug`, not `debug`.
+   ansible-lint enforces this.
+2. **Every task must have a `name:` field.** No unnamed tasks.
+3. **Use underscores in role names and `implementation_strategy`**, never
+   hyphens. Role directory name, `meta/osac.yaml`, and CR annotation must
+   all match.
+4. **Always include `osac.service.common`** (with
+   `tasks_from: get_remote_cluster_kubeconfig`) before creating K8s resources
+   on remote clusters.
+5. **Namespace label syntax**: `k8s.ovn.org/primary-user-defined-network: ""`
+   must be an empty string, not a missing value.
+
+## Validation Commands
+
+Run these before considering any change complete:
+
+```bash
+# Install dependencies (if not already done)
+uv sync --all-groups && source .venv/bin/activate
+
+# Primary lint check (MUST pass)
+uv run ansible-lint
+
+# Syntax check individual playbooks
+ansible-playbook --syntax-check playbook_osac_<name>.yml
+
+# Pre-commit hooks (trailing whitespace, YAML lint, etc.)
+pre-commit run --all-files
+
+# Helm chart lint (only if charts/ was modified)
+helm lint charts/aap/
+helm template test charts/aap/ > /dev/null
+```
+
+### Integration Tests
+
+Integration tests require a kind cluster. Only run these when asked or
+when the change touches workflows, service roles, or test fixtures:
+
+```bash
+uv run make test
+```
+
+This runs `setup_test_env.sh` (creates kind cluster, installs CRDs),
+`run_tests.sh` (baseline + override tests for all workflows and roles),
+and `teardown_test_env.sh` (deletes kind cluster).
+
+## Commit Format
+
+```
+git commit -s -m "OSAC-XXXXX: description of change"
+```
+
+Commits must be signed-off (`-s`). Include the Jira ticket key.
+
+## Files and Directories to Never Modify
+
+- `vendor/` -- vendored third-party collections; re-vendor with
+  `ansible-galaxy collection install -r collections/requirements.yml`
+- `uv.lock` -- auto-generated lockfile; only modify via `uv sync`
+- `.github/workflows/` -- CI pipelines owned by the platform team
+- `collections/ansible_collections/massopencloud/` -- third-party
+- `execution-environment/requirements.txt` -- generated; update the
+  `execution-environment.yaml` instead
+- `OWNERS` -- repo ownership; requires admin approval
+- `LICENSE` -- do not change
+
+## Repository Structure Quick Reference
+
+```
+playbook_osac_*.yml                    Top-level playbooks (AAP job templates)
+collections/ansible_collections/
+  osac/service/                        Core utility roles + filter plugins
+  osac/templates/                      Infrastructure template roles
+  osac/workflows/                      Multi-step workflow playbooks
+  osac/config_as_code/                 AAP configuration
+  osac/test_overrides/                 Test-only override collection
+tests/integration/                     Kind-based integration tests
+vendor/                                Vendored dependency collections
+charts/aap/                            Helm chart for AAP deployment
+samples/                               Example payloads
+```
+
+## Playbook Naming Convention
+
+- File: `playbook_osac_{action}_{resource}.yml`
+- AAP template: `osac-{action}-{resource}`
+- Actions: `create`, `delete`, `report`, `attach`, `detach`, `cleanup`
+
+## Standard Playbook Pattern
+
+Every playbook receives a K8s CR via `ansible_eda.event.payload`, extracts
+`implementation_strategy` from the CR annotation
+(`osac.openshift.io/implementation-strategy`), and dynamically includes the
+matching role from `osac.templates`:
+
+```yaml
+- name: Call the selected role
+  ansible.builtin.include_role:
+    name: "osac.templates.{{ implementation_strategy }}"
+    tasks_from: create_<resource>
+```
+
+## Template Role Requirements
+
+Every template role needs:
+1. `meta/osac.yaml` with `implementation_strategy`, `template_type`, and
+   `capabilities`
+2. Task files named `tasks/create_<resource>.yaml` and
+   `tasks/delete_<resource>.yaml`
+3. Underscore naming throughout (directory name matches
+   `implementation_strategy`)
+
+## ansible-lint Configuration
+
+- **Skip list**: `role-name[path]`, `parser-error`, `fqcn[keyword]`
+- **Warn list**: `risky-file-permissions`
+- **Excluded paths**: `vendor/`, `.github/`,
+  `collections/ansible_collections/massopencloud/`, `execution-environment/`
+- **Ignore file**: `.ansible-lint-ignore` lists known acceptable violations
+  (mostly `var-naming[no-role-prefix]` in playbooks and `risky-file-permissions`
+  in test overrides)
+
+## yamllint Configuration
+
+Extends default with: line-length disabled, document-start disabled,
+indent-sequences whatever, hyphens max-spaces-after 4, truthy check-keys
+false, comments min-spaces-from-content 1.
+
+## Cross-Repo Dependencies
+
+Changes in osac-aap often require coordinated changes in:
+- **osac-operator** -- CRD spec changes, controller logic
+- **fulfillment-service** -- proto/API field additions
+- **osac-installer** -- submodule bump (automated via CI)
+
+Document any cross-repo dependencies in the PR description.

--- a/.ai-bot/instructions.md
+++ b/.ai-bot/instructions.md
@@ -52,16 +52,11 @@ helm template test charts/aap/ > /dev/null
 
 ### Integration Tests
 
-Integration tests require a kind cluster. Only run these when asked or
-when the change touches workflows, service roles, or test fixtures:
-
-```bash
-uv run make test
-```
-
-This runs `setup_test_env.sh` (creates kind cluster, installs CRDs),
-`run_tests.sh` (baseline + override tests for all workflows and roles),
-and `teardown_test_env.sh` (deletes kind cluster).
+Integration tests require a kind cluster and significant resources.
+**Do not run integration tests automatically.** If your change touches
+workflows, service roles, or test fixtures, note in the PR description
+that integration testing is needed and let human reviewers trigger it
+via CI.
 
 ## Commit Format
 
@@ -82,6 +77,11 @@ Commits must be signed-off (`-s`). Include the Jira ticket key.
   `execution-environment.yaml` instead
 - `OWNERS` -- repo ownership; requires admin approval
 - `LICENSE` -- do not change
+- `.ai-bot/` -- bot configuration; changes require human review
+- `.ansible-lint-ignore` -- lint suppressions; additions require human approval
+- `pyproject.toml` -- Python project configuration
+- `.pre-commit-config.yaml` -- pre-commit hook configuration
+- `ansible.cfg` -- Ansible core configuration
 
 ## Repository Structure Quick Reference
 

--- a/.ai-bot/instructions.md
+++ b/.ai-bot/instructions.md
@@ -137,7 +137,9 @@ Every template role needs:
   `collections/ansible_collections/massopencloud/`, `execution-environment/`
 - **Ignore file**: `.ansible-lint-ignore` lists known acceptable violations
   (mostly `var-naming[no-role-prefix]` in playbooks and `risky-file-permissions`
-  in test overrides)
+  in test overrides). **Do not add new entries to `.ansible-lint-ignore`.**
+  Fix violations instead. If a violation cannot be fixed, flag it in the
+  PR description and let a human decide.
 
 ## yamllint Configuration
 
@@ -152,4 +154,6 @@ Changes in osac-aap often require coordinated changes in:
 - **fulfillment-service** -- proto/API field additions
 - **osac-installer** -- submodule bump (automated via CI)
 
-Document any cross-repo dependencies in the PR description.
+You operate on this repo only. If a fix requires changes in another repo,
+document the dependency in the PR description and stop. Do not attempt
+cross-repo changes.

--- a/.ai-bot/new-ticket-workflow.md
+++ b/.ai-bot/new-ticket-workflow.md
@@ -1,0 +1,112 @@
+# osac-aap: New Ticket Bugfix Workflow
+
+## Overview
+
+Multi-phase bugfix workflow for Ansible automation code. This repo uses
+`ansible-lint` as its primary validation gate -- there are no compiled
+artifacts or unit test frameworks. Integration tests exist but require a
+kind cluster and are heavy-weight.
+
+## Workflow
+
+Read and execute `.ai-workflows/bugfix/skills/unattended.md` with the
+settings below.
+
+### Settings
+
+```
+branch: stay on the current branch (already created by the orchestration system)
+lint_command: uv run ansible-lint
+max_retries: 3
+```
+
+### Artifact Paths
+
+All artifact paths (`.artifacts/bugfix/{issue}/`) should use `.ai-bot/`
+instead. Write the PR description to `.ai-bot/pr.md`.
+
+## Phase Details
+
+### Phase 1: Diagnose
+
+1. Read the ticket description from `.ai-bot/issue.md`
+2. Identify which files are involved:
+   - Playbooks: `playbook_osac_*.yml` at repo root
+   - Template roles: `collections/ansible_collections/osac/templates/roles/`
+   - Service roles: `collections/ansible_collections/osac/service/roles/`
+   - Workflow playbooks: `collections/ansible_collections/osac/workflows/playbooks/`
+   - Filter plugins: `collections/ansible_collections/osac/service/plugins/filter/`
+   - Custom modules: `collections/ansible_collections/osac/service/plugins/modules/`
+3. Understand the data flow: osac-operator -> EDA event -> playbook ->
+   implementation_strategy -> template role -> K8s resources
+4. Check `.claude/rules/playbook-patterns.md` and `.claude/rules/networking-cudn.md`
+   for domain-specific patterns
+5. Write root cause analysis to `.ai-bot/root-cause.md`
+
+### Phase 2: Fix
+
+1. Make the code change following all conventions from `instructions.md`
+2. Key rules to remember:
+   - FQCN for all modules (`ansible.builtin.*`, `kubernetes.core.*`)
+   - Every task needs a `name:` field
+   - Underscores in role names and `implementation_strategy`
+   - Include `osac.service.common` before remote K8s operations
+3. If adding a new template role, create `meta/osac.yaml`
+4. Write implementation notes to `.ai-bot/implementation-notes.md`
+
+**Test file exception**: This is an Ansible project without a traditional
+unit test framework. If the fix touches workflow logic that has integration
+test coverage (check `tests/integration/targets/`), update the relevant
+baseline or override test. If no matching integration test target exists,
+document why tests were not added in implementation notes.
+
+### Phase 3: Validate
+
+Run in this order:
+
+```bash
+# 1. Lint (mandatory -- must pass)
+uv run ansible-lint
+
+# 2. Syntax check any modified playbooks
+ansible-playbook --syntax-check playbook_osac_<modified>.yml
+
+# 3. Pre-commit hooks
+pre-commit run --all-files
+
+# 4. Helm lint (only if charts/ changed)
+helm lint charts/aap/
+```
+
+If ansible-lint fails, fix the violations and re-run. Common issues:
+- Missing FQCN: use `ansible.builtin.<module>` not bare `<module>`
+- Missing task name: add `name:` to every task
+- Role name with hyphens: use underscores
+
+If the fix touches `collections/ansible_collections/osac/workflows/` or
+`collections/ansible_collections/osac/service/roles/`, also verify
+integration tests still pass conceptually by reviewing the relevant test
+targets in `tests/integration/targets/`.
+
+### Phase 4: Self-Review
+
+Review the diff against:
+- All conventions in `.ai-bot/instructions.md`
+- Patterns documented in `.claude/rules/playbook-patterns.md`
+- The `.ansible-lint.yml` skip/warn lists (don't introduce new violations)
+- The `.ansible-lint-ignore` file (don't add to it without justification)
+- Cross-repo impact (does this change require coordinated changes in
+  osac-operator or fulfillment-service?)
+
+Write review findings to `.ai-bot/review.md`.
+
+### Phase 5: Document
+
+Write PR description to `.ai-bot/pr.md` including:
+- What changed and why
+- Which collections/roles were modified
+- Cross-repo dependencies (if any)
+- How to test (e.g., which integration test target exercises this code)
+- Checklist from CLAUDE.md PR Checklist section
+
+Write session context to `.ai-bot/session-context.md`.

--- a/.ai-bot/new-ticket-workflow.md
+++ b/.ai-bot/new-ticket-workflow.md
@@ -45,7 +45,7 @@ instead. Write the PR description to `.ai-bot/pr.md`.
 
 ### Phase 2: Fix
 
-1. Make the code change following all conventions from `instructions.md`
+1. Make the code change following all conventions from `.ai-bot/instructions.md`
 2. Key rules to remember:
    - FQCN for all modules (`ansible.builtin.*`, `kubernetes.core.*`)
    - Every task needs a `name:` field


### PR DESCRIPTION
## Summary

Adds `.ai-bot/` configuration directory for the AI bug fix bot ([OSAC-483](https://redhat.atlassian.net/browse/OSAC-483)). Follows the same pattern established in fulfillment-service ([PR #554](https://github.com/osac-project/fulfillment-service/pull/554), merged).

### Files added

| File | Purpose |
|------|---------|
| `instructions.md` | Project overview, Ansible conventions (FQCN, task names, underscores), validation commands, commit format, repo structure, files the bot must never modify |
| `new-ticket-workflow.md` | Bugfix workflow: diagnose → fix → validate → self-review → document. Tailored for Ansible (ansible-lint as primary gate) |
| `feedback-workflow.md` | PR review feedback workflow: gather comments, recover context, implement changes, validate, update session artifacts |
| `config.yaml` | Bot settings: ai-workflows import, validation commands (`uv run ansible-lint`, `pre-commit`), PR defaults (draft, `ai-pr` label) |

Configuration only — does not affect CI, builds, or any existing tooling.

---

## Decisions (from [fulfillment-service PR #554 review](https://github.com/osac-project/fulfillment-service/pull/554#issuecomment-4486828911))

| Decision | Answer |
|----------|--------|
| **Container image** | Andy's purpose-built image (`quay.io/rh-ee-andalton/osac-ai:latest`) — already set in `container.json` |
| **ai-workflows URL** | `https://github.com/flightctl/ai-workflows` — ✅ correct in config |
| **Jira project key** | `OSAC` |
| **Draft PRs** | Yes — drafts by default |
| **PR labels** | `ai-pr` — ✅ correct in config |
| **Scope** | Bugfix-only to start |
| **Target branch** | `main` always |
| **ansible-lint-ignore** | Bot must not add new entries — fix violations or flag in PR description. ✅ Added to `instructions.md` |
| **Cross-repo changes** | Bot operates on this repo only. Document dependencies in PR description and stop. ✅ Added to `instructions.md` |

### Remaining repo-specific question

1. **Helm chart bugs** — Are bugs in `charts/aap/` in scope for the bot? The chart exists (Chart.yaml, templates, values.yaml). Current default: in scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added AI bot configuration, container image, validation command hints, and automated draft PR settings (title prefix and label).

* **Documentation**
  * Added AI bot operating instructions, a PR feedback workflow, and a multi‑phase new‑ticket workflow to standardize conventions, validation steps, and artifact recording.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-aap/pull/307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->