### PR TITLE
OSAC-1297: unbind agents before HostedCluster deletion to enable software reclaim

### DIFF
--- a/collections/ansible_collections/osac/service/roles/manage_agents/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/service/roles/manage_agents/meta/argument_specs.yaml
@@ -44,6 +44,11 @@ argument_specs:
       manage_agents_cluster_order_name:
         type: str
         required: true
+  unbind_agents_for_reclaim:
+    options:
+      manage_agents_cluster_order_name:
+        type: str
+        required: true
   import_agents:
     options:
       manage_agents_node_names:

--- a/collections/ansible_collections/osac/service/roles/manage_agents/tasks/unbind_agents_for_reclaim.yml
+++ b/collections/ansible_collections/osac/service/roles/manage_agents/tasks/unbind_agents_for_reclaim.yml
@@ -44,11 +44,20 @@
         patch:
           - op: remove
             path: /spec/clusterDeploymentName
+      register: _unbind_patch_result
       loop: "{{ manage_agents_reclaim_list.resources }}"
       loop_control:
         loop_var: agent
         label: "Unbind agent {{ agent.metadata.name }}"
       failed_when: false
+
+    - name: Report unbind failures
+      ansible.builtin.debug:
+        msg: "Failed to unbind agent {{ item.agent.metadata.name }}: {{ item.msg | default('unknown error') }}"
+      loop: "{{ _unbind_patch_result.results | selectattr('failed', 'defined') | selectattr('failed') | list }}"
+      loop_control:
+        label: "{{ item.agent.metadata.name }}"
+      when: _unbind_patch_result.results | selectattr('failed', 'defined') | selectattr('failed') | list | length > 0
 
     - name: Wait for agents to return to available state
       kubernetes.core.k8s_info:
@@ -60,7 +69,7 @@
       register: manage_agents_reclaim_status
       until: >-
         manage_agents_reclaim_status.resources | length == 0
-        or manage_agents_reclaim_status.resources[0].status.debugInfo.state
+        or (manage_agents_reclaim_status.resources[0].status.debugInfo.state | default(''))
            in ['known-unbound', 'known', 'discovering-unbound']
       retries: 60
       delay: 10

--- a/collections/ansible_collections/osac/service/roles/manage_agents/tasks/unbind_agents_for_reclaim.yml
+++ b/collections/ansible_collections/osac/service/roles/manage_agents/tasks/unbind_agents_for_reclaim.yml
@@ -1,0 +1,71 @@
+---
+# Unbind agents BEFORE deleting the HostedCluster so the assisted-service software
+# reclaim can run while the spoke API is still alive.
+#
+# Problem: when a HostedCluster is deleted, the spoke API goes down. The assisted-service
+# agent controller then tries to reclaim non-BMH agents (libvirt VMs) by deploying a
+# DaemonSet on the spoke — but the spoke is gone, so reclaim fails silently. The agent
+# gets stuck in unbinding-pending-user-action permanently (it needs to kexec back into
+# the discovery environment, but the reclaim DaemonSet that does this was never deployed).
+#
+# Fix: clear spec.clusterDeploymentName before the HostedCluster is deleted. This triggers
+# the agent controller's unbind flow while the spoke is alive. runReclaimAgent deploys the
+# reclaim DaemonSet on the spoke, the agent kexec-reboots into the discovery environment,
+# and re-registers as known-unbound.
+#
+# This task should only be called from templates that use non-BMH agents (e.g. ocp_ci_small).
+# BMH agents are handled by Ironic via BMC and do not need this.
+
+- name: List all agents in namespace
+  kubernetes.core.k8s_info:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ default_agent_namespace }}"
+  register: _all_agents
+
+- name: Find agents bound to this cluster order
+  ansible.builtin.set_fact:
+    manage_agents_reclaim_list:
+      resources: >-
+        {{ _all_agents.resources
+           | selectattr('spec.clusterDeploymentName', 'defined')
+           | selectattr('spec.clusterDeploymentName', 'equalto', manage_agents_cluster_order_name)
+           | list }}
+
+- name: Unbind agents to trigger software reclaim
+  when: manage_agents_reclaim_list.resources | length > 0
+  block:
+    - name: Clear clusterDeploymentName on each agent
+      kubernetes.core.k8s_json_patch:
+        api_version: agent-install.openshift.io/v1beta1
+        kind: Agent
+        name: "{{ agent.metadata.name }}"
+        namespace: "{{ default_agent_namespace }}"
+        patch:
+          - op: remove
+            path: /spec/clusterDeploymentName
+      loop: "{{ manage_agents_reclaim_list.resources }}"
+      loop_control:
+        loop_var: agent
+        label: "Unbind agent {{ agent.metadata.name }}"
+      failed_when: false
+
+    - name: Wait for agents to return to available state
+      kubernetes.core.k8s_info:
+        kind: Agent
+        api_version: agent-install.openshift.io/v1beta1
+        namespace: "{{ default_agent_namespace }}"
+        field_selectors:
+          - "metadata.name={{ agent.metadata.name }}"
+      register: manage_agents_reclaim_status
+      until: >-
+        manage_agents_reclaim_status.resources | length == 0
+        or manage_agents_reclaim_status.resources[0].status.debugInfo.state
+           in ['known-unbound', 'known', 'discovering-unbound']
+      retries: 60
+      delay: 10
+      failed_when: false
+      loop: "{{ manage_agents_reclaim_list.resources }}"
+      loop_control:
+        loop_var: agent
+        label: "Wait for agent {{ agent.metadata.name }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_ci_small/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_ci_small/tasks/delete.yaml
@@ -2,7 +2,7 @@
   ansible.builtin.set_fact:
     delete_step_pre_delete_hook_default:
       name: osac.templates.ocp_ci_small
-      tasks_from: noop.yaml
+      tasks_from: pre_delete.yaml
     delete_step_hosted_cluster_default:
       name: osac.service.hosted_cluster
       tasks_from: main.yaml

--- a/collections/ansible_collections/osac/templates/roles/ocp_ci_small/tasks/pre_delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_ci_small/tasks/pre_delete.yaml
@@ -1,0 +1,7 @@
+---
+- name: Unbind agents before HostedCluster deletion (non-BMH/libvirt only)
+  ansible.builtin.include_role:
+    name: osac.service.manage_agents
+    tasks_from: unbind_agents_for_reclaim
+  vars:
+    manage_agents_cluster_order_name: "{{ cluster_order.metadata.name }}"


### PR DESCRIPTION
## Summary

Add a pre-delete hook to the `ocp_ci_small` template that unbinds agents before deleting the HostedCluster, enabling the assisted-service software reclaim to run while the spoke API is still alive.

## Problem

When a ClusterOrder is deleted, the HostedCluster (spoke) is deleted first, then the agent controller tries to reclaim non-BMH agents. The software reclaim deploys a DaemonSet on the spoke to kexec the agent back into the discovery environment — but the spoke API is already gone, so reclaim fails silently. The agent gets permanently stuck in `unbinding-pending-user-action`.

This affects only non-BMH agents (libvirt VMs in CI). Bare metal with BMH/BMC is unaffected — Ironic handles the reboot via BMC independently.

## Fix

The `ocp_ci_small` template's pre-delete hook (previously a no-op) now calls `unbind_agents_for_reclaim`, which clears `spec.clusterDeploymentName` on each agent before the HostedCluster is deleted. This triggers the agent controller's unbind flow while the spoke is alive → `runReclaimAgent` deploys a DaemonSet on the spoke → the agent kexec-reboots into discovery → re-registers as `known-unbound`.

**Scope:** Only the `ocp_ci_small` template is affected. The generic `delete_hosted_cluster` flow and all other templates are untouched.

## Changes

- **New**: `manage_agents/tasks/unbind_agents_for_reclaim.yml` — clears `clusterDeploymentName`, waits for agents to reach `known-unbound`
- **New**: `ocp_ci_small/tasks/pre_delete.yaml` — calls `unbind_agents_for_reclaim`
- **Modified**: `ocp_ci_small/tasks/delete.yaml` — pre-delete hook points to `pre_delete.yaml` instead of `noop.yaml`
- **Modified**: `manage_agents/meta/argument_specs.yaml` — adds spec for new task

## Test plan

- [ ] Stress test on libvirt: verify agent returns to `known-unbound` after ClusterOrder deletion
- [ ] Verify non-`ocp_ci_small` templates are completely unaffected

Jira: [OSAC-1297](https://redhat.atlassian.net/browse/OSAC-1297)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unbinds Agents during HostedCluster deletion for non-BMH deployments so Agent resources are cleared before cluster removal.
  * Adds a pre-delete task that triggers the agent-unbinding flow using the cluster order name.

* **Chores**
  * Default pre-delete hook now invokes the pre-delete task set so cleanup runs when no override is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->