### PR TITLE
Integrate BareMetalPools with Profiles in CaaS

### DIFF
--- a/collections/ansible_collections/osac/steps/roles/cluster_infra/defaults/main.yaml
+++ b/collections/ansible_collections/osac/steps/roles/cluster_infra/defaults/main.yaml
@@ -1,0 +1,1 @@
+cluster_infra_default_network_after_delete: "idle-agents-network"

--- a/collections/ansible_collections/osac/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/osac/steps/roles/cluster_infra/tasks/create.yaml
@@ -14,6 +14,9 @@
 # For now, we create the BareMetalPool in the POD_NAMESPACE, but
 # in the future, we hope to have it created in the cluster_working_namespace.
 # This requires updates to the bare-metal-fulfillment-operator
+# Note: Network creation and host attachment to the network are now handled
+# automatically by the BareMetalPool controller via bm_private_network and
+# bm_host_private_network template roles
 
 - name: Step - Create BareMetalPool
   kubernetes.core.k8s:
@@ -27,26 +30,19 @@
         labels: "{{ {cluster_order_label: cluster_infra_name} }}"
       spec:
         hostSets: "{{ baremetalpool_host_sets }}"
+        profile:
+          name: acquire_bare_metal_agents
+          templateParameters: |
+            {
+              "privateNetwork": "network-{{ cluster_infra_name | to_json }}",
+              "networkAfterDelete": "{{ cluster_infra_default_network_after_delete }}"
+            }
+        networkClass: openstack
   register: baremetalpool_response
 
 - name: Set BareMetalPool UID
   ansible.builtin.set_fact:
     baremetalpool_uid: "{{ baremetalpool_response.result.metadata.uid }}"
-
-- name: Create cluster network
-  ansible.builtin.include_role:
-    name: osac.esi.network
-  vars:
-    network_suffix: "{{ cluster_infra_name }}"
-    network_state: present
-    network_properties:
-      instance: "{{ cluster_order.metadata.namespace }}"
-      clusterorder: "{{ cluster_infra_name }}"
-      purpose: "o-sac"
-
-- name: Set cluster_infra_network_name
-  ansible.builtin.set_fact:
-    cluster_infra_network_name: "network-{{ cluster_infra_name }}"
 
 - name: Calculate total desired nodes
   ansible.builtin.set_fact:
@@ -62,6 +58,7 @@
     (
       hostleases_result.resources |
       selectattr('metadata.ownerReferences', 'defined') |
+      selectattr('spec.externalHostID', 'ne', '') |
       map(attribute='metadata.ownerReferences') |
       flatten |
       selectattr('controller', 'defined') |
@@ -89,26 +86,6 @@
 - name: Display allocated host IDs
   ansible.builtin.debug:
     msg: "Allocated host IDs: {{ allocated_host_ids }}"
-
-# Handle scale down **before** scale up: detach agents not in the
-# HostLease allocation before attaching new ones.
-
-- name: Wait for the Agents to be removed from the cluster
-  ansible.builtin.include_role:
-    name: osac.service.manage_agents
-    tasks_from: wait_for_agents_to_be_removed
-  vars:
-    manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
-    manage_agents_desired_count: "{{ item.replicas }}"
-    manage_agents_resource_class: "{{ item.hostType }}"
-  loop: "{{ baremetalpool_host_sets }}"
-
-- name: Detach agents from cluster
-  ansible.builtin.include_role:
-    name: osac.service.manage_agents
-    tasks_from: detach_and_unlabel_all_removed_agents
-  vars:
-    manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
 
 - name: Get all agents in the namespace
   kubernetes.core.k8s_info:
@@ -139,25 +116,52 @@
       {{ allocated_host_ids | length }} leased hosts.
   when: (agents_to_attach | length) != (allocated_host_ids | length)
 
-- name: Display hosts to attach to cluster network
+- name: Initialize agents to detach list
+  ansible.builtin.set_fact:
+    agents_to_detach: []
+
+- name: Select agents with cluster order label NOT in allocated host IDs
+  ansible.builtin.set_fact:
+    agents_to_detach: "{{ agents_to_detach + [item] }}"
+  loop: "{{ all_agents_result.resources }}"
+  when:
+    - item.metadata.labels is defined
+    - item.metadata.labels[cluster_order_label] is defined
+    - item.metadata.labels[cluster_order_label] == cluster_infra_name
+    - item.metadata.annotations is defined
+    - item.metadata.annotations['osac.openshift.io/host_uuid'] is defined
+    - item.metadata.annotations['osac.openshift.io/host_uuid'] not in allocated_host_ids
+  loop_control:
+    label: "Selected agent {{ item.metadata.name }} for label removal"
+
+- name: Display hosts allocated
   ansible.builtin.debug:
-    msg: "Hosts to attach: {{ allocated_host_ids }}"
+    msg: "Hosts allocated: {{ allocated_host_ids }}"
+
+- name: Display agents to unlabel
+  ansible.builtin.debug:
+    msg: "Agents to unlabel: {{ agents_to_detach | map(attribute='metadata.name') | list }}"
 
 - name: Display agents to label
   ansible.builtin.debug:
     msg: "Agents to label: {{ agents_to_attach | map(attribute='metadata.name') | list }}"
 
-- name: Attach new agents's hosts to cluster network
-  ansible.builtin.include_role:
-    name: osac.esi.l2
-    tasks_from: set_networks_for_node
-  vars:
-    node: "{{ item }}"
-    networks:
-    - "{{ cluster_infra_network_name }}"
-  loop: "{{ allocated_host_ids }}"
+- name: Remove cluster order label from agents not in HostLeases
+  kubernetes.core.k8s_json_patch:
+    api_version: agent-install.openshift.io/v1beta1
+    kind: Agent
+    name: "{{ agent.metadata.name }}"
+    namespace: "{{ agent.metadata.namespace }}"
+    patch:
+      - op: remove
+        path: /metadata/labels/{{ cluster_order_label | osac.service.json_pointer_escape }}
+      - op: add
+        path: /spec/approved
+        value: false
+  loop: "{{ agents_to_detach }}"
   loop_control:
-    label: "Attach host {{ item }}"
+    loop_var: agent
+    label: "Removing label from agent {{ agent.metadata.name }}"
 
 - name: Label selected agents with cluster order
   kubernetes.core.k8s_json_patch:

--- a/collections/ansible_collections/osac/steps/roles/cluster_infra/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/steps/roles/cluster_infra/tasks/delete.yaml
@@ -1,13 +1,10 @@
-- name: Detach agents from cluster
-  ansible.builtin.include_role:
-    name: osac.service.manage_agents
-    tasks_from: detach_and_unlabel_all_removed_agents
-  vars:
-    manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
-
-- name: Delete cluster network
-  ansible.builtin.include_role:
-    name: osac.esi.network
-  vars:
-    network_suffix: "{{ cluster_infra_name }}"
-    network_state: absent
+- name: Delete BareMetalPool
+  kubernetes.core.k8s:
+    state: absent
+    definition:
+      apiVersion: osac.openshift.io/v1alpha1
+      kind: BareMetalPool
+      metadata:
+        name: "{{ cluster_infra_name }}"
+        namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+        labels: "{{ {cluster_order_label: cluster_infra_name} }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/delete.yaml
@@ -11,7 +11,7 @@
 
 - name: Detach all networks and delete neutron ports
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ host_lease.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
@@ -87,7 +87,7 @@
 
     - name: Set provisioning network for node
       ansible.builtin.include_role:
-        name: massopencloud.esi.l2
+        name: osac.esi.l2
         tasks_from: set_networks_for_node
       vars:
         node: "{{ host_lease.spec.externalHostID }}"
@@ -113,7 +113,7 @@
 
 - name: Ensure node is on agent private network
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ host_lease.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/create.yaml
@@ -20,7 +20,7 @@
 
 - name: Attach node to private network
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ host_lease.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/delete.yaml
@@ -15,7 +15,7 @@
 
 - name: Detach node from private network
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ host_lease.spec.externalHostID }}"
@@ -23,7 +23,7 @@
 
 - name: Attach node to network after detach
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ host_lease.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/create_openstack.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/create_openstack.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Create OpenStack network for BareMetalPool
   ansible.builtin.include_role:
-    name: massopencloud.esi.network
+    name: osac.esi.network
   vars:
     network_state: present
     network_suffix: "{{ bare_metal_pool.metadata.name }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/delete_openstack.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/delete_openstack.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Delete OpenStack network for BareMetalPool
   ansible.builtin.include_role:
-    name: massopencloud.esi.network
+    name: osac.esi.network
   vars:
     network_state: absent
     network_suffix: "{{ bare_metal_pool.metadata.name }}"


### PR DESCRIPTION
Integrate BareMetalPools with Profiles in CaaS

  Summary

  - Refactors network provisioning to use BareMetalPool Profiles instead of manual Ansible role execution
  - Simplifies cluster infrastructure by delegating network creation to the BareMetalPool controller
  - Removes ~70 lines of manual provisioning code in favor of declarative profile configuration

  Changes

  - BareMetalPool Configuration: Added profile spec with agent_private_network template to automate network provisioning
  - Removed Manual Provisioning: Deleted calls to osac.esi.network role and manage_agents role for manual network/agent operations
  - Cluster Infra Updates: Refactored cluster_infra tasks to depend on BareMetalPool controller automation
  - HostLease Filtering: Added externalHostID filtering to exclude unallocated leases from processing

Closes osac-project/issues#393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated cluster infrastructure creation workflow with improved network management and agent allocation handling
  * Streamlined cluster infrastructure deletion to reduce operational steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-aap/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->