### PR TITLE
fix: use osac.openshift.io for all annotations

### DIFF
--- a/collections/ansible_collections/nico/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/nico/steps/roles/external_access/tasks/create.yaml
@@ -150,11 +150,11 @@
 
 - name: Extract BGP ASN from Tenant annotation
   ansible.builtin.set_fact:
-    nico_local_asn: "{{ tenant_cr_result.resources[0].metadata.annotations['osac.io/bgp-asn'] }}"
+    nico_local_asn: "{{ tenant_cr_result.resources[0].metadata.annotations['osac.openshift.io/bgp-asn'] }}"
   when:
     - tenant_cr_result.resources | length > 0
     - tenant_cr_result.resources[0].metadata.annotations is defined
-    - "'osac.io/bgp-asn' in tenant_cr_result.resources[0].metadata.annotations"
+    - "'osac.openshift.io/bgp-asn' in tenant_cr_result.resources[0].metadata.annotations"
 
 - name: Validate BGP ASN was found
   ansible.builtin.assert:
@@ -164,7 +164,7 @@
     fail_msg: >
       BGP ASN not found on Tenant CR '{{ tenant_name }}'
       in namespace '{{ lookup('env', 'POD_NAMESPACE') }}'.
-      Set the osac.io/bgp-asn annotation on the Tenant resource.
+      Set the osac.openshift.io/bgp-asn annotation on the Tenant resource.
 
 - name: Compute total expected worker count
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/service/roles/nmstate_config/tasks/apply.yaml
+++ b/collections/ansible_collections/osac/service/roles/nmstate_config/tasks/apply.yaml
@@ -21,9 +21,9 @@
     _nmstate_apply_offset_map: >-
       {%- set result = {} -%}
       {%- for cr in _nmstate_apply_existing_crs.resources -%}
-        {%- if cr.metadata.annotations is defined and 'osac.io/ip-offset' in cr.metadata.annotations -%}
+        {%- if cr.metadata.annotations is defined and 'osac.openshift.io/ip-offset' in cr.metadata.annotations -%}
           {%- set agent_name = cr.metadata.name | regex_replace('^' ~ nmstate_config_cluster_name ~ '-', '') -%}
-          {%- set _ = result.update({agent_name: cr.metadata.annotations['osac.io/ip-offset'] | int}) -%}
+          {%- set _ = result.update({agent_name: cr.metadata.annotations['osac.openshift.io/ip-offset'] | int}) -%}
         {%- endif -%}
       {%- endfor -%}
       {{ result }}

--- a/collections/ansible_collections/osac/service/roles/nmstate_config/tasks/create.yaml
+++ b/collections/ansible_collections/osac/service/roles/nmstate_config/tasks/create.yaml
@@ -18,9 +18,9 @@
     _nmstate_offset_map: >-
       {%- set result = {} -%}
       {%- for cr in _nmstate_existing_crs.resources -%}
-        {%- if cr.metadata.annotations is defined and 'osac.io/ip-offset' in cr.metadata.annotations -%}
+        {%- if cr.metadata.annotations is defined and 'osac.openshift.io/ip-offset' in cr.metadata.annotations -%}
           {%- set agent_name = cr.metadata.name | regex_replace('^' ~ nmstate_config_cluster_name ~ '-', '') -%}
-          {%- set _ = result.update({agent_name: cr.metadata.annotations['osac.io/ip-offset'] | int}) -%}
+          {%- set _ = result.update({agent_name: cr.metadata.annotations['osac.openshift.io/ip-offset'] | int}) -%}
         {%- endif -%}
       {%- endfor -%}
       {{ result }}

--- a/collections/ansible_collections/osac/service/roles/nmstate_config/tasks/create_single.yaml
+++ b/collections/ansible_collections/osac/service/roles/nmstate_config/tasks/create_single.yaml
@@ -41,7 +41,7 @@
         namespace: "{{ nmstate_config_namespace }}"
         labels: "{{ nmstate_config_labels | combine({cluster_order_label: nmstate_config_cluster_name}) }}"
         annotations:
-          osac.io/ip-offset: "{{ _nmstate_assignment.offset | string }}"
+          osac.openshift.io/ip-offset: "{{ _nmstate_assignment.offset | string }}"
       spec:
         config: "{{ _nmstate_rendered_config | from_yaml }}"
         interfaces: "{{ _nmstate_agent_interfaces }}"

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/README.md
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/README.md
@@ -42,7 +42,7 @@ SecurityGroups translate to Kubernetes NetworkPolicy resources that enforce netw
 **Key behaviors:**
 - One NetworkPolicy per SecurityGroup (named `sg-{security-group-name}`)
 - NetworkPolicies are deployed to all Subnet namespaces associated with the SecurityGroup's parent VirtualNetwork
-- Pod selection uses label `security-group.osac.io/{sg-name}: ""`
+- Pod selection uses label `security-group.osac.openshift.io/{sg-name}: ""`
 - Multiple SecurityGroups are additive: pods can have multiple SG labels, and traffic is allowed if ANY NetworkPolicy allows it
 - Empty ingress/egress rule arrays result in deny-all for that direction
 
@@ -64,8 +64,8 @@ Pods can have multiple SecurityGroup associations:
 ```yaml
 metadata:
   labels:
-    security-group.osac.io/web-sg: ""
-    security-group.osac.io/db-sg: ""
+    security-group.osac.openshift.io/web-sg: ""
+    security-group.osac.openshift.io/db-sg: ""
 ```
 Each SecurityGroup creates its own NetworkPolicy, and Kubernetes applies them additively (traffic allowed if ANY policy allows).
 

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/defaults/main.yaml
@@ -1,11 +1,11 @@
 ---
 # Default labels for CUDN resources
 default_subnet_labels:
-  osac.io/managed-by: osac-fulfillment
+  osac.openshift.io/managed-by: osac-fulfillment
 
 # SecurityGroup NetworkPolicy defaults
 default_security_group_labels:
-  osac.io/managed-by: osac-fulfillment
+  osac.openshift.io/managed-by: osac-fulfillment
 
 # Layer2 defaults
 default_layer2_role: Primary

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/tasks/create_security_group.yaml
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/tasks/create_security_group.yaml
@@ -96,13 +96,13 @@
             name: "sg-{{ sg_name }}"
             namespace: "{{ item }}"
             labels:
-              osac.io/managed-by: osac-fulfillment
-              osac.io/security-group: "{{ sg_name }}"
-              osac.io/virtual-network: "{{ sg_virtual_network }}"
+              osac.openshift.io/managed-by: osac-fulfillment
+              osac.openshift.io/security-group: "{{ sg_name }}"
+              osac.openshift.io/virtual-network: "{{ sg_virtual_network }}"
           spec:
             podSelector:
               matchLabels:
-                osac.io/security-group: "{{ sg_name }}"
+                osac.openshift.io/security-group: "{{ sg_name }}"
             policyTypes: "{{ policy_types }}"
             ingress: "{{ ingress_policy_rules }}"
             egress: "{{ egress_policy_rules }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_public_ip.yaml
@@ -130,7 +130,7 @@
             namespace: "{{ attach_vm_namespace }}"
             labels:
               osac.openshift.io/publicip: "{{ public_ip_name }}"
-              osac.io/managed-by: osac-fulfillment
+              osac.openshift.io/managed-by: osac-fulfillment
             annotations:
               metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
               metallb.universe.tf/loadBalancerIPs: "{{ attach_ip_address }}"
@@ -170,7 +170,7 @@
             namespace: metallb-system
             labels:
               osac.openshift.io/publicip: "{{ public_ip_name }}"
-              osac.io/managed-by: osac-fulfillment
+              osac.openshift.io/managed-by: osac-fulfillment
             annotations:
               metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
               metallb.universe.tf/loadBalancerIPs: "{{ attach_ip_address }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip.yaml
@@ -41,7 +41,7 @@
           metallb.universe.tf/address-pool: "{{ ip_pool_name }}"
         labels:
           osac.openshift.io/publicip: "{{ ip_name }}"
-          osac.io/managed-by: osac-fulfillment
+          osac.openshift.io/managed-by: osac-fulfillment
       spec:
         type: LoadBalancer
         selector: {}

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_public_ip_pool.yaml
@@ -31,7 +31,7 @@
         namespace: metallb-system
         labels:
           osac.openshift.io/publicippool: "{{ pool_name }}"
-          osac.io/managed-by: osac-fulfillment
+          osac.openshift.io/managed-by: osac-fulfillment
       spec:
         autoAssign: false
         avoidBuggyIPs: true  # skip .0 and .255
@@ -62,7 +62,7 @@
         namespace: metallb-system
         labels:
           osac.openshift.io/publicippool: "{{ pool_name }}"
-          osac.io/managed-by: osac-fulfillment
+          osac.openshift.io/managed-by: osac-fulfillment
       spec:
         ipAddressPools:
           - "{{ pool_name }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_public_ip.yaml
@@ -134,7 +134,7 @@
             namespace: metallb-system
             labels:
               osac.openshift.io/publicip: "{{ public_ip_name }}"
-              osac.io/managed-by: osac-fulfillment
+              osac.openshift.io/managed-by: osac-fulfillment
             annotations:
               metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
               metallb.universe.tf/loadBalancerIPs: "{{ detach_ip_address }}"
@@ -172,7 +172,7 @@
             namespace: "{{ detach_vm_namespace }}"
             labels:
               osac.openshift.io/publicip: "{{ public_ip_name }}"
-              osac.io/managed-by: osac-fulfillment
+              osac.openshift.io/managed-by: osac-fulfillment
             annotations:
               metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
               metallb.universe.tf/loadBalancerIPs: "{{ detach_ip_address }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tests/test.yml
@@ -146,7 +146,7 @@
           ansible.builtin.assert:
             that:
               - ipaddresspool_result.resources[0].metadata.labels['osac.openshift.io/publicippool'] == test_pool_name
-              - ipaddresspool_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
+              - ipaddresspool_result.resources[0].metadata.labels['osac.openshift.io/managed-by'] == 'osac-fulfillment'
             fail_msg: "IPAddressPool labels incorrect"
             success_msg: "IPAddressPool labels correct"
 
@@ -170,7 +170,7 @@
           ansible.builtin.assert:
             that:
               - l2advertisement_result.resources[0].metadata.labels['osac.openshift.io/publicippool'] == test_pool_name
-              - l2advertisement_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
+              - l2advertisement_result.resources[0].metadata.labels['osac.openshift.io/managed-by'] == 'osac-fulfillment'
             fail_msg: "L2Advertisement labels incorrect"
             success_msg: "L2Advertisement labels correct"
 
@@ -272,7 +272,7 @@
           ansible.builtin.assert:
             that:
               - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_name
-              - lb_svc_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
+              - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/managed-by'] == 'osac-fulfillment'
             fail_msg: "LoadBalancer Service labels incorrect"
             success_msg: "LoadBalancer Service labels correct"
 
@@ -613,7 +613,7 @@
                   metallb.universe.tf/address-pool: "{{ test_pool_name }}"
                 labels:
                   osac.openshift.io/publicip: "{{ test_ip_name }}"
-                  osac.io/managed-by: osac-fulfillment
+                  osac.openshift.io/managed-by: osac-fulfillment
               spec:
                 type: LoadBalancer
                 selector: {}
@@ -711,7 +711,7 @@
           ansible.builtin.assert:
             that:
               - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_name
-              - lb_svc_result.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
+              - lb_svc_result.resources[0].metadata.labels['osac.openshift.io/managed-by'] == 'osac-fulfillment'
             fail_msg: "LB Service labels incorrect after attach"
             success_msg: "LB Service labels correct"
 
@@ -902,7 +902,7 @@
           ansible.builtin.assert:
             that:
               - parking_svc_after_detach.resources[0].metadata.labels['osac.openshift.io/publicip'] == test_ip_name
-              - parking_svc_after_detach.resources[0].metadata.labels['osac.io/managed-by'] == 'osac-fulfillment'
+              - parking_svc_after_detach.resources[0].metadata.labels['osac.openshift.io/managed-by'] == 'osac-fulfillment'
             fail_msg: "Re-created parking Service labels incorrect after detach"
             success_msg: "Parking Service labels correct"
 
@@ -992,7 +992,7 @@
                   metallb.universe.tf/loadBalancerIPs: "192.168.100.10"
                 labels:
                   osac.openshift.io/publicip: "{{ test_ip_name }}"
-                  osac.io/managed-by: osac-fulfillment
+                  osac.openshift.io/managed-by: osac-fulfillment
               spec:
                 type: LoadBalancer
                 selector:

--- a/docs/nico-integration.md
+++ b/docs/nico-integration.md
@@ -83,7 +83,7 @@ ClusterOrder resources provide these in `spec.templateParameters`. The same temp
 Before submitting a ClusterOrder, ensure:
 
 1. `NETWORK_STEPS_COLLECTION=nico.steps` is set in the AAP environment
-2. A **Tenant CR** exists with the `osac.io/bgp-asn` annotation set to the local BGP ASN
+2. A **Tenant CR** exists with the `osac.openshift.io/bgp-asn` annotation set to the local BGP ASN
 3. The ClusterOrder has the `osac.openshift.io/tenant` annotation pointing to the Tenant name
 4. An **InfraEnv** resource named `hardware-inventory` exists in the `hardware-inventory` namespace
 


### PR DESCRIPTION
## Summary

Standardizes all OSAC annotations to use the `osac.openshift.io` domain prefix to align with:
- CRD API group: `osac.openshift.io`
- Existing tenant annotation: `osac.openshift.io/tenant`

## Changes

Changed all annotation references from `osac.io/*` to `osac.openshift.io/*`:

### Annotations Updated
- `osac.io/ip-offset` → `osac.openshift.io/ip-offset`
- `osac.io/managed-by` → `osac.openshift.io/managed-by`
- `osac.io/security-group` → `osac.openshift.io/security-group`
- `osac.io/virtual-network` → `osac.openshift.io/virtual-network`
- `osac.io/bgp-asn` → `osac.openshift.io/bgp-asn`
- `security-group.osac.io/*` → `security-group.osac.openshift.io/*`

### Affected Roles
- **nmstate_config** (osac.service collection) - IP offset tracking
- **cudn_net** (osac.templates collection) - Security group NetworkPolicy management
- **metallb_l2** (osac.templates collection) - Public IP provisioning
- **external_access** (nico.steps collection) - BGP ASN annotation
- Documentation files

## Related PRs

- fulfillment-service: https://github.com/osac-project/fulfillment-service/pull/620
- osac-workspace: https://github.com/osac-project/osac-workspace/pull/35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated annotation and label keys from `osac.io/*` format to `osac.openshift.io/*` format across BGP ASN configuration, IP offset configuration, and resource labeling.
  * Updated internal test assertions to reflect new key naming.

* **Documentation**
  * Updated integration documentation to reflect new annotation key format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->