### PR TITLE
Update `manage_agents` role to use bare metal pools

### DIFF
--- a/collections/ansible_collections/osac/service/roles/manage_agents/defaults/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/manage_agents/defaults/main.yaml
@@ -1,3 +1,8 @@
 manage_agents_provisioning_network_name: provisioning
-manage_agents_namespace: hardware-inventory
+manage_agents_idle_agents_network_name: idle-agents-network
+manage_agents_agent_namespace: hardware-inventory
 manage_agents_infraenv_name: hardware-inventory
+manage_agents_provisioning_pool_name: agent-provisioning-pool
+manage_agents_deprovisioning_pool_name: agent-deprovisioning-pool
+manage_agents_provisioning_profile: agentProvisioning
+manage_agents_deprovisioning_profile: agentDeprovisioning

--- a/collections/ansible_collections/osac/service/roles/manage_agents/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/service/roles/manage_agents/meta/argument_specs.yaml
@@ -22,6 +22,22 @@ argument_specs:
       manage_agents_skip_network_detach:
         type: bool
         default: false
+  import_agents:
+    options:
+      manage_agents_host_sets:
+        type: list
+        required: true
+      manage_agents_namespace:
+        type: str
+        required: true
+  remove_agents:
+    options:
+      manage_agents_host_sets:
+        type: list
+        required: true
+      manage_agents_namespace:
+        type: str
+        required: true
   select_and_label_new_agents:
     options:
       manage_agents_desired_count:
@@ -48,19 +64,4 @@ argument_specs:
     options:
       manage_agents_cluster_order_name:
         type: str
-        required: true
-  import_agents:
-    options:
-      manage_agents_node_names:
-        type: list
-        elements: str
-        required: true
-      manage_agents_idle_agents_network:
-        type: str
-        required: true
-  remove_agents:
-    options:
-      manage_agents_node_names:
-        type: list
-        elements: str
         required: true

--- a/collections/ansible_collections/osac/service/roles/manage_agents/tasks/import_agents.yaml
+++ b/collections/ansible_collections/osac/service/roles/manage_agents/tasks/import_agents.yaml
@@ -1,44 +1,8 @@
-- name: Display node names that will be added as agents
-  ansible.builtin.debug:
-    var: manage_agents_node_names
-
-- name: Get all agents
-  kubernetes.core.k8s_info:
-    kind: Agent
-    api_version: agent-install.openshift.io/v1beta1
-    namespace: "{{ manage_agents_namespace }}"
-  register: initial_agents_result
-
-- name: Extract initial agents
-  ansible.builtin.set_fact:
-    initial_agents: "{{ initial_agents_result.resources }}"
-
-- name: Filter non-agent node names
-  when: initial_agents | length > 0
-  ansible.builtin.set_fact:
-    manage_agents_node_names: >-
-      {{
-        manage_agents_node_names |
-        difference(initial_agents |
-          selectattr('spec.hostname', 'defined') |
-          map(attribute='spec.hostname') |
-          list
-        )
-      }}
-
-- name: Get combined node and port info
-  ansible.builtin.include_role:
-    name: osac.esi.node
-    tasks_from: get_nodes
-  vars:
-    node_filter_names: "{{ manage_agents_node_names }}"
-# set_fact: node_info_list
-
 - name: Get InfraEnv information
   kubernetes.core.k8s_info:
     kind: InfraEnv
     api_version: agent-install.openshift.io/v1beta1
-    namespace: "{{ manage_agents_namespace }}"
+    namespace: "{{ manage_agents_agent_namespace }}"
     name: "{{ manage_agents_infraenv_name }}"
   register: infraenv
 
@@ -47,85 +11,45 @@
     discovery_url: "{{ infraenv.resources[0].status.isoDownloadURL }}"
   when: not discovery_url|default(false)
 
-- name: Provision nodes
-  when: >-
-    node_info.ports |
-    map(attribute='address') |
-    osac.service.mac_to_agent_name(initial_agents) is none
-  ansible.builtin.include_role:
-    name: osac.esi.node
-    tasks_from: provision_node
-  vars:
-    node_name: "{{ node_info.name }}"
-    node_provisioning_network_name: "{{ manage_agents_provisioning_network_name }}"
-    node_discovery_url: "{{ discovery_url }}"
-    node_agent_namespace: "{{ manage_agents_namespace }}"
-    node_deploy_wait: false
-  loop: "{{ node_info_list }}"
-  loop_control:
-    loop_var: node_info
-    label: "{{ node_info.name }}"
-
-- name: Wait for nodes to register as agents
-  kubernetes.core.k8s_info:
-    kind: Agent
-    api_version: agent-install.openshift.io/v1beta1
-    namespace: "{{ manage_agents_namespace }}"
-  register: current_agents
-  until: >
-    node_info.ports |
-    map(attribute='address') |
-    osac.service.mac_to_agent_name(current_agents.resources) is not none
-  retries: 90
-  delay: 10
-  loop: "{{ node_info_list }}"
-  loop_control:
-    loop_var: node_info
-    label: "{{ node_info.name }}"
-
-- name: Get all agents
-  kubernetes.core.k8s_info:
-    kind: Agent
-    api_version: agent-install.openshift.io/v1beta1
-    namespace: "{{ manage_agents_namespace }}"
-  register: final_agents_result
-
-- name: Extract final agents
+- name: Set bare metal pool template parameters
   ansible.builtin.set_fact:
-    final_agents: "{{ final_agents_result.resources }}"
+    bare_metal_pool_template_parameters:
+      agentPrivateNetwork: "{{ manage_agents_idle_agents_network_name }}"
+      imageURL: "{{ discovery_url }}"
 
-- name: Configure agent metadata for all nodes
+- name: Create bare metal pool for agent provisioning
   kubernetes.core.k8s:
     state: present
     definition:
-      apiVersion: agent-install.openshift.io/v1beta1
-      kind: Agent
+      apiVersion: osac.openshift.io/v1alpha1
+      kind: BareMetalPool
       metadata:
-        name: "{{ agent_metadata.name }}"
+        name: "{{ manage_agents_provisioning_pool_name }}"
         namespace: "{{ manage_agents_namespace }}"
-        annotations: "{{ agent_metadata.annotations }}"
-        labels: "{{ agent_metadata.labels }}"
       spec:
-        approved: true
-        hostname: "{{ agent_metadata.hostname | lower }}"
-  loop: >-
-    {{
-      node_info_list |
-      osac.esi.get_agent_metadata(final_agents)
-    }}
-  loop_control:
-    loop_var: agent_metadata
-    label: "{{ agent_metadata.name }}"
+        hostSets: "{{ manage_agents_host_sets }}"
+        profile:
+          name: "{{ manage_agents_provisioning_profile }}"
+          templateParameters: "{{ bare_metal_pool_template_parameters | to_json }}"
 
-- name: Move agents to idle agents network
-  ansible.builtin.include_role:
-    name: osac.esi.l2
-    tasks_from: set_networks_for_node
-  vars:
-    node: "{{ node_info.name }}"
-    networks:
-    - "{{ manage_agents_idle_agents_network }}"
-  loop: "{{ node_info_list }}"
-  loop_control:
-    loop_var: node_info
-    label: "{{ node_info.name }} -> {{ manage_agents_idle_agents_network }}"
+- name: Wait for bare metal pool to be ready
+  kubernetes.core.k8s_info:
+    kind: BareMetalPool
+    api_version: osac.openshift.io/v1alpha1
+    namespace: "{{ manage_agents_namespace }}"
+    name: "{{ manage_agents_provisioning_pool_name }}"
+  register: bmp_result
+  until: >
+    bmp_result.resources | length > 0 and
+    bmp_result.resources[0].status is defined and
+    bmp_result.resources[0].status.phase | default('') == "Ready"
+  retries: 120
+  delay: 15
+
+- name: Delete bare metal pool for agent provisioning
+  kubernetes.core.k8s:
+    state: absent
+    api_version: osac.openshift.io/v1alpha1
+    kind: BareMetalPool
+    name: "{{ manage_agents_provisioning_pool_name }}"
+    namespace: "{{ manage_agents_namespace }}"

--- a/collections/ansible_collections/osac/service/roles/manage_agents/tasks/remove_agents.yaml
+++ b/collections/ansible_collections/osac/service/roles/manage_agents/tasks/remove_agents.yaml
@@ -1,51 +1,35 @@
-- name: Display node names that will be removed from being agents
-  ansible.builtin.debug:
-    var: manage_agents_node_names
-
-- name: Get agents
-  kubernetes.core.k8s_info:
-    kind: Agent
-    api_version: agent-install.openshift.io/v1beta1
-    namespace: "{{ manage_agents_namespace }}"
-  register: agents_result
-
-- name: Extract agents
-  ansible.builtin.set_fact:
-    initial_agents: "{{ agents_result.resources }}"
-
-- name: Get node list for removal
-  ansible.builtin.include_role:
-    name: osac.esi.node
-    tasks_from: get_nodes
-  vars:
-    node_filter_names: "{{ manage_agents_node_names }}"
-# set_fact: node_info_list
-
-- name: Delete agents for each node
+- name: Create bare metal pool for agent deprovisioning
   kubernetes.core.k8s:
-    kind: Agent
-    api_version: agent-install.openshift.io/v1beta1
-    namespace: "{{ manage_agents_namespace }}"
-    name: >-
-      {{
-        node_info.ports |
-        map(attribute='address') |
-        osac.service.mac_to_agent_name(initial_agents)
-      }}
-    state: absent
-  loop: "{{ node_info_list }}"
-  loop_control:
-    loop_var: node_info
-    label: "{{ node_info.name }}"
+    state: present
+    definition:
+      apiVersion: osac.openshift.io/v1alpha1
+      kind: BareMetalPool
+      metadata:
+        name: "{{ manage_agents_deprovisioning_pool_name }}"
+        namespace: "{{ manage_agents_namespace }}"
+      spec:
+        hostSets: "{{ manage_agents_host_sets }}"
+        profile:
+          name: "{{ manage_agents_deprovisioning_profile }}"
 
-- name: Clean nodes
-  ansible.builtin.include_role:
-    name: osac.esi.node
-    tasks_from: clean_node
-  vars:
-    node_name: "{{ node_info.name }}"
-    node_clean_wait: true
-  loop: "{{ node_info_list }}"
-  loop_control:
-    loop_var: node_info
-    label: "{{ node_info.name }}"
+- name: Wait for bare metal pool to be ready
+  kubernetes.core.k8s_info:
+    kind: BareMetalPool
+    api_version: osac.openshift.io/v1alpha1
+    namespace: "{{ manage_agents_namespace }}"
+    name: "{{ manage_agents_deprovisioning_pool_name }}"
+  register: bmp_result
+  until: >
+    bmp_result.resources | length > 0 and
+    bmp_result.resources[0].status is defined and
+    bmp_result.resources[0].status.phase | default('') == "Ready"
+  retries: 120
+  delay: 15
+
+- name: Delete bare metal pool for agent deprovisioning
+  kubernetes.core.k8s:
+    state: absent
+    api_version: osac.openshift.io/v1alpha1
+    kind: BareMetalPool
+    name: "{{ manage_agents_deprovisioning_pool_name }}"
+    namespace: "{{ manage_agents_namespace }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+bm_host_agent_deprovisioning_agents_namespace: hardware-inventory

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/create.yaml
@@ -1,4 +1,68 @@
 ---
-- name: No-op for bm_host_agent_deprovisioning create
+- name: Fail if host class is not openstack
+  ansible.builtin.fail:
+    msg: "bm_host_agent_deprovisioning requires hostClass 'openstack', got '{{ bare_metal_instance.spec.hostClass | default('') }}'"
+  when: bare_metal_instance.spec.hostClass | default('') != "openstack"
+
+- name: Fail if network class is not openstack
+  ansible.builtin.fail:
+    msg: "bm_host_agent_deprovisioning requires networkClass 'openstack', got '{{ bare_metal_instance.spec.networkClass | default('') }}'"
+  when: bare_metal_instance.spec.networkClass | default('') != "openstack"
+
+- name: Get bare metal port information
+  openstack.cloud.baremetal_port_info:
+    node: "{{ bare_metal_instance.spec.externalHostID }}"
+  register: baremetal_port_result
+
+- name: Fail if no bare metal ports were found for node
+  ansible.builtin.fail:
+    msg: "No bare metal ports found for node '{{ bare_metal_instance.spec.externalHostID }}'"
+  when: baremetal_port_result.baremetal_ports | length == 0
+
+- name: Get agents
+  kubernetes.core.k8s_info:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ bm_host_agent_deprovisioning_agents_namespace }}"
+  register: agents_result
+
+- name: Extract agents
+  ansible.builtin.set_fact:
+    current_agents: "{{ agents_result.resources }}"
+
+- name: Set agent name
+  ansible.builtin.set_fact:
+    agent_name: >-
+      {{
+        baremetal_port_result.baremetal_ports |
+        map(attribute='address') |
+        osac.service.mac_to_agent_name(current_agents)
+      }}
+
+- name: Delete agent for node
+  when: agent_name is not none
+  kubernetes.core.k8s:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ bm_host_agent_deprovisioning_agents_namespace }}"
+    name: "{{ agent_name }}"
+    state: absent
+
+- name: Detach all networks and delete neutron ports
+  ansible.builtin.include_role:
+    name: osac.esi.l2
+    tasks_from: set_networks_for_node
+  vars:
+    node: "{{ bare_metal_instance.spec.externalHostID }}"
+    networks: []
+
+- name: Undeploy bare metal node
+  openstack.cloud.baremetal_node_action:
+    name: "{{ bare_metal_instance.spec.externalHostID }}"
+    state: absent
+    deploy: false
+    wait: true
+
+- name: Image deprovisioning initiated
   ansible.builtin.debug:
-    msg: "bm_host_agent_deprovisioning does not handle creation"
+    msg: "Image deprovisioning initiated for node {{ bare_metal_instance.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/delete.yaml
@@ -1,29 +1,4 @@
 ---
-- name: Fail if host class is not openstack
-  ansible.builtin.fail:
-    msg: "bm_host_agent_deprovisioning requires hostClass 'openstack', got '{{ bare_metal_instance.spec.hostClass | default('') }}'"
-  when: bare_metal_instance.spec.hostClass | default('') != "openstack"
-
-- name: Fail if network class is not openstack
-  ansible.builtin.fail:
-    msg: "bm_host_agent_deprovisioning requires networkClass 'openstack', got '{{ bare_metal_instance.spec.networkClass | default('') }}'"
-  when: bare_metal_instance.spec.networkClass | default('') != "openstack"
-
-- name: Detach all networks and delete neutron ports
-  ansible.builtin.include_role:
-    name: massopencloud.esi.l2
-    tasks_from: set_networks_for_node
-  vars:
-    node: "{{ bare_metal_instance.spec.externalHostID }}"
-    networks: []
-
-- name: Undeploy bare metal node
-  openstack.cloud.baremetal_node_action:
-    name: "{{ bare_metal_instance.spec.externalHostID }}"
-    state: absent
-    deploy: false
-    wait: true
-
-- name: Image deprovisioning initiated
+- name: No-op for bm_host_agent_deprovisioning delete
   ansible.builtin.debug:
-    msg: "Image deprovisioning initiated for node {{ bare_metal_instance.spec.externalHostID }}"
+    msg: "bm_host_agent_deprovisioning does not handle deletion"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+bm_host_agent_provisioning_agents_namespace: hardware-inventory

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
@@ -23,6 +23,16 @@
     msg: "Bare metal node '{{ bare_metal_instance.spec.externalHostID }}' not found in OpenStack"
   when: baremetal_node_result.nodes | length == 0
 
+- name: Get bare metal port information
+  openstack.cloud.baremetal_port_info:
+    node: "{{ bare_metal_instance.spec.externalHostID }}"
+  register: baremetal_port_result
+
+- name: Fail if no bare metal ports were found for node
+  ansible.builtin.fail:
+    msg: "No bare metal ports found for node '{{ bare_metal_instance.spec.externalHostID }}'"
+  when: baremetal_port_result.baremetal_ports | length == 0
+
 - name: Extract node info
   ansible.builtin.set_fact:
     node_info: "{{ baremetal_node_result.nodes[0] }}"
@@ -87,7 +97,7 @@
 
     - name: Set provisioning network for node
       ansible.builtin.include_role:
-        name: massopencloud.esi.l2
+        name: osac.esi.l2
         tasks_from: set_networks_for_node
       vars:
         node: "{{ bare_metal_instance.spec.externalHostID }}"
@@ -111,9 +121,43 @@
         deploy: true
         wait: true
 
+- name: Wait for node to register as agent
+  kubernetes.core.k8s_info:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ bm_host_agent_provisioning_agents_namespace }}"
+  register: current_agents
+  until: >
+    baremetal_port_result.baremetal_ports |
+    map(attribute='address') |
+    osac.service.mac_to_agent_name(current_agents.resources) is not none
+  retries: 90
+  delay: 10
+
+- name: Find agent
+  ansible.builtin.set_fact:
+    agent_name: "{{ baremetal_port_result.baremetal_ports | map(attribute='address') | osac.service.mac_to_agent_name(current_agents.resources) }}"
+
+- name: Configure agent metadata
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: agent-install.openshift.io/v1beta1
+      kind: Agent
+      metadata:
+        name: "{{ agent_name }}"
+        namespace: "{{ bm_host_agent_provisioning_agents_namespace }}"
+        annotations:
+          "osac.openshift.io/host_uuid": "{{ node_info.id }}"
+        labels:
+          "osac.openshift.io/resource_class": "{{ node_info.resource_class }}"
+      spec:
+        approved: true
+        hostname: "{{ node_info.name | lower }}"
+
 - name: Ensure node is on agent private network
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ bare_metal_instance.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/create.yaml
@@ -20,7 +20,7 @@
 
 - name: Attach node to private network
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ bare_metal_instance.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/delete.yaml
@@ -15,7 +15,7 @@
 
 - name: Detach node from private network
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ bare_metal_instance.spec.externalHostID }}"
@@ -23,7 +23,7 @@
 
 - name: Attach node to network after detach
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ bare_metal_instance.spec.externalHostID }}"


### PR DESCRIPTION
In addition, this PR updates the `bm_host_agent_provisioning` role to execute the additional tasks needed for a host to become an agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New default options for agent namespaces, idle network name, and provisioning/deprovisioning pool and profile names.

* **Changes**
  * Import workflow now uses discovery-based bare-metal provisioning via pool/lease orchestration and auto-registers/approves agents.
  * Removal workflow now deprovisions via resource pools and host leases with stricter validation and network cleanup.

* **Style**
  * Internal role references standardized to the new namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->