### PR TITLE
OSAC-496: Set shared tenant on publish_templates API payloads

### DIFF
--- a/collections/ansible_collections/osac/service/roles/publish_templates/defaults/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/defaults/main.yaml
@@ -2,3 +2,4 @@
 publish_templates_cluster_api_endpoint: "{{ osac_fulfillment_service_uri }}/api/private/v1/cluster_templates"
 publish_templates_compute_instance_api_endpoint: "{{ osac_fulfillment_service_uri }}/api/private/v1/compute_instance_templates"
 publish_templates_network_class_api_endpoint: "{{ osac_fulfillment_service_uri }}/api/private/v1/network_classes"
+publish_templates_tenant: "{{ lookup('env', 'OSAC_PUBLISH_TEMPLATES_TENANT') | default('shared', true) }}"

--- a/collections/ansible_collections/osac/service/roles/publish_templates/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/meta/argument_specs.yaml
@@ -28,3 +28,7 @@ argument_specs:
         type: str
         description: API endpoint for NetworkClass resources
         default: "{{ osac_fulfillment_service_uri }}/api/private/v1/network_classes"
+      publish_templates_tenant:
+        type: str
+        description: Tenant assigned to published platform templates
+        default: shared

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tasks/clusters.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tasks/clusters.yaml
@@ -27,7 +27,12 @@
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
     body_format: json
-    body: "{{ template }}"
+    body: >-
+      {{
+        template | combine({
+          'metadata': (template.metadata | default({})) | combine({'tenant': publish_templates_tenant})
+        }, recursive=True)
+      }}
 
 - name: Create new cluster template
   loop: "{{ osac_cluster_templates }}"
@@ -42,4 +47,9 @@
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
     body_format: json
-    body: "{{ template }}"
+    body: >-
+      {{
+        template | combine({
+          'metadata': (template.metadata | default({})) | combine({'tenant': publish_templates_tenant})
+        }, recursive=True)
+      }}

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tasks/compute_instances.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tasks/compute_instances.yaml
@@ -27,7 +27,12 @@
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
     body_format: json
-    body: "{{ template }}"
+    body: >-
+      {{
+        template | combine({
+          'metadata': (template.metadata | default({})) | combine({'tenant': publish_templates_tenant})
+        }, recursive=True)
+      }}
 
 - name: Create new ComputeInstance template
   loop: "{{ osac_compute_instance_templates }}"
@@ -42,4 +47,9 @@
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
     body_format: json
-    body: "{{ template }}"
+    body: >-
+      {{
+        template | combine({
+          'metadata': (template.metadata | default({})) | combine({'tenant': publish_templates_tenant})
+        }, recursive=True)
+      }}

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tasks/network_classes.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tasks/network_classes.yaml
@@ -30,7 +30,12 @@
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
     body_format: json
-    body: "{{ network_class }}"
+    body: >-
+      {{
+        network_class | combine({
+          'metadata': (network_class.metadata | default({})) | combine({'tenant': publish_templates_tenant})
+        }, recursive=True)
+      }}
 
 - name: Create new NetworkClass
   loop: "{{ osac_network_classes }}"
@@ -47,4 +52,9 @@
     headers:
       authorization: Bearer {{ osac_fulfillment_service_token }}
     body_format: json
-    body: "{{ network_class }}"
+    body: >-
+      {{
+        network_class | combine({
+          'metadata': (network_class.metadata | default({})) | combine({'tenant': publish_templates_tenant})
+        }, recursive=True)
+      }}

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tests/test.yml
@@ -60,6 +60,11 @@
         timeout: 5
       when: test_empty | default(false) | bool
 
+    - name: Reset mock API call log
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ test_mock_port }}/_reset"
+      when: test_empty | default(false) | bool
+
     - name: Run publish_templates role against empty API
       ansible.builtin.include_role:
         name: osac.service.publish_templates
@@ -90,10 +95,11 @@
         that:
           - call_log.json | selectattr('method', 'equalto', 'POST') | list | length == 3
           - call_log.json | selectattr('method', 'equalto', 'PATCH') | list | length == 0
+          - call_log.json | selectattr('method', 'equalto', 'POST') | map(attribute='body') | map(attribute='metadata.tenant') | list | unique == ['shared']
         fail_msg: >-
-          Expected 3 POSTs and 0 PATCHes for empty scenario.
+          Expected 3 POSTs and 0 PATCHes for empty scenario, each with metadata.tenant=shared.
           Calls: {{ call_log.json }}
-        success_msg: "Empty scenario passed: all 3 templates created via POST"
+        success_msg: "Empty scenario passed: all 3 templates created via POST with shared tenant"
       when: test_empty | default(false) | bool
 
     - name: Stop mock server
@@ -131,6 +137,11 @@
       ansible.builtin.wait_for:
         port: "{{ test_mock_port }}"
         timeout: 5
+      when: test_populated | default(false) | bool
+
+    - name: Reset mock API call log
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ test_mock_port }}/_reset"
       when: test_populated | default(false) | bool
 
     - name: Run publish_templates role with existing item IDs
@@ -211,6 +222,11 @@
       ansible.builtin.wait_for:
         port: "{{ test_mock_port }}"
         timeout: 5
+      when: test_no_items_key | default(false) | bool
+
+    - name: Reset mock API call log
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ test_mock_port }}/_reset"
       when: test_no_items_key | default(false) | bool
 
     - name: Run publish_templates role against edge-case API


### PR DESCRIPTION
## Summary

- Merge `metadata.tenant: shared` into publish_templates create/update payloads for cluster templates, ComputeInstance templates, and NetworkClass resources
- Default tenant is `shared`; override with `OSAC_PUBLISH_TEMPLATES_TENANT` env var
- Fixes e2e-vmaas `osac-publish-templates` job failing with `explicit tenant is required` after [OSAC-496](https://redhat.atlassian.net/browse/OSAC-496)

## Why the client must set tenant (not the server)

[OSAC-496](https://redhat.atlassian.net/browse/OSAC-496) / [fulfillment-service PR 704](https://github.com/osac-project/fulfillment-service/pull/704) **removed** the server-side fallback that silently assigned `"shared"` to universal-access callers. The template-publisher service account has universal access (`tenants: ["*"]`), so the fulfillment API now returns `PermissionDenied` unless the request includes an explicit `metadata.tenant`.

This is the same pattern as `osac create hub` hardcoding `shared` in fulfillment-service PR 704 — platform admin/bootstrap flows must be explicit on the **client**, not inferred on the server.

Broader CLI/AAP tenancy design: [OSAC-1546](https://redhat.atlassian.net/browse/OSAC-1546)

## Related PRs

| Repo | PR |
|------|-----|
| fulfillment-service | https://github.com/osac-project/fulfillment-service/pull/704 |
| osac-operator | https://github.com/osac-project/osac-operator/pull/297 |

## Test plan

- [x] `ansible-lint` on publish_templates role
- [x] `ansible-playbook tests/test.yml -e test_empty=true` (POST bodies include `metadata.tenant=shared`)
- [ ] Merge this PR; osac-installer submodule bump is automated
- [ ] Re-run [fulfillment-service PR 704](https://github.com/osac-project/fulfillment-service/pull/704) e2e-vmaas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Templates published to the platform can now be assigned to a specific tenant. Administrators can configure the target tenant using the `publish_templates_tenant` parameter, which defaults to 'shared' when not explicitly specified.

* **Tests**
  * Expanded test coverage to validate that tenant metadata is correctly applied across all template publishing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->