### PR TITLE
OSAC-58: add demo_ocp_4_17 template role for catalog items demo

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/defaults/main.yaml
@@ -1,0 +1,1 @@
+ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.17.0-multi

--- a/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/meta/osac.yaml
@@ -1,0 +1,10 @@
+title: OpenShift 4.17 Demo Base
+description: >
+  Base template for catalog items demo. Supports sandbox and production
+  configurations via catalog item field definitions.
+
+default_node_request:
+- resourceClass: fc430
+  numberOfNodes: 3
+
+allowed_resource_classes: []

--- a/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/meta/osac.yaml
@@ -2,6 +2,10 @@ title: OpenShift 4.17 Demo Base
 description: >
   Base template for catalog items demo. Supports sandbox and production
   configurations via catalog item field definitions.
+implementation_strategy: demo_ocp_4_17
+template_type: cluster
+capabilities:
+  supports_catalog_items: true
 
 default_node_request:
 - resourceClass: fc430

--- a/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/delete.yaml
@@ -1,0 +1,61 @@
+- name: Set delete step defaults
+  ansible.builtin.set_fact:
+    delete_step_pre_delete_hook_default:
+      name: osac.templates.ocp_4_17_small
+      tasks_from: noop.yaml
+    delete_step_hosted_cluster_default:
+      name: osac.service.hosted_cluster
+      tasks_from: main.yaml
+    delete_step_external_access_default:
+      name: osac.service.external_access
+      tasks_from: main.yaml
+    delete_step_cluster_infra_default:
+      name: osac.service.cluster_infra
+      tasks_from: main.yaml
+    delete_step_post_delete_hook_default:
+      name: osac.templates.ocp_4_17_small
+      tasks_from: noop.yaml
+
+- name: Step - Pre-delete hook
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_pre_delete_hook_override | default(delete_step_pre_delete_hook_default)).name }}"
+    tasks_from: "{{ (delete_step_pre_delete_hook_override | default(delete_step_pre_delete_hook_default)).tasks_from }}"
+
+- name: Step - Destroy hosted cluster
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_hosted_cluster_override | default(delete_step_hosted_cluster_default)).name }}"
+    tasks_from: "{{ (delete_step_hosted_cluster_override | default(delete_step_hosted_cluster_default)).tasks_from }}"
+  vars:
+    hosted_cluster_state: absent
+    hosted_cluster_name: "{{ cluster_order.metadata.name }}"
+    hosted_cluster_namespace: "{{ cluster_working_namespace }}"
+    hosted_cluster_settings:
+      ocp_release_image: "{{ ocp_release_image }}"
+      pull_secret: "{{ cluster_settings_pull_secret }}"
+      ssh_public_key: "{{ cluster_settings_ssh_public_key }}"
+    hosted_cluster_node_count: >-
+      {{ cluster_order.spec.nodeRequests | map(attribute="numberOfNodes") | sum }}
+
+- name: Step - Remove port forwarding
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_external_access_override | default(delete_step_external_access_default)).name }}"
+    tasks_from: "{{ (delete_step_external_access_override | default(delete_step_external_access_default)).tasks_from }}"
+  vars:
+    external_access_state: absent
+    external_access_name: "{{ cluster_order.metadata.name }}"
+    external_access_namespace: "{{ cluster_working_namespace }}"
+
+- name: Step - Destroy cluster infrastructure
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_cluster_infra_override | default(delete_step_cluster_infra_default)).name }}"
+    tasks_from: "{{ (delete_step_cluster_infra_override | default(delete_step_cluster_infra_default)).tasks_from }}"
+  vars:
+    cluster_infra_state: absent
+    cluster_infra_name: "{{ cluster_order.metadata.name }}"
+    cluster_infra_namespace: "{{ cluster_working_namespace }}"
+    cluster_infra_node_requests: []
+
+- name: Step - Post-delete hook
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_post_delete_hook_override | default(delete_step_post_delete_hook_default)).name }}"
+    tasks_from: "{{ (delete_step_post_delete_hook_override | default(delete_step_post_delete_hook_default)).tasks_from }}"

--- a/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/delete.yaml
@@ -1,7 +1,7 @@
 - name: Set delete step defaults
   ansible.builtin.set_fact:
     delete_step_pre_delete_hook_default:
-      name: osac.templates.ocp_4_17_small
+      name: osac.templates.demo_ocp_4_17
       tasks_from: noop.yaml
     delete_step_hosted_cluster_default:
       name: osac.service.hosted_cluster
@@ -13,7 +13,7 @@
       name: osac.service.cluster_infra
       tasks_from: main.yaml
     delete_step_post_delete_hook_default:
-      name: osac.templates.ocp_4_17_small
+      name: osac.templates.demo_ocp_4_17
       tasks_from: noop.yaml
 
 - name: Step - Pre-delete hook

--- a/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/install.yaml
@@ -1,0 +1,93 @@
+- name: Set install step defaults
+  ansible.builtin.set_fact:
+    install_step_pre_install_hook_default:
+      name: osac.templates.ocp_4_17_small
+      tasks_from: noop.yaml
+    install_step_hosted_cluster_default:
+      name: osac.service.hosted_cluster
+      tasks_from: main.yaml
+    install_step_cluster_infra_default:
+      name: osac.service.cluster_infra
+      tasks_from: main.yaml
+    install_step_external_access_default:
+      name: osac.service.external_access
+      tasks_from: main.yaml
+    install_step_retrieve_kubeconfig_default:
+      name: osac.service.retrieve_kubeconfig
+      tasks_from: main.yaml
+    install_step_wait_for_nodes_default:
+      name: osac.service.wait_for
+      tasks_from: wait_for_nodes.yaml
+    install_step_wait_for_cluster_operators_default:
+      name: osac.service.wait_for
+      tasks_from: wait_for_cluster_operators.yaml
+    install_step_post_install_hook_default:
+      name: osac.templates.ocp_4_17_small
+      tasks_from: noop.yaml
+
+- name: Step - Pre-install hook
+  ansible.builtin.include_role:
+    name: "{{ (install_step_pre_install_hook_override | default(install_step_pre_install_hook_default)).name }}"
+    tasks_from: "{{ (install_step_pre_install_hook_override | default(install_step_pre_install_hook_default)).tasks_from }}"
+
+- name: Step - Create hosted cluster
+  ansible.builtin.include_role:
+    name: "{{ (install_step_hosted_cluster_override | default(install_step_hosted_cluster_default)).name }}"
+    tasks_from: "{{ (install_step_hosted_cluster_override | default(install_step_hosted_cluster_default)).tasks_from }}"
+  vars:
+    hosted_cluster_name: "{{ cluster_order.metadata.name }}"
+    hosted_cluster_namespace: "{{ cluster_working_namespace }}"
+    hosted_cluster_settings:
+      ocp_release_image: "{{ ocp_release_image }}"
+      pull_secret: "{{ cluster_settings_pull_secret }}"
+      ssh_public_key: "{{ cluster_settings_ssh_public_key }}"
+    hosted_cluster_node_requests: "{{ cluster_order.spec.nodeRequests | unique(attribute='resourceClass') }}"
+    hosted_cluster_state: present
+
+- name: Step - Create cluster infrastructure
+  ansible.builtin.include_role:
+    name: "{{ (install_step_cluster_infra_override | default(install_step_cluster_infra_default)).name }}"
+    tasks_from: "{{ (install_step_cluster_infra_override | default(install_step_cluster_infra_default)).tasks_from }}"
+  vars:
+    cluster_infra_state: present
+    cluster_infra_name: "{{ cluster_order.metadata.name }}"
+    cluster_infra_namespace: "{{ cluster_working_namespace }}"
+    cluster_infra_node_requests: "{{ cluster_order.spec.nodeRequests | unique(attribute='resourceClass') }}"
+
+- name: Step - Configure port forwarding
+  ansible.builtin.include_role:
+    name: "{{ (install_step_external_access_override | default(install_step_external_access_default)).name }}"
+    tasks_from: "{{ (install_step_external_access_override | default(install_step_external_access_default)).tasks_from }}"
+  vars:
+    external_access_name: "{{ cluster_order.metadata.name }}"
+    external_access_state: present
+    external_access_namespace: "{{ cluster_working_namespace }}"
+    external_access_ingress_internal_network: "network-{{ cluster_order.metadata.name }}"
+
+- name: Step - Retrieve kubeconfig
+  ansible.builtin.include_role:
+    name: "{{ (install_step_retrieve_kubeconfig_override | default(install_step_retrieve_kubeconfig_default)).name }}"
+    tasks_from: "{{ (install_step_retrieve_kubeconfig_override | default(install_step_retrieve_kubeconfig_default)).tasks_from }}"
+  vars:
+    retrieve_kubeconfig_cluster_name: "{{ cluster_order.metadata.name }}"
+    retrieve_kubeconfig_namespace: "{{ cluster_working_namespace }}"
+
+- name: Step - Wait for nodes to be ready
+  ansible.builtin.include_role:
+    name: "{{ (install_step_wait_for_nodes_override | default(install_step_wait_for_nodes_default)).name }}"
+    tasks_from: "{{ (install_step_wait_for_nodes_override | default(install_step_wait_for_nodes_default)).tasks_from }}"
+  vars:
+    wait_for_kubeconfig: "{{ admin_kubeconfig }}"
+    wait_for_nodes_expected_count: "{{ cluster_order.spec.nodeRequests | map(attribute='numberOfNodes') | map('int') | sum }}"
+
+- name: Step - Wait for cluster operators
+  ansible.builtin.include_role:
+    name: "{{ (install_step_wait_for_cluster_operators_override | default(install_step_wait_for_cluster_operators_default)).name }}"
+    tasks_from: "{{ (install_step_wait_for_cluster_operators_override | default(install_step_wait_for_cluster_operators_default)).tasks_from }}"
+  vars:
+    wait_for_kubeconfig: "{{ admin_kubeconfig }}"
+
+- name: Step - Post-install hook
+  ansible.builtin.include_role:
+    name: "{{ (install_step_post_install_hook_override | default(install_step_post_install_hook_default)).name }}"
+    tasks_from: "{{ (install_step_post_install_hook_override | default(install_step_post_install_hook_default)).tasks_from }}"

--- a/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/install.yaml
@@ -1,7 +1,7 @@
 - name: Set install step defaults
   ansible.builtin.set_fact:
     install_step_pre_install_hook_default:
-      name: osac.templates.ocp_4_17_small
+      name: osac.templates.demo_ocp_4_17
       tasks_from: noop.yaml
     install_step_hosted_cluster_default:
       name: osac.service.hosted_cluster
@@ -22,7 +22,7 @@
       name: osac.service.wait_for
       tasks_from: wait_for_cluster_operators.yaml
     install_step_post_install_hook_default:
-      name: osac.templates.ocp_4_17_small
+      name: osac.templates.demo_ocp_4_17
       tasks_from: noop.yaml
 
 - name: Step - Pre-install hook

--- a/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/noop.yaml
+++ b/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/noop.yaml
@@ -1,0 +1,3 @@
+---
+# No-op task file for default hooks
+# This file makes the template self-contained without external collection dependencies

--- a/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/post_install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/demo_ocp_4_17/tasks/post_install.yaml
@@ -1,0 +1,69 @@
+---
+- name: Ensure openshift-operators namespace exists
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-operators
+
+- name: Create cert-manager subscription
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: cert-manager
+        namespace: openshift-operators
+      spec:
+        channel: stable
+        installPlanApproval: Automatic
+        name: cert-manager
+        source: community-operators
+        sourceNamespace: openshift-marketplace
+
+- name: Create production issuer
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-production-http01
+      spec:
+        acme:
+          privateKeySecretRef:
+            name: letsencrypt-production-http01
+          server: 'https://acme-v02.api.letsencrypt.org/directory'
+          solvers:
+            - http01:
+                ingress:
+                  class: openshift-default
+  register: production_issuer_result
+  until: production_issuer_result is succeeded
+  retries: 30
+  delay: 30
+
+- name: Create staging issuer
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-staging-http01
+      spec:
+        acme:
+          privateKeySecretRef:
+            name: letsencrypt-staging-http01
+          server: 'https://acme-staging-v02.api.letsencrypt.org/directory'
+          solvers:
+            - http01:
+                ingress:
+                  class: openshift-default
+  register: staging_issuer_result
+  until: staging_issuer_result is succeeded
+  retries: 30
+  delay: 30


### PR DESCRIPTION
## Summary
Fork `ocp_4_17_small` to `demo_ocp_4_17` with 3 worker nodes (instead of 2) to serve as the base template for the catalog items demo.

Two catalog items will reference this template with different field definitions:
- **Developer Sandbox** — locked pull_secret, ssh_key, fixed size
- **Production Cluster** — user-configurable pull_secret, ssh_key, release_image

The role tasks are identical to `ocp_4_17_small` — same HyperShift provisioning flow, same service roles.

## Test plan
- [x] `ansible-lint` passes
- [ ] Deploy to vmaas-dev AAP, run publish_templates, verify template appears in fulfillment API

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenShift 4.17 Demo template with complete installation and deletion workflows
  * Configured cert-manager with ACME-based issuers for production and staging environments

* **Chores**
  * Updated default OpenShift release image to version 4.17.0-multi

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-aap/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->