### PR TITLE
OSAC-954: update attach/detach playbooks for PublicIPAttachment payload

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
@@ -26,7 +26,9 @@
 
 - name: Extract PublicIP attach configuration
   ansible.builtin.set_fact:
-    public_ip_name: "{{ public_ip.metadata.name }}"
+    public_ip_name: >-
+      {{ public_ip.metadata.annotations['osac.openshift.io/publicip-name']
+         | default(public_ip.metadata.name) }}
     attach_vm_namespace: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicip-target-namespace'] }}
     attach_pool_name: >-

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -23,7 +23,9 @@
 
 - name: Extract PublicIP detach configuration
   ansible.builtin.set_fact:
-    public_ip_name: "{{ public_ip.metadata.name }}"
+    public_ip_name: >-
+      {{ public_ip.metadata.annotations['osac.openshift.io/publicip-name']
+         | default(public_ip.metadata.name) }}
     detach_vm_namespace: >-
       {{ public_ip.metadata.annotations['osac.openshift.io/publicip-target-namespace'] }}
     detach_pool_name: >-


### PR DESCRIPTION
## Summary

[OSAC-954](https://redhat.atlassian.net/browse/OSAC-954): Update the metallb_l2 attach/detach
playbooks to support PublicIPAttachment CRs as the payload.

## Why

The PublicIPAttachment controller ([OSAC-835](https://redhat.atlassian.net/browse/OSAC-835)) triggers the same `osac-attach-public-ip` and
`osac-detach-public-ip` AAP templates as the old PublicIP controller, but the payload is now
a PublicIPAttachment CR instead of a PublicIP CR. The playbooks read `metadata.name` for
MetalLB Service naming (`osac-pip-<name>`), which breaks because the attachment's name is
not the PublicIP name.

## What changed

Both `attach_public_ip.yaml` and `detach_public_ip.yaml` in the `metallb_l2` role now read
the PublicIP K8s name from the `osac.openshift.io/publicip-name` annotation (set by the
PublicIPAttachment controller), with a fallback to `metadata.name` for backward compatibility
with the existing PublicIP controller flow.

## Testing

```
ansible-lint   # passes (env warnings only, no violations)
ansible-playbook --syntax-check playbook_osac_attach_public_ip.yml   # passes
ansible-playbook --syntax-check playbook_osac_detach_public_ip.yml   # passes
```

E2E testing on edge22 in progress (operator PR #252 + this PR).

## Related PRs

- osac-operator PR #252: [OSAC-835](https://redhat.atlassian.net/browse/OSAC-835) PublicIPAttachment controller (sets the annotation)

## Ticket

[OSAC-954](https://redhat.atlassian.net/browse/OSAC-954)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>