### PR TITLE
OSAC-1079: Bump chart version from 0.0.0 to 0.1.0

### DIFF
--- a/charts/aap/Chart.yaml
+++ b/charts/aap/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: osac-aap
 description: OSAC AAP integration - bootstrap and configuration
 type: application
-version: 0.0.0
+version: 0.1.0


### PR DESCRIPTION
## Summary
- Bump `osac-aap` chart version from `0.0.0` to `0.1.0`

Part of Helm chart production readiness ([OSAC-1072](https://redhat.atlassian.net/browse/OSAC-1072)). Replaces placeholder version with real semver as the first step toward OCI publication.

## Test plan
- [ ] `helm lint charts/aap`
- [ ] `helm template` renders correctly with new version