### PR TITLE
Add bm_host_private_network template role

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/delete.yaml
@@ -4,6 +4,11 @@
     msg: "bm_host_agent_deprovisioning requires hostClass 'openstack', got '{{ host_lease.spec.hostClass | default('') }}'"
   when: host_lease.spec.hostClass | default('') != "openstack"
 
+- name: Fail if network class is not openstack
+  ansible.builtin.fail:
+    msg: "bm_host_agent_deprovisioning requires networkClass 'openstack', got '{{ host_lease.spec.networkClass | default('') }}'"
+  when: host_lease.spec.networkClass | default('') != "openstack"
+
 - name: Detach all networks and delete neutron ports
   ansible.builtin.include_role:
     name: massopencloud.esi.l2

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
@@ -4,6 +4,11 @@
     msg: "bm_host_agent_provisioning requires hostClass 'openstack', got '{{ host_lease.spec.hostClass | default('') }}'"
   when: host_lease.spec.hostClass | default('') != "openstack"
 
+- name: Fail if network class is not openstack
+  ansible.builtin.fail:
+    msg: "bm_host_agent_provisioning requires networkClass 'openstack', got '{{ host_lease.spec.networkClass | default('') }}'"
+  when: host_lease.spec.networkClass | default('') != "openstack"
+
 - name: Parse template parameters
   ansible.builtin.set_fact:
     template_params: "{{ host_lease.spec.templateParameters | from_json }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/create.yaml
@@ -1,0 +1,31 @@
+---
+- name: Fail if host class is not openstack
+  ansible.builtin.fail:
+    msg: "bm_host_private_network requires hostClass 'openstack', got '{{ host_lease.spec.hostClass | default('') }}'"
+  when: host_lease.spec.hostClass | default('') != "openstack"
+
+- name: Fail if network class is not openstack
+  ansible.builtin.fail:
+    msg: "bm_host_private_network requires networkClass 'openstack', got '{{ host_lease.spec.networkClass | default('') }}'"
+  when: host_lease.spec.networkClass | default('') != "openstack"
+
+- name: Parse template parameters
+  ansible.builtin.set_fact:
+    template_params: "{{ host_lease.spec.templateParameters | from_json }}"
+
+- name: Fail if privateNetwork is missing
+  ansible.builtin.fail:
+    msg: "templateParameters.privateNetwork is required"
+  when: template_params.privateNetwork | default('') | length == 0
+
+- name: Attach node to private network
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l2
+    tasks_from: set_networks_for_node
+  vars:
+    node: "{{ host_lease.spec.externalHostID }}"
+    networks: "{{ [template_params.privateNetwork] }}"
+
+- name: Network attachment completed
+  ansible.builtin.debug:
+    msg: "Node {{ host_lease.spec.externalHostID }} attached to network {{ template_params.privateNetwork }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/delete.yaml
@@ -1,0 +1,22 @@
+---
+- name: Fail if host class is not openstack
+  ansible.builtin.fail:
+    msg: "bm_host_private_network requires hostClass 'openstack', got '{{ host_lease.spec.hostClass | default('') }}'"
+  when: host_lease.spec.hostClass | default('') != "openstack"
+
+- name: Fail if network class is not openstack
+  ansible.builtin.fail:
+    msg: "bm_host_private_network requires networkClass 'openstack', got '{{ host_lease.spec.networkClass | default('') }}'"
+  when: host_lease.spec.networkClass | default('') != "openstack"
+
+- name: Detach node from private network
+  ansible.builtin.include_role:
+    name: massopencloud.esi.l2
+    tasks_from: set_networks_for_node
+  vars:
+    node: "{{ host_lease.spec.externalHostID }}"
+    networks: []
+
+- name: Network detachment completed
+  ansible.builtin.debug:
+    msg: "Node {{ host_lease.spec.externalHostID }} detached from all private networks"


### PR DESCRIPTION
  - Add new bm_host_private_network template role that attaches/detaches bare-metal nodes to private networks
  via ESI L2 `massopencloud.esi.l2`
  - Add `networkClass` validation to existing `bm_host_agent_provisioning` and `bm_host_agent_deprovisioning` roles to
  enforce the openstack network class requirement
