### PR TITLE
Add BareMetalPool Playbooks, bm_private_network role, and AAP config

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -279,6 +279,30 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: false
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-create-bare-metal-pool"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_create_bare_metal_pool.yml"
+    inventory: "{{ aap_prefix }}-bare-metal-fulfillment"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-bare-metal-fulfillment-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+  - name: "{{ aap_prefix }}-delete-bare-metal-pool"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_delete_bare_metal_pool.yml"
+    inventory: "{{ aap_prefix }}-bare-metal-fulfillment"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-bare-metal-fulfillment-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
   - name: "{{ aap_prefix }}-create-host-lease"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_private_network/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_private_network/defaults/main.yaml
@@ -1,0 +1,6 @@
+---
+# We define default_network_class as a temporary workaround the problem that
+# BareMetalPools have no idea what network class to use. The solution will be
+# to specify the network class in the BareMetalPool's status and that will be
+# a future change in the bare-metal-fulfillment-operator.
+default_network_class: openstack

--- a/collections/ansible_collections/osac/templates/roles/bm_private_network/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_private_network/meta/argument_specs.yaml
@@ -1,0 +1,14 @@
+---
+argument_specs:
+  create:
+    options:
+      bare_metal_pool:
+        type: dict
+        required: true
+        description: BareMetalPool CR from fulfillment-api via EDA payload
+  delete:
+    options:
+      bare_metal_pool:
+        type: dict
+        required: true
+        description: BareMetalPool CR from fulfillment-api via EDA payload

--- a/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/create.yaml
@@ -1,0 +1,7 @@
+---
+- name: Extract network class from BareMetalPool status
+  ansible.builtin.set_fact:
+    network_class: "{{ bare_metal_pool.status.networkClass | default(default_network_class) }}"
+
+- name: Create private network using network class implementation
+  ansible.builtin.include_tasks: "create_{{ network_class }}.yaml"

--- a/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/create_openstack.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/create_openstack.yaml
@@ -1,0 +1,7 @@
+---
+- name: Create OpenStack network for BareMetalPool
+  ansible.builtin.include_role:
+    name: massopencloud.esi.network
+  vars:
+    network_state: present
+    network_suffix: "{{ bare_metal_pool.metadata.name }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/delete.yaml
@@ -1,0 +1,7 @@
+---
+- name: Extract network class from BareMetalPool status
+  ansible.builtin.set_fact:
+    network_class: "{{ bare_metal_pool.status.networkClass | default(default_network_class) }}"
+
+- name: Delete private network using network class implementation
+  ansible.builtin.include_tasks: "delete_{{ network_class }}.yaml"

--- a/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/delete_openstack.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/delete_openstack.yaml
@@ -1,0 +1,7 @@
+---
+- name: Delete OpenStack network for BareMetalPool
+  ansible.builtin.include_role:
+    name: massopencloud.esi.network
+  vars:
+    network_state: absent
+    network_suffix: "{{ bare_metal_pool.metadata.name }}"

--- a/playbook_osac_create_bare_metal_pool.yml
+++ b/playbook_osac_create_bare_metal_pool.yml
@@ -1,0 +1,17 @@
+---
+- name: Create a BareMetalPool resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    bare_metal_pool: "{{ ansible_eda.event.payload }}"
+    bare_metal_pool_name: "{{ bare_metal_pool.metadata.name }}"
+    bare_metal_pool_namespace: "{{ bare_metal_pool.metadata.namespace }}"
+    template_id: "{{ bare_metal_pool.metadata.annotations['osac.openshift.io/templateID'] }}"
+
+  tasks:
+    - name: Call the selected bare metal pool template
+      when: template_id != "" and template_id != "noop"
+      ansible.builtin.include_role:
+        name: "osac.templates.{{ template_id }}"
+        tasks_from: create

--- a/playbook_osac_delete_bare_metal_pool.yml
+++ b/playbook_osac_delete_bare_metal_pool.yml
@@ -1,0 +1,17 @@
+---
+- name: Delete a BareMetalPool resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    bare_metal_pool: "{{ ansible_eda.event.payload }}"
+    bare_metal_pool_name: "{{ bare_metal_pool.metadata.name }}"
+    bare_metal_pool_namespace: "{{ bare_metal_pool.metadata.namespace }}"
+    template_id: "{{ bare_metal_pool.metadata.annotations['osac.openshift.io/templateID'] }}"
+
+  tasks:
+    - name: Call the selected bare metal pool template for deletion
+      when: template_id != "" and template_id != "noop"
+      ansible.builtin.include_role:
+        name: "osac.templates.{{ template_id }}"
+        tasks_from: delete


### PR DESCRIPTION
Adds playbooks to run on BareMetalPool create and delete for Profiles. Creates an initial template that creates a private network.

Depends on #301 