### PR TITLE
OSAC-956: fix incompatible yamllint configuration for ansible-lint

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,9 +1,0 @@
-[allowlist]
-  description = "Global Allowlist"
-
-  # Ignore based on any subset of the file path
-  paths = [
-    # Ignore all example certs
-    ''''tests/test-windows-golden-image-sysprep\.yml$'',
-
-  ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,9 @@
+[allowlist]
+  description = "Global Allowlist"
+
+  # Ignore based on any subset of the file path
+  paths = [
+    # Ignore all example certs
+    ''''tests/test-windows-golden-image-sysprep\.yml$'',
+
+  ]

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -10,3 +10,9 @@ rules:
     check-keys: false
   comments:
     min-spaces-from-content: 1
+  comments-indentation: false
+  braces:
+    max-spaces-inside: 1
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true


### PR DESCRIPTION
## Summary

Fixes the incompatible custom yamllint configuration warning from ansible-lint by adding the four required settings to `.yamllint.yaml`.

## Changes

Added required ansible-lint yamllint configuration settings:
- `comments-indentation: false`
- `braces.max-spaces-inside: 1`
- `octal-values.forbid-implicit-octal: true`
- `octal-values.forbid-explicit-octal: true`

## Verification

Ran `uv run ansible-lint` on all Ansible content in the repository:
- ✅ 40 playbooks - 0 failures, 0 warnings
- ✅ 9 files in osac/config_as_code - 0 failures, 1 ignored warning
- ✅ 80 files in osac/service - 0 failures, 0 warnings
- ✅ 94 files in osac/templates - 0 failures, 0 warnings
- ✅ 28 files in osac/test_overrides - 0 failures, 19 ignored warnings
- ✅ 4 files in osac/workflows - 0 failures, 0 warnings

**Total: 255 files linted, 0 failures, all passed**

The incompatible yamllint configuration warning is resolved and fix mode is now available.

## Related

- Jira: https://redhat.atlassian.net/browse/OSAC-956

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated YAML linting configuration to enhance code quality standards and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-aap/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->