### PR TITLE
Simplify DNS record deletion

### DIFF
--- a/collections/ansible_collections/dns/route53/roles/dns/tasks/delete.yaml
+++ b/collections/ansible_collections/dns/route53/roles/dns/tasks/delete.yaml
@@ -1,25 +1,11 @@
 ---
-- name: "Look up existing DNS record via Route 53 - {{ dns_record_name }}"
-  amazon.aws.route53:
-    state: get
-    zone: "{{ dns_zone }}"
-    record: "{{ dns_record_name }}"
-    type: "{{ dns_record_type }}"
-    access_key: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | trim }}"
-    secret_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | trim }}"
-  register: __dns_route53_existing
-  no_log: true
-
 - name: "Delete DNS record via Route 53 - {{ dns_record_name }}"
   amazon.aws.route53:
     state: absent
     zone: "{{ dns_zone }}"
     record: "{{ dns_record_name }}"
     type: "{{ dns_record_type }}"
-    ttl: "{{ __dns_route53_existing.set.ttl }}"
-    value: "{{ __dns_route53_existing.set.value }}"
     wait: true
     access_key: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') | trim }}"
     secret_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') | trim }}"
-  when: __dns_route53_existing.set is defined and (__dns_route53_existing.set | length > 0)
   no_log: true


### PR DESCRIPTION
If we're just going to delete the result of the lookup, we can skip the
lookup and just perform the delete operation. It will be a no-op if the
record does not exist.

The lookup requires the GetHostedZone permission. By removing this
operation we reduce the number of required privileges.

The failure message looks like this:

    [ERROR]: Task failed: Module failed: An error occurred (AccessDenied)
    when calling the GetHostedZone operation: User:
    arn:aws:iam::574733721584:user/innabox-dns-manager is not authorized to
    perform: route53:GetHostedZone on resource:
    arn:aws:route53:::hostedzone/Z04852601TXCBCBTBU5T1 because no
    identity-based policy allows the route53:GetHostedZone action


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified DNS record deletion: the workflow no longer performs a preliminary lookup or conditional guard before removal. Deletions now run directly and consistently using the configured zone, record name, and type, respect environment-provided credentials, execute synchronously, and avoid logging sensitive details to improve reliability and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-aap/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->