### PR TITLE
OSAC-244: Make VM infrastructure independent from cluster infra

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/README.md
+++ b/collections/ansible_collections/osac/config_as_code/README.md
@@ -67,6 +67,21 @@ the namespace where AAP is deployed.
 The cluster fulfillment needs to access the Kube API of the cluster it runs on,
 so we expect a service account `osac-sa` to exists with enough rights.
 
+### Compute instance operations environment variables
+
+Compute instance (VMaaS) job templates run in the
+`compute-instance-operations-ig` instance group. Credentials and configuration
+for VM operations are injected from a dedicated secret:
+
+- `OS_*`: OpenStack application credentials (when required by the deployment)
+
+These variables must be defined in a secret named
+`compute-instance-operations-ig` in the namespace where AAP is deployed.
+
+The compute instance instance group also optionally mounts `storage-operations-ig`
+for JIT tenant storage during VM provisioning, and may mount a remote cluster
+kubeconfig when `REMOTE_CLUSTER_KUBECONFIG_SECRET_NAME` is configured.
+
 ## Deploy a local AAP installation using CRC
 
 ### Download and deploy CRC

--- a/collections/ansible_collections/osac/config_as_code/README.md
+++ b/collections/ansible_collections/osac/config_as_code/README.md
@@ -70,13 +70,15 @@ so we expect a service account `osac-sa` to exists with enough rights.
 ### Compute instance operations environment variables
 
 Compute instance (VMaaS) job templates run in the
-`compute-instance-operations-ig` instance group. Credentials and configuration
-for VM operations are injected from a dedicated secret:
+`compute-instance-operations-ig` instance group. The default KubeVirt path
+(`ocp_virt_vm`) uses the in-cluster `osac-sa` service account and does not
+require credentials in a dedicated secret.
 
-- `OS_*`: OpenStack application credentials (when required by the deployment)
-
-These variables must be defined in a secret named
-`compute-instance-operations-ig` in the namespace where AAP is deployed.
+The pod spec optionally mounts a secret named
+`compute-instance-operations-ig`. Create it only when a deployment-specific
+compute template needs extra environment variables. OpenStack credentials are
+not required for VMaaS; Neutron networking uses `network-fulfillment-ig`, and
+cluster/ESI floating-IP workflows use `cluster-fulfillment-ig`.
 
 The compute instance instance group also optionally mounts `storage-operations-ig`
 for JIT tenant storage during VM provisioning, and may mount a remote cluster

--- a/collections/ansible_collections/osac/config_as_code/roles/aap/templates/compute-instance-operations-ig.j2
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/templates/compute-instance-operations-ig.j2
@@ -36,6 +36,7 @@ spec:
       envFrom:
         - secretRef:
             name: compute-instance-operations-ig
+            optional: true
         - secretRef:
             name: storage-operations-ig
             optional: true

--- a/collections/ansible_collections/osac/config_as_code/roles/aap/templates/compute-instance-operations-ig.j2
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/templates/compute-instance-operations-ig.j2
@@ -35,7 +35,7 @@ spec:
 {% endif %}
       envFrom:
         - secretRef:
-            name: cluster-fulfillment-ig
+            name: compute-instance-operations-ig
         - secretRef:
             name: storage-operations-ig
             optional: true

--- a/config/base/secret-compute-instance-operations-ig-example.yaml
+++ b/config/base/secret-compute-instance-operations-ig-example.yaml
@@ -3,18 +3,13 @@ kind: Secret
 metadata:
   name: compute-instance-operations-ig
 type: Opaque
-data:
-  # OpenStack application credentials for VM/MOC scenarios (e.g. floating IP operations).
-  # Values are plaintext in overlay env files; base64-encode when creating manually.
-
-  # Base64-encoded OpenStack application credential ID
-  OS_APPLICATION_CREDENTIAL_ID: ""
-
-  # Base64-encoded OpenStack application credential secret
-  OS_APPLICATION_CREDENTIAL_SECRET: ""
-
-  # Base64-encoded auth type (e.g., v3applicationcredential)
-  OS_AUTH_TYPE: ""
-
-  # Base64-encoded OpenStack auth URL (e.g., https://openstack.example.com:5000/v3)
-  OS_AUTH_URL: ""
+# Optional: the compute-instance-operations-ig pod spec mounts this Secret with
+# optional: true. Default KubeVirt VMaaS needs no keys here.
+#
+# Add keys only for deployment-specific compute templates. Related config lives
+# elsewhere:
+# - Remote VMaaS cluster kubeconfig: separate Secret via
+#   REMOTE_CLUSTER_KUBECONFIG_SECRET_NAME in config-as-code-ig
+# - JIT tenant storage: storage-operations-ig Secret/ConfigMap
+# - OpenStack / Neutron networking: network-fulfillment-ig
+# - Cluster / ESI floating IPs: cluster-fulfillment-ig

--- a/config/base/secret-compute-instance-operations-ig-example.yaml
+++ b/config/base/secret-compute-instance-operations-ig-example.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: compute-instance-operations-ig
+type: Opaque
+data:
+  # OpenStack application credentials for VM/MOC scenarios (e.g. floating IP operations).
+  # Values are plaintext in overlay env files; base64-encode when creating manually.
+
+  # Base64-encoded OpenStack application credential ID
+  OS_APPLICATION_CREDENTIAL_ID: ""
+
+  # Base64-encoded OpenStack application credential secret
+  OS_APPLICATION_CREDENTIAL_SECRET: ""
+
+  # Base64-encoded auth type (e.g., v3applicationcredential)
+  OS_AUTH_TYPE: ""
+
+  # Base64-encoded OpenStack auth URL (e.g., https://openstack.example.com:5000/v3)
+  OS_AUTH_URL: ""

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -38,6 +38,7 @@ WORKFLOWS=(
 # Roles with multiple scenarios (due to set_fact persistence across plays)
 # list each scenario file separately in ROLE_SCENARIO_TESTS.
 ROLE_TESTS=(
+  "config_as_code_pod_specs"
   "finalizer"
   "lease"
 )

--- a/tests/integration/targets/config_as_code_pod_specs/tasks/baseline.yml
+++ b/tests/integration/targets/config_as_code_pod_specs/tasks/baseline.yml
@@ -1,0 +1,56 @@
+---
+# Contract tests for config-as-code instance group pod spec templates.
+
+- name: Compute-instance pod spec without remote kubeconfig
+  hosts: localhost
+  gather_facts: false
+  vars:
+    aap_ee_image: ghcr.io/osac-project/osac-aap:latest
+    remote_cluster_kubeconfig_secret_name: ""
+    _template_path: >-
+      {{ playbook_dir }}/../../../../../collections/ansible_collections/osac/config_as_code/roles/aap/templates/compute-instance-operations-ig.j2
+
+  tasks:
+    - name: Render compute-instance-operations pod spec
+      ansible.builtin.set_fact:
+        _pod_spec: "{{ lookup('ansible.builtin.template', _template_path) }}"
+
+    - name: Assert dedicated compute-instance secret is referenced
+      ansible.builtin.assert:
+        that:
+          - "_pod_spec is search('name: compute-instance-operations-ig')"
+        fail_msg: Expected compute-instance-operations-ig secretRef in pod spec
+
+    - name: Assert cluster-fulfillment secret is not referenced
+      ansible.builtin.assert:
+        that:
+          - "_pod_spec is not search('cluster-fulfillment-ig')"
+        fail_msg: Pod spec must not reference cluster-fulfillment-ig
+
+    - name: Assert storage-operations references are retained
+      ansible.builtin.assert:
+        that:
+          - "_pod_spec is search('storage-operations-ig')"
+        fail_msg: Expected storage-operations-ig references in pod spec
+
+- name: Compute-instance pod spec with remote kubeconfig
+  hosts: localhost
+  gather_facts: false
+  vars:
+    aap_ee_image: ghcr.io/osac-project/osac-aap:latest
+    remote_cluster_kubeconfig_secret_name: remote-cluster-kubeconfig
+    remote_cluster_kubeconfig_secret_key: kubeconfig
+    _template_path: >-
+      {{ playbook_dir }}/../../../../../collections/ansible_collections/osac/config_as_code/roles/aap/templates/compute-instance-operations-ig.j2
+
+  tasks:
+    - name: Render compute-instance-operations pod spec with remote cluster
+      ansible.builtin.set_fact:
+        _pod_spec_remote: "{{ lookup('ansible.builtin.template', _template_path) }}"
+
+    - name: Assert remote kubeconfig volume is present when configured
+      ansible.builtin.assert:
+        that:
+          - "_pod_spec_remote is search('remote-cluster-kubeconfig')"
+          - "_pod_spec_remote is search('OSAC_REMOTE_CLUSTER_KUBECONFIG')"
+        fail_msg: Expected remote cluster kubeconfig mount when secret name is set

--- a/tests/integration/targets/config_as_code_pod_specs/tasks/baseline.yml
+++ b/tests/integration/targets/config_as_code_pod_specs/tasks/baseline.yml
@@ -15,11 +15,12 @@
       ansible.builtin.set_fact:
         _pod_spec: "{{ lookup('ansible.builtin.template', _template_path) }}"
 
-    - name: Assert dedicated compute-instance secret is referenced
+    - name: Assert dedicated compute-instance secret is referenced optionally
       ansible.builtin.assert:
         that:
           - "_pod_spec is search('name: compute-instance-operations-ig')"
-        fail_msg: Expected compute-instance-operations-ig secretRef in pod spec
+          - "_pod_spec is search('optional: true')"
+        fail_msg: Expected optional compute-instance-operations-ig secretRef in pod spec
 
     - name: Assert cluster-fulfillment secret is not referenced
       ansible.builtin.assert:

--- a/tests/integration/targets/config_as_code_pod_specs/tasks/baseline.yml
+++ b/tests/integration/targets/config_as_code_pod_specs/tasks/baseline.yml
@@ -15,11 +15,28 @@
       ansible.builtin.set_fact:
         _pod_spec: "{{ lookup('ansible.builtin.template', _template_path) }}"
 
+    - name: Parse rendered pod spec
+      ansible.builtin.set_fact:
+        _pod: "{{ _pod_spec | from_yaml }}"
+
+    - name: Extract compute-instance secretRef from envFrom
+      ansible.builtin.set_fact:
+        _compute_secret_ref: >-
+          {{
+            _pod.spec.containers[0].envFrom
+            | selectattr('secretRef', 'defined')
+            | map(attribute='secretRef')
+            | selectattr('name', 'equalto', 'compute-instance-operations-ig')
+            | list
+            | first
+          }}
+
     - name: Assert dedicated compute-instance secret is referenced optionally
       ansible.builtin.assert:
         that:
-          - "_pod_spec is search('name: compute-instance-operations-ig')"
-          - "_pod_spec is search('optional: true')"
+          - _compute_secret_ref is defined
+          - _compute_secret_ref.name == 'compute-instance-operations-ig'
+          - _compute_secret_ref.optional | default(false) | bool
         fail_msg: Expected optional compute-instance-operations-ig secretRef in pod spec
 
     - name: Assert cluster-fulfillment secret is not referenced


### PR DESCRIPTION
## [OSAC-244](https://redhat.atlassian.net/browse/OSAC-244): Make VM infrastructure independent from cluster infra

**Jira:** https://redhat.atlassian.net/browse/OSAC-244
**Story type:** Task

### Summary

Decouple compute-instance AAP pod infrastructure from cluster-fulfillment by replacing the `cluster-fulfillment-ig` secretRef with a dedicated `compute-instance-operations-ig` mount. Inventory and instance group were already independent; this change completes secret independence for VMaaS workflows.

Default KubeVirt VMaaS (`ocp_virt_vm`) uses the in-cluster `osac-sa` service account and does not require credentials in a dedicated secret. The compute-instance secret mount is **optional** — deployments only create `compute-instance-operations-ig` when a compute template needs deployment-specific environment variables.

### Changes

- **`compute-instance-operations-ig.j2`:** Replace `cluster-fulfillment-ig` secretRef with optional `compute-instance-operations-ig`; retain optional `storage-operations-ig` refs
- **Contract test:** `tests/integration/targets/config_as_code_pod_specs` asserts optional dedicated secret, no cluster-fulfillment dependency, remote kubeconfig volume
- **Example secret:** `config/base/secret-compute-instance-operations-ig-example.yaml` — comments-only; no OpenStack placeholders (OSP/Neutron uses `network-fulfillment-ig`; cluster/ESI floating IPs use `cluster-fulfillment-ig`)
- **Docs:** Update `config_as_code/README.md` for multi-IG configuration and optional compute secret

### Testing

- **Unit tests:** N/A (Ansible/config project)
- **Integration tests:** `config_as_code_pod_specs` contract test (6 tasks, pass)
- **Lint:** `ansible-lint` pass; playbook syntax-check pass on compute instance create/delete

### Cross-repo dependency

No companion osac-installer PR required. Submodule and image pins are handled by the automated [bump-submodules](https://github.com/osac-project/osac-installer/blob/main/.github/workflows/bump-submodules.yaml) workflow after this PR merges and its image is published. No overlay `secretGenerator` or installer wiring is needed for default VMaaS.

### Acceptance Criteria

- [x] [AC-1](https://redhat.atlassian.net/browse/AC-1): Dedicated bundle (secrets, SA, inventory) — optional secret + existing inventory/IG; shared `osac-sa`
- [x] AC-2: No `cluster-fulfillment-ig` dependency in compute-instance pod spec
- [x] [AC-3](https://redhat.atlassian.net/browse/AC-3): Dedicated secret extension point documented (empty by default; add keys only for deployment-specific compute templates)
- [x] AC-4: Extension point documented in osac-aap (`config_as_code/README.md` + example secret manifest)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented compute instance operations environment variables, including the dedicated `compute-instance-operations-ig` secret and when it is optionally mounted.
  * Clarified VMaaS credential expectations and related networking/fulfillment behavior.
  * Added guidance for optional JIT tenant storage and remote cluster kubeconfig mounting.
  * Added an example `compute-instance-operations-ig` Secret manifest.

* **Tests**
  * Extended integration test coverage for the `compute-instance-operations-ig` pod spec to verify the correct secretRef and optional mounts, plus remote kubeconfig behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->