### PR TITLE
OSAC-1949: Add disk image deploy support and fix openstack.cloud module compatibility

### DIFF
--- a/collections/ansible_collections/osac/service/roles/openstack_bm_node/tasks/preflight.yaml
+++ b/collections/ansible_collections/osac/service/roles/openstack_bm_node/tasks/preflight.yaml
@@ -1,0 +1,50 @@
+---
+- name: Fail if host class is not openstack
+  ansible.builtin.fail:
+    msg: "Role requires hostClass 'openstack', got '{{ bare_metal_instance.spec.hostClass | default('') }}'"
+  when: bare_metal_instance.spec.hostClass | default('') != "openstack"
+
+- name: Fail if network class is not openstack
+  ansible.builtin.fail:
+    msg: "Role requires networkClass 'openstack', got '{{ bare_metal_instance.spec.networkClass | default('') }}'"
+  when: bare_metal_instance.spec.networkClass | default('') != "openstack"
+
+- name: Parse template parameters
+  block:
+    - name: Decode template parameters JSON
+      ansible.builtin.set_fact:
+        template_params: "{{ bare_metal_instance.spec.templateParameters | from_json }}"
+  rescue:
+    - name: Fail if templateParameters is missing or invalid JSON
+      ansible.builtin.fail:
+        msg: "spec.templateParameters must be valid JSON"
+
+- name: Get bare metal node information
+  openstack.cloud.baremetal_node_info:
+    name: "{{ bare_metal_instance.spec.externalHostID }}"
+  register: baremetal_node_result
+
+- name: Fail if node not found
+  ansible.builtin.fail:
+    msg: "Bare metal node '{{ bare_metal_instance.spec.externalHostID }}' not found in OpenStack"
+  when: baremetal_node_result.nodes | length == 0
+
+- name: Extract node info
+  ansible.builtin.set_fact:
+    node_info: "{{ baremetal_node_result.nodes[0] }}"
+
+- name: Display current node state
+  ansible.builtin.debug:
+    msg:
+      - "Node: {{ node_info.name }}"
+      - "Provision State: {{ node_info.provision_state }}"
+
+- name: Fail if image URL is missing
+  ansible.builtin.fail:
+    msg: "templateParameters.imageURL is required for image provisioning"
+  when: template_params.imageURL | default('') | length == 0
+
+- name: Fail if private network is missing
+  ansible.builtin.fail:
+    msg: "templateParameters.privateNetwork is required for image provisioning"
+  when: template_params.privateNetwork | default('') | length == 0

--- a/collections/ansible_collections/osac/service/roles/openstack_bm_node/tasks/prepare_for_deploy.yaml
+++ b/collections/ansible_collections/osac/service/roles/openstack_bm_node/tasks/prepare_for_deploy.yaml
@@ -1,0 +1,18 @@
+---
+- name: Transition node to available and set provisioning network
+  when: not (node_already_has_image | default(false))
+  block:
+    - name: Move node to available state
+      when: node_info.provision_state not in ['manageable', 'available']
+      openstack.cloud.baremetal_node_action:
+        name: "{{ bare_metal_instance.spec.externalHostID }}"
+        state: absent
+        wait: true
+
+    - name: Set provisioning network for node
+      ansible.builtin.include_role:
+        name: osac.esi.l2
+        tasks_from: set_networks_for_node
+      vars:
+        node: "{{ bare_metal_instance.spec.externalHostID }}"
+        networks: "{{ [template_params.provisioningNetwork | default('provisioning')] }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
@@ -1,42 +1,8 @@
 ---
-- name: Fail if host class is not openstack
-  ansible.builtin.fail:
-    msg: "bm_host_agent_provisioning requires hostClass 'openstack', got '{{ bare_metal_instance.spec.hostClass | default('') }}'"
-  when: bare_metal_instance.spec.hostClass | default('') != "openstack"
-
-- name: Fail if network class is not openstack
-  ansible.builtin.fail:
-    msg: "bm_host_agent_provisioning requires networkClass 'openstack', got '{{ bare_metal_instance.spec.networkClass | default('') }}'"
-  when: bare_metal_instance.spec.networkClass | default('') != "openstack"
-
-- name: Parse template parameters
-  ansible.builtin.set_fact:
-    template_params: "{{ bare_metal_instance.spec.templateParameters | from_json }}"
-
-- name: Get bare metal node information
-  openstack.cloud.baremetal_node_info:
-    name: "{{ bare_metal_instance.spec.externalHostID }}"
-  register: baremetal_node_result
-
-- name: Fail if node not found
-  ansible.builtin.fail:
-    msg: "Bare metal node '{{ bare_metal_instance.spec.externalHostID }}' not found in OpenStack"
-  when: baremetal_node_result.nodes | length == 0
-
-- name: Extract node info
-  ansible.builtin.set_fact:
-    node_info: "{{ baremetal_node_result.nodes[0] }}"
-
-- name: Display current node state
-  ansible.builtin.debug:
-    msg:
-      - "Node: {{ node_info.name }}"
-      - "Provision State: {{ node_info.provision_state }}"
-
-- name: Fail if image URL is missing
-  ansible.builtin.fail:
-    msg: "templateParameters.imageURL is required for image provisioning"
-  when: template_params.imageURL | default('') | length == 0
+- name: Get bare metal node info
+  ansible.builtin.include_role:
+    name: osac.service.openstack_bm_node
+    tasks_from: preflight
 
 - name: Handle already-active node
   when: node_info.provision_state == "active"
@@ -56,7 +22,8 @@
         - name: Undeploy node to re-provision with new image
           openstack.cloud.baremetal_node_action:
             name: "{{ bare_metal_instance.spec.externalHostID }}"
-            undeploy: true
+            state: absent
+            deploy: false
             wait: true
 
         - name: Refresh node info after undeploy
@@ -68,7 +35,12 @@
           ansible.builtin.set_fact:
             node_info: "{{ baremetal_node_result.nodes[0] }}"
 
-- name: Transition node to available and deploy
+- name: Prepare node for deploy
+  ansible.builtin.include_role:
+    name: osac.service.openstack_bm_node
+    tasks_from: prepare_for_deploy
+
+- name: Deploy node with ramdisk image
   when: not (node_already_has_image | default(false))
   block:
     - name: Move node to manageable state
@@ -111,7 +83,7 @@
         deploy: true
         wait: true
 
-- name: Ensure node is on agent private network
+- name: Set agent private network
   ansible.builtin.include_role:
     name: osac.esi.l2
     tasks_from: set_networks_for_node

--- a/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/defaults/main.yaml
@@ -3,3 +3,4 @@ bm_host_metal3_default_image_url: >-
   https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2
 bm_host_metal3_default_image_checksum: "28680fe5b371a5a82ebf43a31926e086a168e59949d03969c5093e7071f90b7f"
 bm_host_metal3_default_checksum_type: "sha256"
+bm_host_openstack_external_network: "external"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/tasks/create_openstack.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/tasks/create_openstack.yaml
@@ -1,0 +1,163 @@
+---
+- name: Get bare metal node info
+  ansible.builtin.include_role:
+    name: osac.service.openstack_bm_node
+    tasks_from: preflight
+
+- name: Undeploy active node for re-provisioning
+  when: node_info.provision_state == "active"
+  block:
+    - name: Undeploy node
+      openstack.cloud.baremetal_node_action:
+        name: "{{ bare_metal_instance.spec.externalHostID }}"
+        state: absent
+        deploy: false
+        wait: true
+
+    - name: Refresh node info after undeploy
+      openstack.cloud.baremetal_node_info:
+        name: "{{ bare_metal_instance.spec.externalHostID }}"
+      register: baremetal_node_result
+
+    - name: Update node info after undeploy
+      ansible.builtin.set_fact:
+        node_info: "{{ baremetal_node_result.nodes[0] }}"
+
+- name: Prepare node for deploy
+  ansible.builtin.include_role:
+    name: osac.service.openstack_bm_node
+    tasks_from: prepare_for_deploy
+
+- name: Deploy node with image
+  block:
+    - name: Build instance_info for disk image deploy
+      vars:
+        _checksum_type: "{{ template_params.get('checksumType', '') }}"
+        _checksum: "{{ template_params.get('imageChecksum', '') | default('auto', true) }}"
+      ansible.builtin.set_fact:
+        node_instance_info: >-
+          {{
+            {'image_source': template_params.imageURL}
+            | combine(
+                {'image_os_hash_algo': _checksum_type, 'image_os_hash_value': _checksum}
+                if (_checksum_type | length > 0 and _checksum != 'auto')
+                else {'image_checksum': _checksum}
+              )
+            | combine(
+                (template_params.get('rootGb', '') | string | length > 0)
+                | ternary(
+                    {'root_gb': template_params.rootGb | int},
+                    {}
+                  )
+              )
+          }}
+
+    - name: Read user data from Secret
+      when: template_params.get('userDataSecret', '') | length > 0
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ template_params.userDataSecret }}"
+        namespace: "{{ bare_metal_instance.metadata.namespace }}"
+      register: user_data_secret_result
+
+    - name: Fail if user data Secret not found
+      when: user_data_secret_result is not skipped and user_data_secret_result.resources | length == 0
+      ansible.builtin.fail:
+        msg: "Secret '{{ template_params.userDataSecret }}' not found in namespace '{{ bare_metal_instance.metadata.namespace }}'"
+
+    - name: Fail if user data Secret is missing 'user-data' key
+      when: user_data_secret_result is not skipped and 'user-data' not in user_data_secret_result.resources[0].data
+      ansible.builtin.fail:
+        msg: "Secret '{{ template_params.userDataSecret }}' does not contain 'user-data' key"
+
+    - name: Extract user data content from Secret
+      when: user_data_secret_result is not skipped
+      ansible.builtin.set_fact:
+        _user_data_content: "{{ user_data_secret_result.resources[0].data['user-data'] | b64decode }}"
+
+    - name: Build config_drive for deploy
+      vars:
+        _ssh_keys: "{{ template_params.get('sshKeys', []) }}"
+        _user_data: "{{ _user_data_content | default('') }}"
+      ansible.builtin.set_fact:
+        node_config_drive: >-
+          {{
+            {}
+            | combine(
+                (_ssh_keys | length > 0)
+                | ternary(
+                    {'meta_data': {'public_keys': dict(range(_ssh_keys | length) | map('string') | zip(_ssh_keys))}},
+                    {}
+                  )
+              )
+            | combine(
+                (_user_data | length > 0)
+                | ternary(
+                    {'user_data': _user_data},
+                    {}
+                  )
+              )
+          }}
+
+    - name: Deploy bare metal node with image
+      openstack.cloud.baremetal_node_action:
+        name: "{{ bare_metal_instance.spec.externalHostID }}"
+        instance_info: "{{ node_instance_info }}"
+        config_drive: "{{ node_config_drive if node_config_drive | length > 0 else omit }}"
+        deploy: true
+        wait: true
+
+- name: Set private network
+  ansible.builtin.include_role:
+    name: osac.esi.l2
+    tasks_from: set_networks_for_node
+  vars:
+    node: "{{ bare_metal_instance.spec.externalHostID }}"
+    networks: "{{ [template_params.privateNetwork] }}"
+
+- name: Attach floating IP from external network
+  when: template_params.get('attachFloatingIp', false) | bool
+  block:
+    - name: Allocate floating IP
+      ansible.builtin.include_role:
+        name: osac.esi.floating_ip
+      vars:
+        floating_ip_state: present
+        floating_ip_name: "{{ bare_metal_instance.metadata.name }}"
+        floating_ip_network: "{{ bm_host_openstack_external_network }}"
+
+    - name: Get node network info for private network
+      ansible.builtin.include_role:
+        name: osac.esi.network
+        tasks_from: get_node_network_info
+      vars:
+        node: "{{ bare_metal_instance.spec.externalHostID }}"
+        network: "{{ template_params.privateNetwork }}"
+
+    - name: Fail if no port found on private network
+      when: (node_network_info.stdout | from_json) | length == 0
+      ansible.builtin.fail:
+        msg: "No port found for node '{{ bare_metal_instance.spec.externalHostID }}' on network '{{ template_params.privateNetwork }}'"
+
+    - name: Associate floating IP with node port  # noqa:no-changed-when
+      ansible.builtin.command: >-
+        openstack floating ip set
+        --port {{ (node_network_info.stdout | from_json)[0]['Port'] }}
+        {{ allocate_floating_ip_result }}
+  rescue:
+    - name: Release orphaned floating IP on failure
+      ansible.builtin.include_role:
+        name: osac.esi.floating_ip
+      vars:
+        floating_ip_state: absent
+        floating_ip_name: "{{ bare_metal_instance.metadata.name }}"
+      when: allocate_floating_ip_result is defined
+
+    - name: Re-raise floating IP association failure
+      ansible.builtin.fail:
+        msg: "Floating IP association failed and allocated IP has been released"
+
+- name: Image provisioning completed
+  ansible.builtin.debug:
+    msg: "Image provisioning completed for node {{ bare_metal_instance.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/tasks/delete_openstack.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/tasks/delete_openstack.yaml
@@ -1,0 +1,26 @@
+---
+- name: Release floating IP if allocated
+  ansible.builtin.include_role:
+    name: osac.esi.floating_ip
+  vars:
+    floating_ip_state: absent
+    floating_ip_name: "{{ bare_metal_instance.metadata.name }}"
+
+- name: Detach all networks and delete neutron ports
+  ansible.builtin.include_role:
+    name: osac.esi.l2
+    tasks_from: set_networks_for_node
+  vars:
+    node: "{{ bare_metal_instance.spec.externalHostID }}"
+    networks: []
+
+- name: Undeploy bare metal node
+  openstack.cloud.baremetal_node_action:
+    name: "{{ bare_metal_instance.spec.externalHostID }}"
+    state: absent
+    deploy: false
+    wait: true
+
+- name: Image deprovisioning completed
+  ansible.builtin.debug:
+    msg: "Image deprovisioning completed for node {{ bare_metal_instance.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/vars/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/vars/main.yaml
@@ -1,3 +1,4 @@
 ---
 supported_host_classes:
   - metal3
+  - openstack


### PR DESCRIPTION
Closes: https://github.com/osac-project/issues/issues/410
- Support imageChecksum, checksumType, and rootGb as optional templateParams
- Inject ssh_key and user_data via config_drive for disk image deploys
- Replace manage/provide with state: absent (module only supports state param)

Jira link: [OSAC-1949](https://redhat.atlassian.net/browse/OSAC-1949)

A sample templateParams look like this:
```
templateParameters: >-
          {"imageURL": "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-latest.x86_64.qcow2",
          "imageChecksum": "13baa70caebd7d5dc6cebe816f3bc8fbe357ce330af4155255c7648c2798ff1c",
          "checksumType": "sha256",
          "rootGb": 20,
          "privateNetwork": "private-agent",
          "provisioningNetwork": "provisioning",
          "sshKeys": ["ssh-rsa xxxxxxx"],
          "userDataSecret": "bmi-xxx-user-data",
          "attachFloatingIp": "true",
          "externalNetwork": "external"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end OpenStack bare-metal provisioning support, including deploy, reprovision, and delete flows.
  * Enabled image-based deployment with optional checksum handling, root disk sizing, user data, SSH keys, private networking, and floating IP attachment.
  * Expanded supported host classes to include OpenStack.

* **Bug Fixes**
  * Added stricter validation for required provisioning settings and node availability checks.
  * Improved cleanup by releasing floating IPs and removing networks/ports during deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->