### PR TITLE
OSAC-1063: fix server-side apply field manager conflict on AAP CR labels

### DIFF
--- a/charts/aap/templates/aap.yaml
+++ b/charts/aap/templates/aap.yaml
@@ -5,7 +5,8 @@ metadata:
   name: {{ include "osac-aap.instanceName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "osac-aap.labels" . | nindent 4 }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   controller:
     disabled: {{ .Values.aap.instance.controller.disabled }}


### PR DESCRIPTION
## Summary

- The AAP operator CRD defines OpenAPI defaults for `app.kubernetes.io/name` and `app.kubernetes.io/managed-by` labels, owned by the `"OpenAPI-Generator"` field manager. When Helm uses server-side apply with the full label set from `osac-aap.labels`, Kubernetes rejects the update because two different field managers claim ownership of the same fields.
- Replace the `osac-aap.labels` include in `aap.yaml` with inline labels that exclude the two conflicting labels, keeping only `helm.sh/chart` and `app.kubernetes.io/instance`. Other templates (bootstrap-job.yaml, osac-sa.yaml, template-publisher.yaml) continue using the shared label helper since they are standard Kubernetes resources without CRD-level OpenAPI defaults.

## Test plan

- [x] `helm lint charts/aap/` passes (0 charts failed)
- [x] `helm template test charts/aap/` renders correctly -- AAP CR has only non-conflicting labels while all other resources retain the full label set

Fixes: https://issues.redhat.com/browse/OSAC-1063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes deployment metadata for Ansible Automation Platform with additional resource labels to improve tracking and identification in cluster environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osac-project/osac-aap/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->