### PR TITLE
OSAC-712: Add BCM inventory integration for importing bare metal agents

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/playbooks/vars/config.yml
+++ b/collections/ansible_collections/osac/config_as_code/playbooks/vars/config.yml
@@ -17,3 +17,4 @@ remote_cluster_kubeconfig_secret_name: "{{ lookup('env', 'REMOTE_CLUSTER_KUBECON
 remote_cluster_kubeconfig_secret_key: "{{ lookup('env', 'REMOTE_CLUSTER_KUBECONFIG_SECRET_KEY', default='kubeconfig') }}"
 osac_publish_templates_enabled: "{{ lookup('env', 'OSAC_PUBLISH_TEMPLATES_ENABLED', default='true') | bool }}"
 osac_import_agents_enabled: "{{ lookup('env', 'OSAC_IMPORT_AGENTS_ENABLED', default='false') | bool }}"
+osac_import_bcm_agents_enabled: "{{ lookup('env', 'OSAC_IMPORT_BCM_AGENTS_ENABLED', default='false') | bool }}"

--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -355,6 +355,18 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: false
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-import-bcm-agents"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_import_bcm_agents.yml"
+    inventory: "{{ aap_prefix }}-cluster-fulfillment"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-cluster-fulfillment-ig"
+    allow_simultaneous: false
+    ask_variables_on_launch: true
+    verbosity: 0
 
 controller_job_template_surveys: # noqa: var-naming[no-role-prefix]
   - name: "{{ aap_prefix }}-create-hosted-cluster-post-install"
@@ -553,6 +565,12 @@ controller_schedules: # noqa: var-naming[no-role-prefix]
     unified_job_template: "{{ aap_prefix }}-import-agents"
     rrule: "DTSTART:20250331T144500Z RRULE:FREQ=MINUTELY;INTERVAL=10"
     enabled: "{{ osac_import_agents_enabled }}"
+  - name: "{{ aap_prefix }}-import-bcm-agents"
+    description: "Periodic BCM agent import reconciliation"
+    organization: "{{ aap_organization_name }}"
+    unified_job_template: "{{ aap_prefix }}-import-bcm-agents"
+    rrule: "DTSTART:20250519T120000Z RRULE:FREQ=MINUTELY;INTERVAL=10"
+    enabled: "{{ osac_import_bcm_agents_enabled }}"
 
 # Create custom execution environments
 controller_execution_environments: # noqa: var-naming[no-role-prefix]
@@ -605,6 +623,9 @@ controller_instance_groups: # noqa: var-naming[no-role-prefix]
               - name: import-agents-inventory
                 mountPath: /var/config/import-agents
                 readOnly: true
+              - name: bcm-certs
+                mountPath: /var/secrets/bcm-certs
+                readOnly: true
             env:
               - name: POD_NAMESPACE
                 valueFrom:
@@ -625,6 +646,10 @@ controller_instance_groups: # noqa: var-naming[no-role-prefix]
               - secretRef:
                   name: cluster-fulfillment-ig
         volumes:
+        - name: bcm-certs
+          secret:
+            secretName: bcm-certs
+            optional: true
         - name: kube-api-access
           projected:
             sources:

--- a/collections/ansible_collections/osac/service/plugins/filter/bcm.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/bcm.py
@@ -1,0 +1,224 @@
+import re
+
+
+BMC_TYPE_PATTERNS = {
+    "redfish": re.compile(r"^rf\d+$"),
+    "ipmi": re.compile(r"^ipmi\d+$"),
+    "ilo": re.compile(r"^ilo\d+$"),
+    "drac": re.compile(r"^drac\d+$"),
+}
+
+# BMC types that support Redfish and need system ID discovery via MAC matching.
+# The protocol prefix is used instead of "redfish-virtualmedia".
+REDFISH_COMPATIBLE_PROTOCOLS = {
+    "redfish": "redfish-virtualmedia",
+    "drac": "idrac-virtualmedia",
+    "ilo": "ilo5-virtualmedia",
+}
+
+# BMC types with static URL formats (no Redfish discovery needed).
+BMC_STATIC_URL_FORMATS = {
+    "ipmi": "ipmi://{bmc_ip}",
+}
+
+_K8S_LABEL_RE = re.compile(r"[^a-zA-Z0-9._-]")
+
+
+def classify_bmc_type(interface_name: str) -> str:
+    for bmc_type, pattern in BMC_TYPE_PATTERNS.items():
+        if pattern.match(interface_name):
+            return bmc_type
+    return "unknown"
+
+
+def sanitize_k8s_name(name: str) -> str:
+    """Converts a string to a valid Kubernetes DNS subdomain name."""
+    sanitized = re.sub(r"[^a-z0-9.-]", "-", name.lower())
+    sanitized = re.sub(r"\.{2,}", ".", sanitized)
+    return sanitized[:253].strip(".-")
+
+
+def sanitize_k8s_label_value(value: str) -> str:
+    """Converts a string to a valid Kubernetes label value."""
+    sanitized = _K8S_LABEL_RE.sub("-", value)
+    return re.sub(r"^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$", "", sanitized[:63])
+
+
+def parse_notes(notes: str) -> dict:
+    """Parses key=value pairs from the BCM device notes field.
+
+    Inverse of build_notes() in scripts/bcm_add_lite_nodes.py.
+    """
+    result = {}
+    for line in (notes or "").splitlines():
+        line = line.strip()
+        if "=" in line:
+            key, _, value = line.partition("=")
+            result[key.strip()] = value.strip()
+    return result
+
+
+def bcm_device_to_server(device: dict,
+                         racks_by_uuid: dict,
+                         disable_bmc_cert_verification: bool = True) -> dict:
+    """Converts a BCM device object into a normalized server dict for BMH creation.
+
+    Resource class is read from the device notes field (resource_class=<value>).
+    BMC type is classified from the interface name (rf0=redfish, ipmi0=ipmi, etc.).
+    Hostname is sanitized for use as a Kubernetes resource name.
+    """
+
+    bmc_ip = ""
+    bmc_type = "unknown"
+    for iface in device.get("interfaces", []):
+        if iface.get("childType") == "NetworkBmcInterface":
+            bmc_ip = iface.get("ip", "")
+            bmc_type = classify_bmc_type(iface.get("name", ""))
+            break
+
+    notes = parse_notes(device.get("notes", ""))
+    resource_class = sanitize_k8s_label_value(
+        notes.get("resource_class", "unknown"))
+
+    rack_uuid = device.get("rackPosition", {}).get("rack", "")
+    rack_name = sanitize_k8s_label_value(
+        racks_by_uuid.get(rack_uuid, ""))
+
+    bmc = device.get("bmcSettings") or {}
+
+    return {
+        "name": sanitize_k8s_name(device.get("hostname", "") or device.get("uuid", "")),
+        "uuid": device.get("uuid", ""),
+        "boot_mac": device.get("mac", ""),
+        "bmc_ip": bmc_ip,
+        "bmc_type": bmc_type,
+        "bmc_username": bmc.get("userName", ""),
+        "bmc_password": bmc.get("password", ""),
+        "resource_class": resource_class,
+        "rack": rack_name,
+        "disable_bmc_cert_verification": bool(disable_bmc_cert_verification),
+    }
+
+
+def bcm_attach_bmc_urls(servers: list[dict],
+                        mac_to_redfish: dict) -> list[dict]:
+    """Attaches BMC URLs to servers based on their bmc_type.
+
+    Redfish-compatible types (redfish, drac, ilo) use MAC-based system
+    discovery with their respective protocol prefix.
+    Static types (ipmi) get a simple URL from BMC_STATIC_URL_FORMATS.
+    Servers with empty boot_mac or bmc_ip get an empty bmc_url.
+    """
+    result = []
+    for server in servers:
+        bmc_type = server.get("bmc_type", "unknown")
+        bmc_url = ""
+
+        if not server.get("boot_mac") or not server.get("bmc_ip"):
+            result.append({**server, "bmc_url": bmc_url})
+            continue
+
+        if bmc_type in REDFISH_COMPATIBLE_PROTOCOLS:
+            mac = server["boot_mac"].lower()
+            entry = mac_to_redfish.get(mac, {})
+            if entry.get("system_path"):
+                bmc_ip = entry.get("bmc_ip", server["bmc_ip"])
+                protocol = REDFISH_COMPATIBLE_PROTOCOLS[bmc_type]
+                bmc_url = f"{protocol}+https://{bmc_ip}{entry['system_path']}"
+        elif bmc_type in BMC_STATIC_URL_FORMATS:
+            bmc_url = BMC_STATIC_URL_FORMATS[bmc_type].format(bmc_ip=server["bmc_ip"])
+
+        result.append({**server, "bmc_url": bmc_url})
+    return result
+
+
+def bcm_build_redfish_queries(servers: list[dict],
+                              redfish_results: list[dict]) -> list[dict]:
+    """Builds a flat list of Redfish EthernetInterface queries from system collections.
+
+    Correlates servers to results by positional index — relies on Ansible's
+    loop+register producing .results in the same order as the input list.
+    """
+    queries = []
+    for i, result in enumerate(redfish_results):
+        if result.get("skipped") or result.get("failed"):
+            continue
+        server = servers[i]
+        members = result.get("json", {}).get("Members", [])
+        for member in members:
+            odata_id = member.get("@odata.id")
+            if not odata_id:
+                continue
+            queries.append({
+                "bmc_ip": server["bmc_ip"],
+                "bmc_username": server["bmc_username"],
+                "bmc_password": server["bmc_password"],
+                "disable_bmc_cert_verification": server.get("disable_bmc_cert_verification", True),
+                "system_path": odata_id,
+            })
+    return queries
+
+
+def bcm_build_eth_iface_queries(eth_collection_results: list[dict]) -> list[dict]:
+    """Expands EthernetInterfaces collection responses into individual interface queries.
+
+    Takes registered results from fetching /EthernetInterfaces collections
+    and produces a flat list of individual interface URLs to fetch, along
+    with the parent system path and BMC credentials.
+    """
+    queries = []
+    for result in eth_collection_results:
+        if result.get("skipped") or result.get("failed"):
+            continue
+        query = result.get("query", {})
+        members = result.get("json", {}).get("Members", [])
+        for member in members:
+            odata_id = member.get("@odata.id")
+            if not odata_id:
+                continue
+            queries.append({
+                "bmc_ip": query.get("bmc_ip", ""),
+                "bmc_username": query.get("bmc_username", ""),
+                "bmc_password": query.get("bmc_password", ""),
+                "disable_bmc_cert_verification": query.get("disable_bmc_cert_verification", True),
+                "system_path": query.get("system_path", ""),
+                "iface_path": odata_id,
+            })
+    return queries
+
+
+def bcm_build_mac_to_redfish(iface_results: list[dict]) -> dict:
+    """Builds MAC-to-Redfish-system mapping from individual EthernetInterface responses.
+
+    Reads the MACAddress property from each fetched interface and maps it
+    to the parent system path and BMC IP.
+    """
+    mapping = {}
+    for result in iface_results:
+        if result.get("skipped") or result.get("failed"):
+            continue
+        query = result.get("query", {})
+        mac = result.get("json", {}).get("MACAddress", "")
+        if mac:
+            mapping[mac.lower()] = {
+                "bmc_ip": query.get("bmc_ip", ""),
+                "system_path": query.get("system_path", ""),
+            }
+    return mapping
+
+
+def bcm_redfish_compatible_types(_input=None) -> list[str]:
+    """Returns list of BMC types that need Redfish discovery."""
+    return list(REDFISH_COMPATIBLE_PROTOCOLS.keys())
+
+
+class FilterModule:
+    def filters(self):
+        return {
+            "bcm_device_to_server": bcm_device_to_server,
+            "bcm_attach_bmc_urls": bcm_attach_bmc_urls,
+            "bcm_build_redfish_queries": bcm_build_redfish_queries,
+            "bcm_build_eth_iface_queries": bcm_build_eth_iface_queries,
+            "bcm_build_mac_to_redfish": bcm_build_mac_to_redfish,
+            "bcm_redfish_compatible_types": bcm_redfish_compatible_types,
+        }

--- a/docs/bcm-inventory-integration.md
+++ b/docs/bcm-inventory-integration.md
@@ -1,0 +1,234 @@
+# BCM Inventory Integration
+
+Import bare metal servers managed by NVIDIA Base Command Manager (BCM) as
+Assisted Installer agents so they can be used for cluster-as-a-service via OSAC.
+
+This integration was built and tested against **BCM 11** (Rocky Linux 9).
+
+## Overview
+
+BCM acts as the inventory source of truth for bare metal hardware. This
+integration reads device information from BCM's JSON API, discovers BMC
+system IDs by matching boot MAC addresses, and creates BareMetalHost CRs
+so that Metal3/Ironic can boot the nodes with a discovery ISO. Once the nodes
+register as Agents, the playbook labels them with resource class and rack
+metadata from BCM.
+
+```text
+BCM (Lite Nodes)
+      |
+      | 1. Fetch inventory via JSON API (mTLS)
+      v
+playbook_osac_import_bcm_agents.yml
+      |
+      | 2. Query BMC endpoints, match systems by MAC
+      | 3. Create BMC secrets + BareMetalHost CRs
+      v
+Metal3 / Ironic
+      |
+      | 4. Boot nodes with discovery ISO via virtual media
+      v
+Assisted Installer Agents
+      |
+      | 5. Label agents with resource_class, rack metadata
+      v
+OSAC (cluster provisioning)
+```
+
+## Device Model
+
+Nodes are registered in BCM as **Lite Nodes** rather than Physical Nodes. This
+means BCM provides inventory and monitoring without managing the OS — OpenShift
+handles provisioning via RHCOS.
+
+Each Lite Node has:
+- **Hostname and MAC** for identification
+- **BMC interface** pointing to the BMC endpoint (e.g., `rf0` for Redfish,
+  `ipmi0` for IPMI, `drac0` for iDRAC, `ilo0` for iLO)
+- **BMC credentials** (`bmcSettings`) for BMC authentication
+- **Notes field** containing `resource_class=<value>` for hardware classification
+
+## Supported BMC Types
+
+| BCM Interface | BMC Type | Protocol | Discovery |
+|---------------|----------|----------|-----------|
+| `rf0` | Redfish | `redfish-virtualmedia+https://` | MAC-based system discovery |
+| `drac0` | iDRAC | `idrac-virtualmedia+https://` | MAC-based system discovery |
+| `ilo0` | iLO | `ilo5-virtualmedia+https://` | MAC-based system discovery |
+| `ipmi0` | IPMI | `ipmi://` | Static URL (no discovery needed) |
+
+Redfish-compatible types (redfish, drac, ilo) query the BMC's
+`/redfish/v1/Systems/` and `/EthernetInterfaces` endpoints to find the
+correct system UUID by matching boot MAC addresses. IPMI uses a simple
+`ipmi://<bmc_ip>` URL with no discovery step.
+
+## Prerequisites
+
+- BCM head node with JSON API accessible on port 8081
+- Client certificate and key for BCM mTLS authentication
+- BMC endpoints accessible from the cluster
+- OpenShift cluster with:
+  - Baremetal Operator (BMO) configured with `watchAllNamespaces: true`
+  - Assisted service installed
+  - Agent namespace created (default: `hardware-inventory`)
+  - Pull secret in the agent namespace
+
+## Adding Nodes to BCM
+
+Use the `bcm_add_lite_nodes.py` script to register bare metal machines as
+Lite Nodes in BCM:
+
+```bash
+python3 hack/bcm_add_lite_nodes.py \
+  --url https://bcm-head:8081 \
+  --cert /path/to/cert.pem \
+  --key /path/to/key.pem \
+  --inventory samples/bcm_lite_nodes_inventory.yml
+```
+
+### Inventory File Format
+
+```yaml
+network: internalnet
+
+nodes:
+  - hostname: node001
+    ip: 10.141.0.10
+    mac: "52:54:00:4B:5D:71"
+    resource_class: gpu-large
+    bmc:
+      ip: 10.141.0.1
+      username: root
+      password: "<from-vault-or-secret-manager>"
+      interface_name: rf0
+
+  - hostname: node002
+    ip: 10.141.0.11
+    mac: "52:54:00:B6:E8:33"
+    resource_class: default
+    bmc:
+      ip: 10.141.0.1
+      username: root
+      password: "<from-vault-or-secret-manager>"
+      interface_name: rf0
+```
+
+| Field | Description |
+|-------|-------------|
+| `network` | BCM network name for interfaces (default: `internalnet`) |
+| `hostname` | Node hostname in BCM |
+| `ip` | Node's own IP on the internal network |
+| `mac` | Boot NIC MAC address |
+| `resource_class` | Hardware classification (stored in BCM notes field) |
+| `bmc.ip` | BMC endpoint address |
+| `bmc.username` | BMC username |
+| `bmc.password` | BMC password |
+| `bmc.interface_name` | BMC interface name in BCM (determines BMC type, default: `rf0`) |
+
+The script is idempotent — it skips nodes that already exist in BCM.
+
+## Running the Import Playbook
+
+### Locally
+
+```bash
+ansible-playbook playbook_osac_import_bcm_agents.yml \
+  -e bcm_api_url=https://bcm-head:8081 \
+  -e bcm_cert_path=/path/to/cert.pem \
+  -e bcm_key_path=/path/to/key.pem \
+  -e hosted_cluster_default_infraenv=infraenv
+```
+
+### Via AAP
+
+The playbook is configured in AAP config-as-code with:
+- Job template: `osac-import-bcm-agents`
+- Schedule: every 10 minutes (disabled by default)
+- Instance group: `cluster-fulfillment-ig` with `bcm-certs` secret mounted
+
+To enable:
+
+1. Create the `bcm-certs` secret in the AAP namespace with `tls.crt` and `tls.key`
+2. Set `OSAC_IMPORT_BCM_AGENTS_ENABLED=true` in the `config-as-code-ig` secret
+3. Set `BCM_API_URL` in the `cluster-fulfillment-ig` secret
+4. (Lab/debug only) If BCM uses self-signed certificates, set
+   `BCM_VALIDATE_CERTS=false` in the `cluster-fulfillment-ig` secret.
+   **Not recommended for production** — configure proper CA certificates instead.
+5. (Lab/debug only) If BMCs use self-signed certificates, set
+   `BCM_DISABLE_BMC_CERT_VERIFICATION=true` in the `cluster-fulfillment-ig`
+   secret. **Not recommended for production.**
+6. Run config-as-code to apply the schedule
+
+## Configuration
+
+All configuration is in `group_vars/all/bcm.yaml`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `bcm_api_url` | (env: `BCM_API_URL`) | BCM API endpoint |
+| `bcm_cert_path` | `/var/secrets/bcm-certs/tls.crt` | Client certificate path |
+| `bcm_key_path` | `/var/secrets/bcm-certs/tls.key` | Client key path |
+| `bcm_validate_certs` | `false` | Verify BCM TLS certificates |
+| `bcm_agent_namespace` | `hardware-inventory` | Namespace for BMH/Agent CRs |
+| `bcm_infraenv_name` | `infraenv` | InfraEnv CR name |
+| `bcm_pull_secret_name` | `pull-secret` | Pull secret for InfraEnv |
+| `bcm_disable_bmc_cert_verification` | `true` | Skip BMC TLS verification |
+| `bcm_managed_by_label` | `osac.openshift.io/managed-by=import-bcm-agents` | Label selector for managed resources |
+| `bcm_agent_resource_class_label` | `osac.openshift.io/resource_class` | Agent resource class label key |
+| `bcm_agent_rack_label` | `osac.openshift.io/rack` | Agent rack label key |
+
+## How It Works
+
+The playbook runs in 5 phases:
+
+### Phase 1: Fetch inventory from BCM
+
+Queries the BCM JSON API via mTLS to get:
+- All devices (filtered to `LiteNode` type)
+- Rack information
+
+Validates that BCM returns a list (not an error dict). For each Lite Node,
+extracts hostname, boot MAC, BMC IP, BMC type, BMC credentials, resource
+class (from notes field), and rack position. Hostnames are sanitized for
+use as Kubernetes resource names.
+
+### Phase 2: Discover BMC system paths
+
+For Redfish-compatible BMC types (redfish, drac, ilo):
+1. Queries `/redfish/v1/Systems/` on each BMC endpoint
+2. Fetches the `/EthernetInterfaces` collection for each system
+3. Fetches individual EthernetInterface resources to read the `MACAddress` property
+4. Matches boot MACs to Redfish system paths
+
+For IPMI BMC types, builds a simple `ipmi://<bmc_ip>` URL with no discovery.
+
+BMC queries use `ignore_errors` so one unreachable BMC does not abort the
+entire import. Failed queries are logged as warnings with the error message.
+
+### Phase 3: Reconcile Kubernetes resources
+
+- Ensures the InfraEnv CR exists
+- Creates/updates BMC secrets with credentials from BCM
+- Creates/updates BareMetalHost CRs with BMC URLs
+- Servers with no BMC URL (unsupported type or failed discovery) are skipped
+  with a warning
+
+### Phase 4: Clean up stale resources
+
+Finds BareMetalHost CRs labeled `managed-by=import-bcm-agents` that no longer
+correspond to a BCM Lite Node, and deletes the Agent, BMH, and BMC secret.
+
+Stale detection compares against all BCM server names (not just those with
+resolved BMC URLs), so a temporary BMC outage does not cause deletion of
+a server's resources.
+
+### Phase 5: Wait for agents and apply labels
+
+Waits for each node to boot the discovery ISO and register as an Agent (up to
+15 minutes per node). Then labels agents with `resource_class` and `rack`
+metadata from BCM.
+
+## Removing Nodes
+
+Remove the Lite Node from BCM (via `cmsh` or the API). On the next playbook
+run, the stale BMH, Agent, and BMC secret will be automatically cleaned up.

--- a/group_vars/all/bcm.yaml
+++ b/group_vars/all/bcm.yaml
@@ -1,0 +1,39 @@
+---
+# NVIDIA Base Command Manager (BCM) Configuration
+# =================================================
+# These settings configure the BCM inventory integration for importing
+# bare metal servers as Assisted Installer agents.
+#
+# Sensitive values (client cert/key) should be provided via:
+#   1. Kubernetes secrets mounted into the AAP pod (recommended)
+#   2. Environment variables pointing to file paths
+#
+# NEVER commit actual certificates or keys to this file!
+
+# API Connection Settings
+# -----------------------
+bcm_api_url: "{{ lookup('env', 'BCM_API_URL') | default('', true) }}"
+bcm_cert_path: "{{ lookup('env', 'BCM_CERT_PATH') | default('/var/secrets/bcm-certs/tls.crt', true) }}"
+bcm_key_path: "{{ lookup('env', 'BCM_KEY_PATH') | default('/var/secrets/bcm-certs/tls.key', true) }}"
+bcm_validate_certs: "{{ lookup('env', 'BCM_VALIDATE_CERTS') | default('true', true) | bool }}"
+
+# Agent Namespace and InfraEnv
+# ----------------------------
+bcm_agent_namespace: "{{ default_agent_namespace }}"
+bcm_infraenv_name: "{{ hosted_cluster_default_infraenv }}"
+bcm_pull_secret_name: "pull-secret"
+
+# Resource Tracking
+# -----------------
+bcm_managed_by_label: "osac.openshift.io/managed-by=import-bcm-agents"
+bcm_managed_by_value: "import-bcm-agents"
+
+# Agent Labels
+# ------------
+bcm_agent_resource_class_label: "osac.openshift.io/resource_class"
+bcm_agent_rack_label: "osac.openshift.io/rack"
+
+# BMC Configuration
+# -----------------
+# Set to true to skip BMC TLS verification (lab/debug only)
+bcm_disable_bmc_cert_verification: "{{ lookup('env', 'BCM_DISABLE_BMC_CERT_VERIFICATION') | default('false', true) | bool }}"

--- a/hack/bcm_add_lite_nodes.py
+++ b/hack/bcm_add_lite_nodes.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Add Lite Nodes to BCM from a YAML inventory file.
+
+Usage:
+    bcm_add_lite_nodes.py --url https://bcm-head:8081 \
+        --cert /path/to/cert.pem --key /path/to/key.pem \
+        --inventory nodes.yml
+
+See samples/bcm_lite_nodes_inventory.yml for inventory file format.
+"""
+
+import argparse
+import json
+import ssl
+import sys
+import uuid
+from urllib.request import Request, urlopen
+
+import yaml
+
+
+def make_ssl_context(cert, key, *, verify=True):
+    ctx = ssl.create_default_context()
+    ctx.load_cert_chain(cert, key)
+    if not verify:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+def bcm_call(url, ssl_ctx, service, call, args=None):
+    payload = json.dumps({
+        "service": service,
+        "call": call,
+        "minify": True,
+        "args": args or [],
+    }).encode()
+
+    req = Request(url + "/json", data=payload)
+    req.add_header("Content-Type", "application/json")
+
+    resp = urlopen(req, context=ssl_ctx, timeout=30)
+    return json.loads(resp.read())
+
+
+def get_devices(url, ssl_ctx):
+    """Fetches all devices, returning (partition_uuid, hostname_to_device_map)."""
+    devices = bcm_call(url, ssl_ctx, "cmdevice", "getDevices")
+    if not isinstance(devices, list):
+        msg = devices.get("errormessage", str(devices)) if isinstance(devices, dict) else str(devices)
+        raise RuntimeError(f"BCM getDevices failed: {msg}")
+    partition = None
+    existing = {}
+    for d in devices:
+        if d.get("partition") and not partition:
+            partition = d["partition"]
+        existing[d.get("hostname", d.get("uuid", "unknown"))] = d
+    if not partition:
+        raise RuntimeError("No partition found in BCM — is the cluster initialized?")
+    return partition, existing
+
+
+def get_networks(url, ssl_ctx):
+    nets = bcm_call(url, ssl_ctx, "cmnet", "getNetworks")
+    if not isinstance(nets, list):
+        msg = nets.get("errormessage", str(nets)) if isinstance(nets, dict) else str(nets)
+        raise RuntimeError(f"BCM getNetworks failed: {msg}")
+    return {n["name"]: n["uuid"] for n in nets}
+
+
+def build_notes(node):
+    """Builds key=value notes string. Inverse of parse_notes() in bcm.py filter."""
+    parts = []
+    if node.get("resource_class"):
+        parts.append(f"resource_class={node['resource_class']}")
+    return "\n".join(parts)
+
+
+def add_lite_node(url, ssl_ctx, node, partition, network_uuid=None):
+    device = {
+        "baseType": "Device",
+        "childType": "LiteNode",
+        "hostname": node["hostname"],
+        "mac": node["mac"],
+        "uuid": str(uuid.uuid4()),
+        "partition": partition,
+    }
+
+    notes = build_notes(node)
+    if notes:
+        device["notes"] = notes
+
+    interfaces = []
+    if node.get("ip") and network_uuid:
+        interfaces.append({
+            "baseType": "NetworkInterface",
+            "childType": "NetworkPhysicalInterface",
+            "name": "BOOTIF",
+            "ip": node["ip"],
+            "network": network_uuid,
+            "uuid": str(uuid.uuid4()),
+        })
+
+    if node.get("bmc"):
+        bmc = node["bmc"]
+        if bmc.get("username") and bmc.get("password"):
+            device["bmcSettings"] = {
+                "baseType": "BMCSettings",
+                "userName": bmc["username"],
+                "password": bmc["password"],
+                "userID": bmc.get("user_id", 2),
+                "uuid": str(uuid.uuid4()),
+            }
+        if network_uuid and bmc.get("ip"):
+            interfaces.append({
+                "baseType": "NetworkInterface",
+                "childType": "NetworkBmcInterface",
+                "name": bmc.get("interface_name", "rf0"),
+                "ip": bmc["ip"],
+                "network": network_uuid,
+                "uuid": str(uuid.uuid4()),
+            })
+
+    if interfaces:
+        device["interfaces"] = interfaces
+
+    result = bcm_call(url, ssl_ctx, "cmdevice", "addLiteNode", [device])
+
+    if result.get("success") is False:
+        errors = [v.get("message", str(v)) for v in result.get("validation", [])]
+        error_msg = "; ".join(errors) if errors else result.get("errormessage", "unknown error")
+        print(f"  Failed to add {node['hostname']}: {error_msg}", file=sys.stderr)
+        return None
+
+    bmc_info = ""
+    if node.get("bmc", {}).get("ip"):
+        bmc_info = f", bmc={node['bmc']['ip']}"
+    rc_info = ""
+    if node.get("resource_class"):
+        rc_info = f", resource_class={node['resource_class']}"
+    print(f"  Added {node['hostname']} (uuid: {device['uuid']}{bmc_info}{rc_info})")
+    return device["uuid"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Add Lite Nodes to BCM")
+    parser.add_argument("--url", required=True, help="BCM API URL (e.g. https://bcm-head:8081)")
+    parser.add_argument("--cert", required=True, help="Client certificate path")
+    parser.add_argument("--key", required=True, help="Client key path")
+    parser.add_argument("--inventory", required=True, help="YAML inventory file")
+    parser.add_argument("--no-verify-certs", action="store_true",
+                        help="Disable TLS certificate verification (insecure, for lab/debug only)")
+    args = parser.parse_args()
+
+    if not args.url.startswith("https://"):
+        print("Error: --url must use https://", file=sys.stderr)
+        sys.exit(1)
+
+    ssl_ctx = make_ssl_context(args.cert, args.key, verify=not args.no_verify_certs)
+
+    with open(args.inventory) as f:
+        inventory = yaml.safe_load(f)
+
+    nodes = inventory.get("nodes", [])
+    if not nodes:
+        print("No nodes in inventory file", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loading BCM state from {args.url}...")
+    partition, existing = get_devices(args.url, ssl_ctx)
+    networks = get_networks(args.url, ssl_ctx)
+
+    print(f"Partition: {partition}")
+    print(f"Networks: {', '.join(networks.keys())}")
+    print(f"Existing devices: {', '.join(existing.keys())}")
+    print()
+
+    network_name = inventory.get("network", "internalnet")
+    network_uuid = networks.get(network_name)
+    if not network_uuid:
+        print(f"Warning: network '{network_name}' not found, BMC interfaces will be skipped",
+              file=sys.stderr)
+
+    for node in nodes:
+        hostname = node["hostname"]
+        if hostname in existing:
+            print(f"Skipping {hostname} — already exists as {existing[hostname].get('childType')}")
+            continue
+
+        print(f"Adding {hostname}...")
+        add_lite_node(args.url, ssl_ctx, node, partition, network_uuid)
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/playbook_osac_import_bcm_agents.yml
+++ b/playbook_osac_import_bcm_agents.yml
@@ -1,0 +1,442 @@
+---
+- name: Import BCM-managed bare metal servers as Assisted Installer agents
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    bcm_api_endpoint: "{{ bcm_api_url }}/json"
+
+  tasks:
+    # =========================================================================
+    # Phase 1: Fetch inventory from BCM API
+    # =========================================================================
+
+    - name: Validate BCM API URL is configured
+      ansible.builtin.fail:
+        msg: >-
+          bcm_api_url must be set and must use HTTPS. Provide it via the
+          BCM_API_URL environment variable or as an extra var.
+      when: bcm_api_url | length == 0 or not bcm_api_url.startswith('https://')
+
+    - name: Fetch devices from BCM
+      ansible.builtin.uri:
+        url: "{{ bcm_api_endpoint }}"
+        method: POST
+        body_format: json
+        body:
+          service: cmdevice
+          call: getDevices
+          minify: true
+          args: []
+        client_cert: "{{ bcm_cert_path }}"
+        client_key: "{{ bcm_key_path }}"
+        validate_certs: "{{ bcm_validate_certs }}"
+        return_content: true
+      register: _bcm_devices_response
+
+    - name: Fetch racks from BCM
+      ansible.builtin.uri:
+        url: "{{ bcm_api_endpoint }}"
+        method: POST
+        body_format: json
+        body:
+          service: cmpart
+          call: getRacksByUuids
+          minify: true
+          args:
+            - []
+        client_cert: "{{ bcm_cert_path }}"
+        client_key: "{{ bcm_key_path }}"
+        validate_certs: "{{ bcm_validate_certs }}"
+        return_content: true
+      register: _bcm_racks_response
+
+    - name: Validate BCM devices response
+      ansible.builtin.fail:
+        msg: >-
+          BCM getDevices returned an error: {{ _bcm_devices_response.json.errormessage | default('unexpected response format') }}
+      when: _bcm_devices_response.json is not iterable or _bcm_devices_response.json is mapping
+
+    - name: Validate BCM racks response
+      ansible.builtin.fail:
+        msg: >-
+          BCM getRacksByUuids returned an error: {{ _bcm_racks_response.json.errormessage | default('unexpected response format') }}
+      when: _bcm_racks_response.json is not iterable or _bcm_racks_response.json is mapping
+
+    - name: Build rack lookup by UUID
+      ansible.builtin.set_fact:
+        _bcm_racks_by_uuid: >-
+          {{
+            dict(
+              _bcm_racks_response.json |
+              map(attribute='uuid') |
+              zip(_bcm_racks_response.json | map(attribute='name'))
+            )
+          }}
+
+    - name: Filter lite nodes from BCM devices
+      ansible.builtin.set_fact:
+        _bcm_lite_nodes: >-
+          {{
+            _bcm_devices_response.json |
+            selectattr('childType', 'equalto', 'LiteNode') |
+            list
+          }}
+
+    - name: Display discovered lite nodes
+      ansible.builtin.debug:
+        msg: "Found {{ _bcm_lite_nodes | length }} lite nodes in BCM"
+
+    - name: Build server list from BCM devices
+      ansible.builtin.set_fact:
+        _bcm_servers: >-
+          {{
+            _bcm_lite_nodes | map('osac.service.bcm_device_to_server',
+              _bcm_racks_by_uuid,
+              bcm_disable_bmc_cert_verification) |
+            list
+          }}
+
+    - name: Display servers to import
+      ansible.builtin.debug:
+        msg: "Servers: {{ _bcm_servers | map(attribute='name') | list }}"
+
+    # =========================================================================
+    # Phase 2: Discover BMC system paths
+    # =========================================================================
+
+    # --- Redfish discovery (for Redfish-compatible BMC types: redfish, drac, ilo) ---
+
+    - name: Filter Redfish-compatible servers
+      ansible.builtin.set_fact:
+        _bcm_redfish_servers: >-
+          {{ _bcm_servers | selectattr('bmc_type', 'in', [] | osac.service.bcm_redfish_compatible_types()) | list }}
+
+    - name: Query Redfish systems for each server
+      ansible.builtin.uri:
+        url: "https://{{ server.bmc_ip }}/redfish/v1/Systems/"
+        method: GET
+        user: "{{ server.bmc_username }}"
+        password: "{{ server.bmc_password }}"
+        force_basic_auth: true
+        validate_certs: "{{ not server.disable_bmc_cert_verification }}"
+        return_content: true
+      register: _redfish_systems
+      loop: "{{ _bcm_redfish_servers }}"
+      loop_control:
+        loop_var: server
+        label: "{{ server.name }}"
+      when: server.bmc_ip | length > 0
+      ignore_errors: true
+      no_log: true
+
+    - name: Warn about failed Redfish system queries
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Redfish query failed for {{ item.server.name }} ({{ item.server.bmc_ip }}):
+          {{ item.msg | default('unknown error') }}
+      loop: "{{ _redfish_systems.results | default([]) }}"
+      loop_control:
+        label: "{{ item.server.name | default('unknown') }}"
+      when:
+        - item is not skipped
+        - item.failed | default(false)
+
+    - name: Build flat list of Redfish systems to query
+      ansible.builtin.set_fact:
+        _redfish_system_queries: >-
+          {{ _bcm_redfish_servers | osac.service.bcm_build_redfish_queries(_redfish_systems.results | default([])) }}
+
+    - name: Fetch EthernetInterfaces collection for each Redfish system
+      ansible.builtin.uri:
+        url: "https://{{ query.bmc_ip }}{{ query.system_path }}/EthernetInterfaces"
+        method: GET
+        user: "{{ query.bmc_username }}"
+        password: "{{ query.bmc_password }}"
+        force_basic_auth: true
+        validate_certs: "{{ not query.disable_bmc_cert_verification }}"
+        return_content: true
+      register: _redfish_eth_collections
+      loop: "{{ _redfish_system_queries }}"
+      loop_control:
+        loop_var: query
+        label: "{{ query.system_path }}"
+      ignore_errors: true
+      no_log: true
+
+    - name: Build flat list of individual EthernetInterface URLs
+      ansible.builtin.set_fact:
+        _redfish_iface_queries: >-
+          {{ _redfish_eth_collections.results | default([]) | osac.service.bcm_build_eth_iface_queries() }}
+
+    - name: Fetch individual EthernetInterface details
+      ansible.builtin.uri:
+        url: "https://{{ query.bmc_ip }}{{ query.iface_path }}"
+        method: GET
+        user: "{{ query.bmc_username }}"
+        password: "{{ query.bmc_password }}"
+        force_basic_auth: true
+        validate_certs: "{{ not query.disable_bmc_cert_verification }}"
+        return_content: true
+      register: _redfish_ifaces
+      loop: "{{ _redfish_iface_queries }}"
+      loop_control:
+        loop_var: query
+        label: "{{ query.iface_path }}"
+      ignore_errors: true
+      no_log: true
+
+    - name: Build MAC to Redfish system path mapping
+      ansible.builtin.set_fact:
+        _mac_to_redfish: >-
+          {{ _redfish_ifaces.results | default([]) | osac.service.bcm_build_mac_to_redfish() }}
+
+    - name: Display MAC to Redfish mapping
+      ansible.builtin.debug:
+        var: _mac_to_redfish
+
+    # --- Build BMC URLs for all servers (dispatches by bmc_type) ---
+
+    - name: Build servers with BMC URLs
+      ansible.builtin.set_fact:
+        _bcm_all_servers_with_bmc: >-
+          {{
+            _bcm_servers |
+            osac.service.bcm_attach_bmc_urls(_mac_to_redfish) |
+            list
+          }}
+
+    - name: Set servers with valid BMC URLs
+      ansible.builtin.set_fact:
+        _bcm_servers_with_bmc: >-
+          {{ _bcm_all_servers_with_bmc | selectattr('bmc_url', 'ne', '') | list }}
+
+    - name: Warn about servers with no BMC URL
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: {{ item.name }} (bmc_type={{ item.bmc_type }}) has no BMC URL and will be skipped
+      loop: >-
+        {{ _bcm_all_servers_with_bmc | selectattr('bmc_url', 'equalto', '') | list }}
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Display servers with BMC URLs
+      ansible.builtin.debug:
+        msg: >-
+          {{ _bcm_servers_with_bmc | map(attribute='name') |
+             zip(_bcm_servers_with_bmc | map(attribute='bmc_type')) |
+             zip(_bcm_servers_with_bmc | map(attribute='bmc_url')) | list }}
+
+    # =========================================================================
+    # Phase 3: Reconcile Kubernetes resources
+    # =========================================================================
+
+    - name: Ensure InfraEnv exists
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: agent-install.openshift.io/v1beta1
+          kind: InfraEnv
+          metadata:
+            name: "{{ bcm_infraenv_name }}"
+            namespace: "{{ bcm_agent_namespace }}"
+          spec:
+            pullSecretRef:
+              name: "{{ bcm_pull_secret_name }}"
+
+    - name: Create or update BMC secrets for each server
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ server.name }}-bmc-secret"
+            namespace: "{{ bcm_agent_namespace }}"
+            labels:
+              osac.openshift.io/managed-by: "{{ bcm_managed_by_value }}"
+          type: Opaque
+          stringData:
+            username: "{{ server.bmc_username }}"
+            password: "{{ server.bmc_password }}"
+      loop: "{{ _bcm_servers_with_bmc }}"
+      loop_control:
+        loop_var: server
+        label: "{{ server.name }}"
+      no_log: true
+
+    - name: Get existing managed BareMetalHost CRs
+      kubernetes.core.k8s_info:
+        api_version: metal3.io/v1alpha1
+        kind: BareMetalHost
+        namespace: "{{ bcm_agent_namespace }}"
+        label_selectors:
+          - "{{ bcm_managed_by_label }}"
+      register: _existing_bmh
+
+    - name: Extract existing BMH names
+      ansible.builtin.set_fact:
+        _existing_bmh_names: >-
+          {{ _existing_bmh.resources | map(attribute='metadata.name') | list }}
+
+    - name: Display existing managed BMHs
+      ansible.builtin.debug:
+        var: _existing_bmh_names
+
+    - name: Reconcile BareMetalHost for each server
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: metal3.io/v1alpha1
+          kind: BareMetalHost
+          metadata:
+            name: "{{ server.name }}"
+            namespace: "{{ bcm_agent_namespace }}"
+            labels:
+              osac.openshift.io/managed-by: "{{ bcm_managed_by_value }}"
+              infraenvs.agent-install.openshift.io: "{{ bcm_infraenv_name }}"
+            annotations:
+              inspect.metal3.io: disabled
+              bmac.agent-install.openshift.io/hostname: "{{ server.name }}"
+          spec:
+            automatedCleaningMode: disabled
+            bmc:
+              address: "{{ server.bmc_url }}"
+              credentialsName: "{{ server.name }}-bmc-secret"
+              disableCertificateVerification: "{{ server.disable_bmc_cert_verification | bool }}"
+            bootMACAddress: "{{ server.boot_mac }}"
+            online: true
+      loop: "{{ _bcm_servers_with_bmc }}"
+      loop_control:
+        loop_var: server
+        label: "{{ server.name }}"
+
+    # =========================================================================
+    # Phase 4: Clean up stale resources
+    # =========================================================================
+
+    - name: Compute stale BMH names
+      ansible.builtin.set_fact:
+        _stale_bmh_names: >-
+          {{
+            _existing_bmh_names |
+            difference(_bcm_servers | map(attribute='name') | list)
+          }}
+
+    - name: Display stale BMHs to delete
+      ansible.builtin.debug:
+        var: _stale_bmh_names
+
+    - name: Get agents linked to stale BMHs
+      kubernetes.core.k8s_info:
+        api_version: agent-install.openshift.io/v1beta1
+        kind: Agent
+        namespace: "{{ bcm_agent_namespace }}"
+        label_selectors:
+          - "agent-install.openshift.io/bmh={{ bmh_name }}"
+      register: _stale_agents
+      loop: "{{ _stale_bmh_names }}"
+      loop_control:
+        loop_var: bmh_name
+        label: "{{ bmh_name }}"
+
+    - name: Delete stale Agent CRs
+      kubernetes.core.k8s:
+        state: absent
+        api_version: agent-install.openshift.io/v1beta1
+        kind: Agent
+        namespace: "{{ bcm_agent_namespace }}"
+        name: "{{ agent.metadata.name }}"
+      loop: >-
+        {{
+          _stale_agents.results |
+          map(attribute='resources') |
+          flatten
+        }}
+      loop_control:
+        loop_var: agent
+        label: "{{ agent.metadata.name }}"
+
+    - name: Delete stale BareMetalHost CRs
+      kubernetes.core.k8s:
+        state: absent
+        api_version: metal3.io/v1alpha1
+        kind: BareMetalHost
+        namespace: "{{ bcm_agent_namespace }}"
+        name: "{{ bmh_name }}"
+      loop: "{{ _stale_bmh_names }}"
+      loop_control:
+        loop_var: bmh_name
+        label: "{{ bmh_name }}"
+
+    - name: Delete stale BMC secrets
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        namespace: "{{ bcm_agent_namespace }}"
+        name: "{{ bmh_name }}-bmc-secret"
+      loop: "{{ _stale_bmh_names }}"
+      loop_control:
+        loop_var: bmh_name
+        label: "{{ bmh_name }}"
+
+    # =========================================================================
+    # Phase 5: Wait for agent registration and label agents
+    # =========================================================================
+
+    - name: Wait for each server to register as an Agent
+      kubernetes.core.k8s_info:
+        api_version: agent-install.openshift.io/v1beta1
+        kind: Agent
+        namespace: "{{ bcm_agent_namespace }}"
+      register: _current_agents
+      until: >-
+        [server.boot_mac | lower] |
+        osac.service.mac_to_agent_name(_current_agents.resources) is not none
+      retries: 90
+      delay: 10
+      loop: "{{ _bcm_servers_with_bmc }}"
+      loop_control:
+        loop_var: server
+        label: "{{ server.name }}"
+
+    - name: Get final agent list
+      kubernetes.core.k8s_info:
+        api_version: agent-install.openshift.io/v1beta1
+        kind: Agent
+        namespace: "{{ bcm_agent_namespace }}"
+      register: _final_agents
+
+    - name: Configure agent metadata
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: agent-install.openshift.io/v1beta1
+          kind: Agent
+          metadata:
+            name: >-
+              {{
+                [server.boot_mac | lower] |
+                osac.service.mac_to_agent_name(_final_agents.resources)
+              }}
+            namespace: "{{ bcm_agent_namespace }}"
+            labels: >-
+              {{
+                {
+                  bcm_agent_resource_class_label: server.resource_class,
+                  bcm_agent_rack_label: server.rack
+                }
+              }}
+            annotations:
+              bmac.agent-install.openshift.io/hostname: "{{ server.name }}"
+          spec:
+            approved: true
+            hostname: "{{ server.name | lower }}"
+      loop: "{{ _bcm_servers_with_bmc }}"
+      loop_control:
+        loop_var: server
+        label: "{{ server.name }}"
+      failed_when: >-
+        [server.boot_mac | lower] |
+        osac.service.mac_to_agent_name(_final_agents.resources) is none

--- a/samples/bcm_lite_nodes_inventory.yml
+++ b/samples/bcm_lite_nodes_inventory.yml
@@ -1,0 +1,43 @@
+---
+# Sample inventory for bcm_add_lite_nodes.py
+#
+# Usage:
+#   python3 scripts/bcm_add_lite_nodes.py \
+#     --url https://bcm-head:8081 \
+#     --cert /path/to/cert.pem \
+#     --key /path/to/key.pem \
+#     --inventory samples/bcm_lite_nodes_inventory.yml
+
+# BCM network name for BMC interfaces (default: internalnet)
+network: internalnet
+
+nodes:
+  - hostname: node001
+    ip: 10.141.0.10
+    mac: "52:54:00:4B:5D:71"
+    resource_class: gpu-large
+    bmc:
+      ip: 10.141.0.1
+      username: root
+      password: "<bmc-password>"
+      interface_name: rf0
+
+  - hostname: node002
+    ip: 10.141.0.11
+    mac: "52:54:00:B6:E8:33"
+    resource_class: default
+    bmc:
+      ip: 10.141.0.1
+      username: root
+      password: "<bmc-password>"
+      interface_name: rf0
+
+  - hostname: node003
+    ip: 10.141.0.12
+    mac: "52:54:00:03:76:56"
+    resource_class: gpu-large
+    bmc:
+      ip: 10.141.0.1
+      username: root
+      password: "<bmc-password>"
+      interface_name: rf0

--- a/samples/import_bcm_agents_extra_vars.yml
+++ b/samples/import_bcm_agents_extra_vars.yml
@@ -1,0 +1,19 @@
+---
+# Sample extra vars for local testing of BCM agent import.
+#
+# Usage:
+#   ansible-playbook playbook_osac_import_bcm_agents.yml \
+#     -e @samples/import_bcm_agents_extra_vars.yml
+
+bcm_api_url: "https://bcm-head:8081"
+bcm_cert_path: "/path/to/client-cert.pem"
+bcm_key_path: "/path/to/client-key.pem"
+
+# Override default namespaces for local testing
+bcm_agent_namespace: "hardware-inventory"
+bcm_infraenv_name: "infraenv"
+bcm_pull_secret_name: "pull-secret"
+
+# Uncomment for lab/debug environments with self-signed certificates:
+# bcm_validate_certs: false
+# bcm_disable_bmc_cert_verification: true


### PR DESCRIPTION
## Summary

- Add Ansible playbook that queries NVIDIA Base Command Manager (BCM 11) JSON API to discover Lite Nodes, resolves Redfish/iDRAC/iLO/IPMI BMC system IDs by MAC address matching, creates BareMetalHost CRs for Metal3/Ironic provisioning, and labels registered agents with resource class metadata from BCM device notes
- Add Python filter plugins for BCM device normalization, BMC type classification, Redfish system discovery, and K8s name/label sanitization
- Add Python script (`bcm_add_lite_nodes.py`) for registering bare metal machines as BCM Lite Nodes with BMC interfaces and resource class annotations via the BCM JSON API
- Add AAP config-as-code for job template, 10-minute periodic schedule, and `bcm-certs` secret volume mount in `cluster-fulfillment-ig`

## Supported BMC Types

| BCM Interface | Protocol | Discovery |
|---------------|----------|-----------|
| `rf0` (Redfish) | `redfish-virtualmedia+https://` | MAC-based system discovery |
| `drac0` (iDRAC) | `idrac-virtualmedia+https://` | MAC-based system discovery |
| `ilo0` (iLO) | `ilo5-virtualmedia+https://` | MAC-based system discovery |
| `ipmi0` (IPMI) | `ipmi://` | Static URL |

## Device Model

Nodes are registered in BCM as **Lite Nodes** (not Physical Nodes) — BCM provides inventory and monitoring, OpenShift/Metal3 handles OS provisioning via RHCOS. Resource class is stored in the BCM device `notes` field (`resource_class=<value>`).

## Test plan

- [x] Playbook tested end-to-end in dev environment with BCM 11.0 head node and 3 compute VMs
- [x] BCM API fetch (getDevices, getRacksByUuids) with mTLS authentication
- [x] Redfish MAC-based system discovery via individual EthernetInterface MACAddress property
- [x] BareMetalHost CR creation and reconciliation
- [x] Agent registration wait and metadata labeling
- [x] Stale resource cleanup (Agent, BMH, Secret)
- [x] Idempotency verified (repeated runs produce changed=0)
- [x] Error isolation (single BMC failure doesn't abort entire import)
- [x] BCM response validation (type guards on API responses)
- [x] K8s name/label sanitization for non-DNS-safe hostnames
- [ ] Test with real iDRAC/iLO hardware (verified URL format against Dell iDRAC Redfish endpoint)
- [ ] Test IPMI BMC type

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added NVIDIA Base Command Manager (BCM) integration to automatically import managed bare metal systems into discovery infrastructure
  * Introduced periodic playbook for BCM agent discovery, BMC credential management, and Metal3/Ironic resource creation
  * Added CLI tool to provision LiteNode devices to BCM inventory with resource class labeling

* **Documentation**
  * Added comprehensive BCM inventory integration guide covering workflows, configuration, and setup procedures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-aap/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->