### PR TITLE
OSAC-1612: Add ocp_4_20_ai_maas template role for MaaS on RHOAI 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,8 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
+*.iml
 
 .ansible
 .vscode

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
@@ -1,0 +1,119 @@
+---
+# OCP release image
+ocp_4_20_ai_maas_ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.20.0-multi
+
+# Feature flags
+ocp_4_20_ai_maas_enable_maas: true
+ocp_4_20_ai_maas_enable_keycloak: true
+ocp_4_20_ai_maas_run_verify: true
+
+# --- Platform Operators ---
+
+# cert-manager
+ocp_4_20_ai_maas_cert_manager_channel: stable-v1.18
+ocp_4_20_ai_maas_cert_manager_source: redhat-operators
+
+# Service Mesh (must install BEFORE RHCL)
+ocp_4_20_ai_maas_sm_channel: stable-3.2
+ocp_4_20_ai_maas_sm_starting_csv: servicemeshoperator3.v3.2.6
+ocp_4_20_ai_maas_sm_source: redhat-operators
+
+# RHCL sub-operators (pre-create to prevent OLM auto-upgrade to v1.4.0)
+ocp_4_20_ai_maas_authorino_starting_csv: authorino-operator.v1.3.1
+ocp_4_20_ai_maas_limitador_starting_csv: limitador-operator.v1.3.1
+ocp_4_20_ai_maas_dns_starting_csv: dns-operator.v1.3.1
+
+# RHCL operator
+ocp_4_20_ai_maas_rhcl_starting_csv: rhcl-operator.v1.3.4
+ocp_4_20_ai_maas_rhcl_source: redhat-operators
+
+# Version to reject/accept in install plans
+ocp_4_20_ai_maas_reject_version: "v1.4.0"
+ocp_4_20_ai_maas_accept_version: "v1.3"
+
+# Leader Worker Set
+ocp_4_20_ai_maas_lws_channel: stable-v1.0
+ocp_4_20_ai_maas_lws_source: redhat-operators
+
+# RHOAI
+ocp_4_20_ai_maas_rhoai_channel: stable-3.4
+ocp_4_20_ai_maas_rhoai_source: redhat-operators
+
+# --- DSC ---
+
+ocp_4_20_ai_maas_dsc_components:
+  codeflare: Removed
+  dashboard: Managed
+  datasciencepipelines: Removed
+  kserve: Managed
+  kueue: Removed
+  modelmeshserving: Removed
+  ray: Removed
+  trainingoperator: Removed
+  trustyai: Removed
+  workbenches: Removed
+
+# --- MaaS Configuration ---
+
+# Gateway
+ocp_4_20_ai_maas_gateway_hostname: maas
+ocp_4_20_ai_maas_gateway_memory_limit: 2Gi
+ocp_4_20_ai_maas_gateway_cert_name: router-certs
+
+# PostgreSQL
+ocp_4_20_ai_maas_db_image: registry.redhat.io/rhel9/postgresql-16:latest
+ocp_4_20_ai_maas_db_user: maas
+ocp_4_20_ai_maas_db_password: maas-db-password  # Override in production
+ocp_4_20_ai_maas_db_name: maas
+ocp_4_20_ai_maas_db_storage: 5Gi
+
+# Keycloak
+ocp_4_20_ai_maas_keycloak_namespace: keycloak-maas
+ocp_4_20_ai_maas_keycloak_channel: stable-v26.4
+ocp_4_20_ai_maas_keycloak_instances: 1
+ocp_4_20_ai_maas_keycloak_db_password: keycloak-db-password  # Override in production
+ocp_4_20_ai_maas_keycloak_db_storage: 5Gi
+ocp_4_20_ai_maas_keycloak_realm: maas
+ocp_4_20_ai_maas_keycloak_client_id: maas-client
+ocp_4_20_ai_maas_keycloak_client_secret: maas-client-secret-value  # Override in production
+ocp_4_20_ai_maas_keycloak_test_password: password123  # Override in production
+
+# Tenant
+ocp_4_20_ai_maas_tenant_name: default-tenant
+ocp_4_20_ai_maas_api_key_max_expiration_days: 90
+
+# Model
+ocp_4_20_ai_maas_model_name: facebook-opt-125m-simulated
+ocp_4_20_ai_maas_model_id: facebook/opt-125m
+ocp_4_20_ai_maas_model_namespace: llm
+ocp_4_20_ai_maas_model_replicas: 1
+ocp_4_20_ai_maas_model_image: ghcr.io/llm-d/llm-d-inference-sim:v0.7.1
+ocp_4_20_ai_maas_model_uri: hf://sshleifer/tiny-gpt2
+
+# Subscription tiers
+ocp_4_20_ai_maas_tiers:
+  - name: free-subscription
+    group: tier-free-users
+    token_limit: 100
+    window: 1m
+    priority: 0
+  - name: premium-subscription
+    group: tier-premium-users
+    token_limit: 50000
+    window: 1m
+    priority: 1
+  - name: enterprise-subscription
+    group: tier-enterprise-users
+    token_limit: 100000
+    window: 1m
+    priority: 2
+
+# Monitoring
+ocp_4_20_ai_maas_monitoring_retention: 24h
+
+# --- Timeouts ---
+
+ocp_4_20_ai_maas_operator_retries: 50
+ocp_4_20_ai_maas_operator_delay: 10
+ocp_4_20_ai_maas_long_retries: 60
+ocp_4_20_ai_maas_dsc_retries: 90

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/files/kuadrant-instance.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/files/kuadrant-instance.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authorino-authorino-authorization
+  namespace: kuadrant-system
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: authorino-server-cert
+spec:
+  selector:
+    authorino-resource: authorino
+  ports:
+  - name: grpc
+    port: 50051
+    targetPort: 50051
+  - name: http
+    port: 5001
+    targetPort: 5001
+  type: ClusterIP
+---
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  namespace: kuadrant-system
+spec:
+  observability:
+    enable: true
+---
+apiVersion: operator.authorino.kuadrant.io/v1beta1
+kind: Authorino
+metadata:
+  name: authorino
+  namespace: kuadrant-system
+spec:
+  clusterWide: true
+  replicas: 1
+  listener:
+    tls:
+      enabled: true
+      certSecretRef:
+        name: authorino-server-cert
+  oidcServer:
+    tls:
+      enabled: false

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/argument_specs.yaml
@@ -1,0 +1,307 @@
+---
+argument_specs:
+  main:
+    short_description: Deploy MaaS on RHOAI 3.4 with RHCL 1.3 version pinning
+    description: >
+      Provisions an OpenShift cluster with Red Hat OpenShift AI 3.4,
+      Models-as-a-Service (GA), Keycloak SSO, and RHCL 1.3.x version
+      pinning. Extends ocp_4_17_small via post-install hook override.
+      SECURITY: All credential defaults (db_password, keycloak_db_password,
+      keycloak_client_secret, keycloak_test_password) are for development
+      and testing only. You MUST override every credential variable before
+      production use.
+    options:
+      # --- Feature Flags ---
+      ocp_4_20_ai_maas_enable_maas:
+        type: bool
+        required: false
+        default: true
+        description: Enable MaaS deployment (operators + configuration).
+      ocp_4_20_ai_maas_enable_keycloak:
+        type: bool
+        required: false
+        default: true
+        description: Deploy a dedicated Keycloak instance for MaaS OIDC authentication.
+      ocp_4_20_ai_maas_run_verify:
+        type: bool
+        required: false
+        default: true
+        description: Run verification tests after deployment.
+      ocp_4_20_ai_maas_ocp_release_image:
+        type: str
+        required: false
+        default: "quay.io/openshift-release-dev/ocp-release:4.20.0-multi"
+        description: OCP release image passed to the parent template.
+
+      # --- Platform Operators ---
+      ocp_4_20_ai_maas_cert_manager_channel:
+        type: str
+        required: false
+        default: "stable-v1.18"
+        description: >
+          OLM channel for cert-manager. RHCL 1.3 requires cert-manager 1.18
+          per https://access.redhat.com/articles/7092611.
+      ocp_4_20_ai_maas_cert_manager_source:
+        type: str
+        required: false
+        default: "redhat-operators"
+        description: OLM catalog source for cert-manager.
+      ocp_4_20_ai_maas_sm_channel:
+        type: str
+        required: false
+        default: "stable-3.2"
+        description: >
+          OLM channel for Service Mesh. Must match RHCL supported configuration.
+          SM 3.2 pairs with RHCL 1.3 per https://access.redhat.com/articles/7092611.
+      ocp_4_20_ai_maas_sm_starting_csv:
+        type: str
+        required: false
+        default: "servicemeshoperator3.v3.2.6"
+        description: Starting CSV for Service Mesh subscription (Manual approval).
+      ocp_4_20_ai_maas_sm_source:
+        type: str
+        required: false
+        default: "redhat-operators"
+        description: OLM catalog source for Service Mesh.
+      ocp_4_20_ai_maas_authorino_starting_csv:
+        type: str
+        required: false
+        default: "authorino-operator.v1.3.1"
+        description: Starting CSV for Authorino operator. Pre-created to prevent OLM auto-upgrade to v1.4.0.
+      ocp_4_20_ai_maas_limitador_starting_csv:
+        type: str
+        required: false
+        default: "limitador-operator.v1.3.1"
+        description: Starting CSV for Limitador operator. Pre-created to prevent OLM auto-upgrade to v1.4.0.
+      ocp_4_20_ai_maas_dns_starting_csv:
+        type: str
+        required: false
+        default: "dns-operator.v1.3.1"
+        description: Starting CSV for DNS operator. Pre-created to prevent OLM auto-upgrade to v1.4.0.
+      ocp_4_20_ai_maas_rhcl_starting_csv:
+        type: str
+        required: false
+        default: "rhcl-operator.v1.3.4"
+        description: >
+          Starting CSV for RHCL operator. Pinned to 1.3.4 per
+          https://access.redhat.com/articles/7092611.
+      ocp_4_20_ai_maas_rhcl_source:
+        type: str
+        required: false
+        default: "redhat-operators"
+        description: OLM catalog source for RHCL and sub-operators.
+      ocp_4_20_ai_maas_reject_version:
+        type: str
+        required: false
+        default: "v1.4.0"
+        description: Version string to reject in OLM install plan approval (SM, RHCL steps).
+      ocp_4_20_ai_maas_accept_version:
+        type: str
+        required: false
+        default: "v1.3"
+        description: >
+          Version pattern to accept in sub-operator install plan approval. OLM may
+          bundle v1.4.0 upgrades with v1.3.x installs non-deterministically; this
+          ensures plans containing v1.3.x CSVs are approved regardless.
+      ocp_4_20_ai_maas_lws_channel:
+        type: str
+        required: false
+        default: "stable-v1.0"
+        description: OLM channel for Leader Worker Set operator.
+      ocp_4_20_ai_maas_lws_source:
+        type: str
+        required: false
+        default: "redhat-operators"
+        description: OLM catalog source for Leader Worker Set.
+      ocp_4_20_ai_maas_rhoai_channel:
+        type: str
+        required: false
+        default: "stable-3.4"
+        description: OLM channel for Red Hat OpenShift AI.
+      ocp_4_20_ai_maas_rhoai_source:
+        type: str
+        required: false
+        default: "redhat-operators"
+        description: OLM catalog source for RHOAI.
+
+      # --- DSC ---
+      ocp_4_20_ai_maas_dsc_components:
+        type: dict
+        required: false
+        description: >
+          DataScienceCluster component management states. Keys are component
+          names, values are Managed or Removed.
+
+      # --- Gateway ---
+      ocp_4_20_ai_maas_gateway_hostname:
+        type: str
+        required: false
+        default: "maas"
+        description: Hostname prefix for the MaaS gateway (prepended to cluster domain).
+      ocp_4_20_ai_maas_gateway_memory_limit:
+        type: str
+        required: false
+        default: "2Gi"
+        description: Memory limit for the gateway Envoy proxy. Prevents OOMKill with Wasm plugins.
+      ocp_4_20_ai_maas_gateway_cert_name:
+        type: str
+        required: false
+        default: "router-certs"
+        description: TLS certificate Secret name in openshift-ingress for the gateway.
+
+      # --- PostgreSQL ---
+      ocp_4_20_ai_maas_db_image:
+        type: str
+        required: false
+        default: "registry.redhat.io/rhel9/postgresql-16:latest"
+        description: PostgreSQL container image for maas-api and Keycloak databases.
+      ocp_4_20_ai_maas_db_user:
+        type: str
+        required: false
+        default: "maas"
+        description: PostgreSQL username for the maas-api database.
+      ocp_4_20_ai_maas_db_password:
+        type: str
+        required: false
+        default: "maas-db-password"
+        description: PostgreSQL password for the maas-api database. Override in production.
+      ocp_4_20_ai_maas_db_name:
+        type: str
+        required: false
+        default: "maas"
+        description: PostgreSQL database name for maas-api.
+      ocp_4_20_ai_maas_db_storage:
+        type: str
+        required: false
+        default: "5Gi"
+        description: PVC storage size for the maas-api PostgreSQL database.
+
+      # --- Keycloak ---
+      ocp_4_20_ai_maas_keycloak_namespace:
+        type: str
+        required: false
+        default: "keycloak-maas"
+        description: Namespace and CR name for the Keycloak instance and its resources.
+      ocp_4_20_ai_maas_keycloak_channel:
+        type: str
+        required: false
+        default: "stable-v26.4"
+        description: OLM channel for Red Hat build of Keycloak (RHBK).
+      ocp_4_20_ai_maas_keycloak_instances:
+        type: int
+        required: false
+        default: 1
+        description: Number of Keycloak pod replicas.
+      ocp_4_20_ai_maas_keycloak_db_password:
+        type: str
+        required: false
+        default: "keycloak-db-password"
+        description: PostgreSQL password for Keycloak database. Override in production.
+      ocp_4_20_ai_maas_keycloak_db_storage:
+        type: str
+        required: false
+        default: "5Gi"
+        description: PVC storage size for the Keycloak PostgreSQL database.
+      ocp_4_20_ai_maas_keycloak_realm:
+        type: str
+        required: false
+        default: "maas"
+        description: Keycloak realm name for MaaS OIDC authentication.
+      ocp_4_20_ai_maas_keycloak_client_id:
+        type: str
+        required: false
+        default: "maas-client"
+        description: OIDC client ID registered in Keycloak for MaaS.
+      ocp_4_20_ai_maas_keycloak_client_secret:
+        type: str
+        required: false
+        default: "maas-client-secret-value"
+        description: OIDC client secret for MaaS. Override in production.
+      ocp_4_20_ai_maas_keycloak_test_password:
+        type: str
+        required: false
+        default: "password123"
+        description: Password for test users created in the Keycloak realm. Override in production.
+
+      # --- Tenant ---
+      ocp_4_20_ai_maas_tenant_name:
+        type: str
+        required: false
+        default: "default-tenant"
+        description: MaaS Tenant CR name.
+      ocp_4_20_ai_maas_api_key_max_expiration_days:
+        type: int
+        required: false
+        default: 90
+        description: Maximum API key expiration in days.
+
+      # --- Model ---
+      ocp_4_20_ai_maas_model_name:
+        type: str
+        required: false
+        default: "facebook-opt-125m-simulated"
+        description: K8s resource name for the LLMInferenceService.
+      ocp_4_20_ai_maas_model_id:
+        type: str
+        required: false
+        default: "facebook/opt-125m"
+        description: vLLM model identifier used in inference requests and container args.
+      ocp_4_20_ai_maas_model_namespace:
+        type: str
+        required: false
+        default: "llm"
+        description: Namespace where the model is deployed.
+      ocp_4_20_ai_maas_model_replicas:
+        type: int
+        required: false
+        default: 1
+        description: Number of model serving replicas.
+      ocp_4_20_ai_maas_model_image:
+        type: str
+        required: false
+        default: "ghcr.io/llm-d/llm-d-inference-sim:v0.7.1"
+        description: Container image for the model. Default is the CPU-only simulator (no GPU required).
+      ocp_4_20_ai_maas_model_uri:
+        type: str
+        required: false
+        default: "hf://sshleifer/tiny-gpt2"
+        description: Model URI. Not used by the simulator but required by LLMInferenceService spec.
+
+      # --- Subscription Tiers ---
+      ocp_4_20_ai_maas_tiers:
+        type: list
+        elements: dict
+        required: false
+        description: >
+          Subscription tiers. Each tier defines a MaaSSubscription with token
+          rate limits. Also creates Keycloak groups and test users. Each entry
+          needs name, group, token_limit, window, and priority.
+
+      # --- Monitoring ---
+      ocp_4_20_ai_maas_monitoring_retention:
+        type: str
+        required: false
+        default: "24h"
+        description: Prometheus retention period for user workload monitoring.
+
+      # --- Timeouts ---
+      ocp_4_20_ai_maas_operator_retries:
+        type: int
+        required: false
+        default: 50
+        description: Retry count for operator installation waits (at operator_delay interval).
+      ocp_4_20_ai_maas_operator_delay:
+        type: int
+        required: false
+        default: 10
+        description: Delay in seconds between operator wait retries.
+      ocp_4_20_ai_maas_long_retries:
+        type: int
+        required: false
+        default: 60
+        description: Retry count for long-running waits (RHOAI CSV, DSCI, Keycloak).
+      ocp_4_20_ai_maas_dsc_retries:
+        type: int
+        required: false
+        default: 90
+        description: Retry count for DataScienceCluster Ready wait.

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
@@ -1,0 +1,12 @@
+---
+title: OpenShift AI 4.20 Cluster with MaaS
+description: >
+  Builds an OpenShift 4.20 cluster with RHOAI 3.4, Models-as-a-Service (GA),
+  Keycloak SSO, and GPU support. Includes RHCL 1.3 version pinning for auth
+  enforcement compatibility with Service Mesh 3.2.
+template_type: cluster
+implementation_strategy: ocp_4_20_ai_maas
+default_node_request:
+  - resourceClass: dgx
+    numberOfNodes: 2
+allowed_resource_classes: []

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_maas.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_maas.yaml
@@ -1,0 +1,495 @@
+---
+# MaaS deployment: Keycloak → prereqs → enable MaaS → model → subscriptions
+# Translates design-thinking/maas/README.md Phases 1-5 into Ansible tasks.
+
+# --- Discover cluster domain ---
+
+- name: Get cluster ingress domain
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: _ingress_config
+
+- name: Set cluster domain
+  ansible.builtin.set_fact:
+    _cluster_domain: "{{ _ingress_config.resources[0].spec.domain }}"
+
+- name: Get ingress certificate name
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operator.openshift.io/v1
+    kind: IngressController
+    name: default
+    namespace: openshift-ingress-operator
+  register: _ingress_controller
+
+- name: Set certificate name
+  ansible.builtin.set_fact:
+    _cert_name: >-
+      {{ (_ingress_controller.resources[0].spec.defaultCertificate | default({})).name
+         | default(ocp_4_20_ai_maas_gateway_cert_name) }}
+
+- name: Report cluster info
+  ansible.builtin.debug:
+    msg:
+      - "Cluster domain: {{ _cluster_domain }}"
+      - "Certificate: {{ _cert_name }}"
+
+# --- Phase 1: Keycloak (conditional) ---
+
+- name: Deploy Keycloak MaaS instance
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  block:
+    - name: Apply Keycloak resources (namespace, RHBK, PostgreSQL, instance, route)
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: present
+        definition: "{{ item }}"
+      loop: "{{ lookup('ansible.builtin.template', 'keycloak.yaml.j2') | from_yaml_all | list }}"
+      loop_control:
+        label: "{{ item.kind }}/{{ item.metadata.name }}"
+      no_log: true
+      register: _r
+      retries: 5
+      delay: 10
+      until: _r is not failed
+
+    - name: Wait for Keycloak PostgreSQL
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        api_version: apps/v1
+        kind: Deployment
+        name: keycloak-postgres
+        namespace: "{{ ocp_4_20_ai_maas_keycloak_namespace }}"
+      register: _kc_pg
+      retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+      delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+      until:
+        - _kc_pg.resources | length > 0
+        - (_kc_pg.resources[0].status.availableReplicas | default(0)) > 0
+
+    - name: Wait for Keycloak instance ready
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        api_version: k8s.keycloak.org/v2alpha1
+        kind: Keycloak
+        name: "{{ ocp_4_20_ai_maas_keycloak_namespace }}"
+        namespace: "{{ ocp_4_20_ai_maas_keycloak_namespace }}"
+      register: _kc_instance
+      retries: "{{ ocp_4_20_ai_maas_long_retries }}"
+      delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+      ignore_errors: true
+      until:
+        - _kc_instance.resources is defined
+        - _kc_instance.resources | length > 0
+        - (_kc_instance.resources[0].status.conditions | default([]))
+          | selectattr('type', 'equalto', 'Ready')
+          | selectattr('status', 'equalto', 'True')
+          | list | length > 0
+
+    - name: Fail if Keycloak never became ready
+      ansible.builtin.fail:
+        msg: >-
+          Keycloak instance did not become ready after {{ ocp_4_20_ai_maas_long_retries }} retries.
+          Check that the RHBK operator is installed and the certified-operators catalog is healthy.
+      when: >-
+        _kc_instance.resources is not defined
+        or _kc_instance.resources | length == 0
+        or (_kc_instance.resources[0].status.conditions | default([])
+            | selectattr('type', 'equalto', 'Ready')
+            | selectattr('status', 'equalto', 'True')
+            | list | length) == 0
+
+    - name: Apply Keycloak realm import
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: present
+        definition: "{{ lookup('ansible.builtin.template', 'keycloak-realm-maas.yaml.j2') | from_yaml }}"
+      no_log: true
+      register: _r
+      retries: 5
+      delay: 10
+      until: _r is not failed
+
+    - name: Wait for realm import
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        api_version: k8s.keycloak.org/v2alpha1
+        kind: KeycloakRealmImport
+        name: maas-realm
+        namespace: "{{ ocp_4_20_ai_maas_keycloak_namespace }}"
+      register: _realm
+      retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+      delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+      ignore_errors: true
+      until:
+        - _realm.resources is defined
+        - _realm.resources | length > 0
+        - (_realm.resources[0].status.conditions | default([]))
+          | selectattr('type', 'equalto', 'Done')
+          | selectattr('status', 'equalto', 'True')
+          | list | length > 0
+
+    - name: Fail if realm import did not complete
+      ansible.builtin.fail:
+        msg: >-
+          Keycloak realm import did not complete after {{ ocp_4_20_ai_maas_operator_retries }} retries.
+          Check Keycloak operator logs in {{ ocp_4_20_ai_maas_keycloak_namespace }} namespace.
+      when: >-
+        _realm.resources is not defined
+        or _realm.resources | length == 0
+        or (_realm.resources[0].status.conditions | default([])
+            | selectattr('type', 'equalto', 'Done')
+            | selectattr('status', 'equalto', 'True')
+            | list | length) == 0
+
+# --- Phase 2: MaaS Prerequisites ---
+
+- name: Apply User Workload Monitoring
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ item }}"
+  loop: "{{ lookup('ansible.builtin.template', 'user-workload-monitoring.yaml.j2') | from_yaml_all | list }}"
+  loop_control:
+    label: "{{ item.kind }}/{{ item.metadata.name }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Apply Kuadrant instance
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    src: "{{ role_path }}/files/kuadrant-instance.yaml"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for Kuadrant ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: kuadrant.io/v1beta1
+    kind: Kuadrant
+    name: kuadrant
+    namespace: kuadrant-system
+  register: _kuadrant
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _kuadrant.resources is defined
+    - _kuadrant.resources | length > 0
+    - (_kuadrant.resources[0].status.conditions | default([]))
+      | selectattr('type', 'equalto', 'Ready')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+- name: Apply gateway resources ConfigMap
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', 'gateway-resources.yaml.j2') | from_yaml }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Apply maas-default-gateway
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', 'gateway.yaml.j2') | from_yaml }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for gateway Programmed
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: gateway.networking.k8s.io/v1
+    kind: Gateway
+    name: maas-default-gateway
+    namespace: openshift-ingress
+  register: _gateway
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _gateway.resources is defined
+    - _gateway.resources | length > 0
+    - (_gateway.resources[0].status.conditions | default([]))
+      | selectattr('type', 'equalto', 'Programmed')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+- name: Apply PostgreSQL for maas-api
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ item }}"
+  loop: "{{ lookup('ansible.builtin.template', 'postgres-maas.yaml.j2') | from_yaml_all | list }}"
+  loop_control:
+    label: "{{ item.kind }}/{{ item.metadata.name }}"
+  no_log: true
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for maas-postgres
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: apps/v1
+    kind: Deployment
+    name: maas-postgres
+    namespace: maas-db
+  register: _maas_pg
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _maas_pg.resources is defined
+    - _maas_pg.resources | length > 0
+    - (_maas_pg.resources[0].status.availableReplicas | default(0)) > 0
+
+- name: Create maas-db-config secret
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: maas-db-config
+        namespace: redhat-ods-applications
+      type: Opaque
+      stringData:
+        DB_CONNECTION_URL: >-
+          postgresql://{{ ocp_4_20_ai_maas_db_user }}:{{ ocp_4_20_ai_maas_db_password }}@maas-postgres.maas-db.svc.cluster.local:5432/maas?sslmode=disable
+  no_log: true
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+# --- Phase 3: Enable MaaS ---
+
+- name: Patch DSC to enable MaaS
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: datasciencecluster.opendatahub.io/v1
+      kind: DataScienceCluster
+      metadata:
+        name: default-dsc
+      spec:
+        components:
+          kserve:
+            managementState: Managed
+            modelsAsService:
+              managementState: Managed
+    merge_type: merge
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for MaaS components ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: datasciencecluster.opendatahub.io/v1
+    kind: DataScienceCluster
+    name: default-dsc
+  register: _dsc_maas
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _dsc_maas.resources is defined
+    - _dsc_maas.resources | length > 0
+    - (_dsc_maas.resources[0].status.conditions | default([]))
+      | selectattr('type', 'equalto', 'ModelsAsServiceReady')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+- name: Fail if MaaS components never became ready
+  ansible.builtin.fail:
+    msg: >-
+      MaaS components did not become ready after {{ ocp_4_20_ai_maas_operator_retries }} retries.
+      Check DSC status and RHOAI operator logs.
+  when: >-
+    _dsc_maas.resources is not defined
+    or _dsc_maas.resources | length == 0
+    or (_dsc_maas.resources[0].status.conditions | default([])
+        | selectattr('type', 'equalto', 'ModelsAsServiceReady')
+        | selectattr('status', 'equalto', 'True')
+        | list | length) == 0
+
+- name: Configure Tenant CR
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: maas.opendatahub.io/v1alpha1
+      kind: Tenant
+      metadata:
+        name: "{{ ocp_4_20_ai_maas_tenant_name }}"
+        namespace: models-as-a-service
+      spec:
+        gatewayRef:
+          namespace: openshift-ingress
+          name: maas-default-gateway
+        externalOIDC: >-
+          {{ {'issuerUrl': 'https://' + ocp_4_20_ai_maas_keycloak_namespace + '.' + _cluster_domain + '/realms/' + ocp_4_20_ai_maas_keycloak_realm,
+              'clientId': ocp_4_20_ai_maas_keycloak_client_id}
+             if ocp_4_20_ai_maas_enable_keycloak else omit }}
+        apiKeys:
+          maxExpirationDays: "{{ ocp_4_20_ai_maas_api_key_max_expiration_days }}"
+        telemetry:
+          enabled: true
+    merge_type: merge
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for Tenant Active
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: Tenant
+    name: "{{ ocp_4_20_ai_maas_tenant_name }}"
+    namespace: models-as-a-service
+  register: _tenant
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _tenant.resources is defined
+    - _tenant.resources | length > 0
+    - _tenant.resources[0].status.phase | default('') == 'Active'
+
+# --- Phase 4: Deploy Model ---
+
+- name: Create model namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ ocp_4_20_ai_maas_model_namespace }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Deploy LLMInferenceService
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', 'model.yaml.j2') | from_yaml }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for LLMInferenceService Ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: serving.kserve.io/v1alpha2
+    kind: LLMInferenceService
+    name: "{{ ocp_4_20_ai_maas_model_name }}"
+    namespace: "{{ ocp_4_20_ai_maas_model_namespace }}"
+  register: _llm
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _llm.resources is defined
+    - _llm.resources | length > 0
+    - (_llm.resources[0].status.conditions | default([]))
+      | selectattr('type', 'equalto', 'Ready')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+- name: Create MaaSModelRef
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', 'maas-model-ref.yaml.j2') | from_yaml }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for MaaSModelRef Ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: MaaSModelRef
+    name: "{{ ocp_4_20_ai_maas_model_name }}"
+    namespace: "{{ ocp_4_20_ai_maas_model_namespace }}"
+  register: _modelref
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _modelref.resources is defined
+    - _modelref.resources | length > 0
+    - _modelref.resources[0].status.phase | default('') == 'Ready'
+
+# --- Phase 5: Auth Policies + Subscriptions ---
+
+- name: Create MaaSAuthPolicy
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ lookup('ansible.builtin.template', 'maas-auth-policy.yaml.j2') | from_yaml }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Create MaaSSubscriptions
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ item }}"
+  loop: "{{ lookup('ansible.builtin.template', 'maas-subscriptions.yaml.j2') | from_yaml_all | list }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for auto-generated AuthPolicy
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: kuadrant.io/v1
+    kind: AuthPolicy
+    namespace: "{{ ocp_4_20_ai_maas_model_namespace }}"
+  register: _auth_policy
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _auth_policy.resources is defined
+    - _auth_policy.resources | length > 0
+
+- name: Report MaaS configuration complete
+  ansible.builtin.debug:
+    msg:
+      - "MaaS deployment complete"
+      - "Gateway: https://{{ ocp_4_20_ai_maas_gateway_hostname }}.{{ _cluster_domain }}"
+      - "Model: {{ ocp_4_20_ai_maas_model_name }}"
+      - "Tiers: {{ ocp_4_20_ai_maas_tiers | map(attribute='name') | join(', ') }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
@@ -1,0 +1,163 @@
+---
+# Undeploy MaaS resources, then delegate cluster deletion to the parent template.
+# This only removes MaaS-specific resources (Tenant, subscriptions, model, Keycloak,
+# gateway, PostgreSQL). Operators are NOT removed — in the OSAC pipeline, the cluster
+# itself is deleted after this step, which removes everything.
+
+- name: Remove MaaS subscriptions
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition: "{{ item }}"
+  loop: "{{ lookup('ansible.builtin.template', 'maas-subscriptions.yaml.j2') | from_yaml_all | list }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+  ignore_errors: true
+
+- name: Remove MaaSAuthPolicy
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition: "{{ lookup('ansible.builtin.template', 'maas-auth-policy.yaml.j2') | from_yaml }}"
+  ignore_errors: true
+
+- name: Remove MaaSModelRef
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition: "{{ lookup('ansible.builtin.template', 'maas-model-ref.yaml.j2') | from_yaml }}"
+  ignore_errors: true
+
+- name: Remove LLMInferenceService
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition: "{{ lookup('ansible.builtin.template', 'model.yaml.j2') | from_yaml }}"
+  ignore_errors: true
+
+- name: Remove model namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ ocp_4_20_ai_maas_model_namespace }}"
+  ignore_errors: true
+
+- name: Remove Tenant CR
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition:
+      apiVersion: maas.opendatahub.io/v1alpha1
+      kind: Tenant
+      metadata:
+        name: "{{ ocp_4_20_ai_maas_tenant_name }}"
+        namespace: models-as-a-service
+  ignore_errors: true
+
+- name: Disable MaaS in DSC
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: datasciencecluster.opendatahub.io/v1
+      kind: DataScienceCluster
+      metadata:
+        name: default-dsc
+      spec:
+        components:
+          kserve:
+            modelsAsService:
+              managementState: Removed
+    merge_type: merge
+  ignore_errors: true
+
+- name: Remove maas-db-config secret
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: maas-db-config
+        namespace: redhat-ods-applications
+  ignore_errors: true
+
+- name: Remove PostgreSQL
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition: "{{ item }}"
+  loop: "{{ lookup('ansible.builtin.template', 'postgres-maas.yaml.j2') | from_yaml_all | list }}"
+  loop_control:
+    label: "{{ item.kind }}/{{ item.metadata.name }}"
+  no_log: true
+  ignore_errors: true
+
+- name: Remove maas-default-gateway
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition:
+      apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      metadata:
+        name: maas-default-gateway
+        namespace: openshift-ingress
+  ignore_errors: true
+
+- name: Remove gateway resources
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition: "{{ lookup('ansible.builtin.template', 'gateway-resources.yaml.j2') | from_yaml }}"
+  ignore_errors: true
+
+- name: Remove Kuadrant
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    src: "{{ role_path }}/files/kuadrant-instance.yaml"
+  ignore_errors: true
+
+- name: Remove monitoring config
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition: "{{ item }}"
+  loop: "{{ lookup('ansible.builtin.template', 'user-workload-monitoring.yaml.j2') | from_yaml_all | list }}"
+  loop_control:
+    label: "{{ item.kind }}/{{ item.metadata.name }}"
+  ignore_errors: true
+
+- name: Remove Keycloak namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ ocp_4_20_ai_maas_keycloak_namespace }}"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+- name: Remove models-as-a-service namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: models-as-a-service
+  ignore_errors: true
+
+- name: Delete cluster (delegate to parent)
+  ansible.builtin.include_role:
+    name: osac.templates.ocp_4_17_small
+    tasks_from: delete

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install.yaml
@@ -1,0 +1,14 @@
+---
+# Entry point: creates an OpenShift cluster with RHOAI + MaaS.
+# Delegates cluster creation to ocp_4_17_small and overrides the
+# post-install hook to install operators and configure MaaS.
+
+- name: Create cluster with RHOAI + MaaS post-install
+  ansible.builtin.include_role:
+    name: osac.templates.ocp_4_17_small
+    tasks_from: install
+  vars:
+    ocp_release_image: "{{ ocp_4_20_ai_maas_ocp_release_image }}"
+    install_step_post_install_hook_override:
+      name: osac.templates.ocp_4_20_ai_maas
+      tasks_from: post_install.yaml

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
@@ -99,11 +99,12 @@
         - _cert_manager_sub.resources[0].status.installedCSV is defined
 
 # --- Step 2: Service Mesh 3.2 (MUST be before RHCL) ---
-# OCP Ingress Operator pre-creates a SM subscription on 'stable' channel and
-# continuously reconciles it (via ingress.operator.openshift.io/owned annotation).
-# We must scale down the Ingress Operator, replace the subscription without the
-# owned annotation, then scale it back up. Without this, any channel/CSV change
-# is overwritten within seconds.
+# TEMPORARY WORKAROUND: OCP Ingress Operator pre-creates a SM subscription on
+# 'stable' channel and continuously reconciles it (ingress.operator.openshift.io/owned).
+# We scale down the Ingress Operator for the entire operator install phase, replace
+# the subscription without the owned annotation, then scale it back up at the end.
+# Remove once RHCL v1.4.0 compatibility with SM is resolved and SM version pinning
+# is no longer needed. See: https://access.redhat.com/solutions/7097633
 
 - name: Scale down Ingress Operator (prevents SM subscription override)
   kubernetes.core.k8s:
@@ -193,6 +194,11 @@
   when: "'v3.2' not in item.metadata.name"
   ignore_errors: true
 
+# TEMPORARY WORKAROUND: RHCL v1.4.0 breaks MaaS auth enforcement (Envoy
+# allow_on_headers_stop_iteration not supported by SM 3.2/3.3). Tasks from here
+# through "Approve install plans and wait for RHCL CSV" implement a two-pass
+# install plan approval strategy to pin RHCL at v1.3.x. Remove once RHCL v1.4.0
+# compatibility with SM is resolved. See: https://access.redhat.com/solutions/7097633
 - name: Clear stale installedCSV from SM subscription
   environment:
     KUBECONFIG: "{{ admin_kubeconfig }}"
@@ -247,6 +253,9 @@
   changed_when: false
 
 # --- Step 3: Pre-create sub-operator subscriptions (v1.3.x, Manual) ---
+# TEMPORARY WORKAROUND (continued): Pre-creating sub-operator subscriptions with
+# Manual approval and startingCSV pins them to v1.3.1 before RHCL creates its own.
+# Remove once RHCL v1.4.0 compatibility is resolved.
 
 - name: Pre-create Authorino Subscription (v1.3.1, Manual)
   kubernetes.core.k8s:
@@ -314,6 +323,8 @@
   delay: 10
   until: _r is not failed
 
+# TEMPORARY WORKAROUND (continued): Two-pass install plan approval — approve
+# v1.3.x-only plans, delete v1.4.0-bundled plans so OLM regenerates clean ones.
 - name: Approve install plans and wait for sub-operator CSVs
   environment:
     KUBECONFIG: "{{ admin_kubeconfig }}"
@@ -375,6 +386,8 @@
   delay: 10
   until: _r is not failed
 
+# TEMPORARY WORKAROUND (continued): Final pass — approve remaining v1.3.x plans
+# for RHCL itself. End of RHCL version pinning workaround block.
 - name: Approve install plans and wait for RHCL CSV
   environment:
     KUBECONFIG: "{{ admin_kubeconfig }}"
@@ -629,6 +642,7 @@
     or _dsc.resources | length == 0
     or _dsc.resources[0].status.phase | default('') != 'Ready'
 
+# TEMPORARY WORKAROUND (end): Restore Ingress Operator after version-pinned install.
 - name: Scale up Ingress Operator
   kubernetes.core.k8s:
     kubeconfig: "{{ admin_kubeconfig }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
@@ -1,0 +1,646 @@
+---
+# BOM Phase 2: Install platform operators with RHCL 1.3.x version pinning.
+# Critical ordering: cert-manager → SM 3.2 → sub-operators → RHCL → LWS → RHOAI → DSC
+# SM must be installed BEFORE RHCL subscriptions exist to prevent OLM bundling v1.4.0 upgrades.
+
+- name: Validate shell-interpolated variables (prevent injection)
+  ansible.builtin.assert:
+    that:
+      - ocp_4_20_ai_maas_reject_version is regex('^v[\d.]+$')
+      - ocp_4_20_ai_maas_accept_version is regex('^v[\d.]+$')
+      - ocp_4_20_ai_maas_authorino_starting_csv is regex('^[\w.\-]+$')
+      - ocp_4_20_ai_maas_limitador_starting_csv is regex('^[\w.\-]+$')
+      - ocp_4_20_ai_maas_dns_starting_csv is regex('^[\w.\-]+$')
+      - ocp_4_20_ai_maas_rhcl_starting_csv is regex('^[\w.\-]+$')
+      - ocp_4_20_ai_maas_sm_starting_csv is regex('^[\w.\-]+$')
+    fail_msg: "Shell-interpolated variables contain invalid characters"
+
+# --- Step 1: cert-manager ---
+# RHCL 1.3 requires cert-manager 1.18 per https://access.redhat.com/articles/7092611
+# Parent template may already install cert-manager; skip if found.
+
+- name: Check if cert-manager is already installed
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: cert-manager-operator
+    label_selectors:
+      - "operators.coreos.com/openshift-cert-manager-operator.cert-manager-operator"
+  register: _cert_manager_csv
+  ignore_errors: true
+
+- name: Install cert-manager
+  when: (_cert_manager_csv.resources | default([])) | length == 0
+  block:
+    - name: Create cert-manager namespace
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: cert-manager-operator
+      register: _r
+      retries: 5
+      delay: 10
+      until: _r is not failed
+
+    - name: Create cert-manager OperatorGroup
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: operators.coreos.com/v1
+          kind: OperatorGroup
+          metadata:
+            name: cert-manager-operator
+            namespace: cert-manager-operator
+          spec: {}
+      register: _r
+      retries: 5
+      delay: 10
+      until: _r is not failed
+
+    - name: Create cert-manager Subscription
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: openshift-cert-manager-operator
+            namespace: cert-manager-operator
+          spec:
+            channel: "{{ ocp_4_20_ai_maas_cert_manager_channel }}"
+            installPlanApproval: Automatic
+            name: openshift-cert-manager-operator
+            source: "{{ ocp_4_20_ai_maas_cert_manager_source }}"
+            sourceNamespace: openshift-marketplace
+      register: _r
+      retries: 5
+      delay: 10
+      until: _r is not failed
+
+    - name: Wait for cert-manager CSV
+      kubernetes.core.k8s_info:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        api_version: operators.coreos.com/v1alpha1
+        kind: Subscription
+        name: openshift-cert-manager-operator
+        namespace: cert-manager-operator
+      register: _cert_manager_sub
+      retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+      delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+      until:
+        - _cert_manager_sub.resources | length > 0
+        - _cert_manager_sub.resources[0].status.installedCSV is defined
+
+# --- Step 2: Service Mesh 3.2 (MUST be before RHCL) ---
+# OCP Ingress Operator pre-creates a SM subscription on 'stable' channel and
+# continuously reconciles it (via ingress.operator.openshift.io/owned annotation).
+# We must scale down the Ingress Operator, replace the subscription without the
+# owned annotation, then scale it back up. Without this, any channel/CSV change
+# is overwritten within seconds.
+
+- name: Scale down Ingress Operator (prevents SM subscription override)
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ingress-operator
+        namespace: openshift-ingress-operator
+      spec:
+        replicas: 0
+    merge_type: merge
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for Ingress Operator to stop
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: apps/v1
+    kind: Deployment
+    name: ingress-operator
+    namespace: openshift-ingress-operator
+  register: _ingress_op
+  retries: 6
+  delay: 5
+  until:
+    - _ingress_op.resources | length > 0
+    - (_ingress_op.resources[0].status.replicas | default(0)) == 0
+
+- name: Delete Ingress Operator SM subscription
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: servicemeshoperator3
+    namespace: openshift-operators
+  ignore_errors: true
+
+- name: Create Service Mesh Subscription (stable-3.2, Manual, no owned annotation)
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: servicemeshoperator3
+        namespace: openshift-operators
+      spec:
+        channel: "{{ ocp_4_20_ai_maas_sm_channel }}"
+        installPlanApproval: Manual
+        name: servicemeshoperator3
+        source: "{{ ocp_4_20_ai_maas_sm_source }}"
+        sourceNamespace: openshift-marketplace
+        startingCSV: "{{ ocp_4_20_ai_maas_sm_starting_csv }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Find stale SM CSVs (not v3.2.x)
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: openshift-operators
+    label_selectors:
+      - "operators.coreos.com/servicemeshoperator3.openshift-operators"
+  register: _sm_stale_csvs
+
+- name: Delete stale SM CSVs
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ item.metadata.name }}"
+    namespace: openshift-operators
+  loop: "{{ _sm_stale_csvs.resources | default([]) }}"
+  loop_control:
+    label: "{{ item.metadata.name }}"
+  when: "'v3.2' not in item.metadata.name"
+  ignore_errors: true
+
+- name: Clear stale installedCSV from SM subscription
+  ansible.builtin.shell: |
+    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    oc patch sub servicemeshoperator3 -n openshift-operators --type merge \
+      --subresource status -p '{"status":{"installedCSV":"","currentCSV":""}}' 2>/dev/null || true
+  args:
+    executable: /bin/bash
+  changed_when: false
+
+- name: Delete stale SM install plans
+  ansible.builtin.shell: |
+    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    oc get installplan -n openshift-operators -o json 2>/dev/null | \
+      jq -r '.items[] | select(.spec.clusterServiceVersionNames | join(",") | test("servicemeshoperator3")) |
+        select(.spec.clusterServiceVersionNames | join(",") | test("v3\\.2") | not) |
+        .metadata.name' 2>/dev/null | \
+      while read -r plan; do
+        oc delete installplan "$plan" -n openshift-operators 2>/dev/null || true
+      done || true
+  args:
+    executable: /bin/bash
+  changed_when: false
+
+- name: Approve install plans and wait for SM CSV
+  ansible.builtin.shell: |
+    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    # Approve unapproved install plans that do not contain the reject version
+    oc get installplan -n openshift-operators -o json 2>/dev/null | \
+      jq -r '.items[] | select(.spec.approved == false) |
+        select((.spec.clusterServiceVersionNames | join(",") | contains("{{ ocp_4_20_ai_maas_reject_version }}")) | not) |
+        .metadata.name' 2>/dev/null | \
+      while read -r plan; do
+        oc patch installplan "$plan" -n openshift-operators \
+          --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
+      done || true
+    # Check SM CSV is Succeeded (any version via label selector)
+    oc get csv -n openshift-operators \
+      -l operators.coreos.com/servicemeshoperator3.openshift-operators \
+      -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Succeeded
+  args:
+    executable: /bin/bash
+  register: _sm_result
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until: _sm_result.rc == 0
+  changed_when: false
+
+# --- Step 3: Pre-create sub-operator subscriptions (v1.3.x, Manual) ---
+
+- name: Pre-create Authorino Subscription (v1.3.1, Manual)
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: authorino-operator
+        namespace: openshift-operators
+      spec:
+        channel: stable
+        installPlanApproval: Manual
+        name: authorino-operator
+        source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
+        sourceNamespace: openshift-marketplace
+        startingCSV: "{{ ocp_4_20_ai_maas_authorino_starting_csv }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Pre-create Limitador Subscription (v1.3.1, Manual)
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: limitador-operator
+        namespace: openshift-operators
+      spec:
+        channel: stable
+        installPlanApproval: Manual
+        name: limitador-operator
+        source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
+        sourceNamespace: openshift-marketplace
+        startingCSV: "{{ ocp_4_20_ai_maas_limitador_starting_csv }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Pre-create DNS Subscription (v1.3.1, Manual)
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: dns-operator
+        namespace: openshift-operators
+      spec:
+        channel: stable
+        installPlanApproval: Manual
+        name: dns-operator
+        source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
+        sourceNamespace: openshift-marketplace
+        startingCSV: "{{ ocp_4_20_ai_maas_dns_starting_csv }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Approve install plans and wait for sub-operator CSVs
+  ansible.builtin.shell: |
+    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    # Approve plans without v1.4.0, then delete unapproved v1.4.0 upgrade plans
+    # so OLM creates fresh plans for any remaining v1.3.x CSVs without bundling.
+    oc get installplan -n openshift-operators -o json 2>/dev/null | \
+      jq -r '.items[] | select(.spec.approved == false) |
+        select((.spec.clusterServiceVersionNames | join(",") | contains("{{ ocp_4_20_ai_maas_reject_version }}")) | not) |
+        .metadata.name' 2>/dev/null | \
+      while read -r plan; do
+        oc patch installplan "$plan" -n openshift-operators \
+          --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
+      done || true
+    # Delete unapproved plans containing v1.4.0 to prevent bundling
+    oc get installplan -n openshift-operators -o json 2>/dev/null | \
+      jq -r '.items[] | select(.spec.approved == false) |
+        select((.spec.clusterServiceVersionNames | join(",") | contains("{{ ocp_4_20_ai_maas_reject_version }}"))) |
+        .metadata.name' 2>/dev/null | \
+      while read -r plan; do
+        oc delete installplan "$plan" -n openshift-operators 2>/dev/null || true
+      done || true
+    oc get csv "{{ ocp_4_20_ai_maas_authorino_starting_csv }}" -n openshift-operators \
+      -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Succeeded || exit 1
+    oc get csv "{{ ocp_4_20_ai_maas_limitador_starting_csv }}" -n openshift-operators \
+      -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Succeeded || exit 1
+    oc get csv "{{ ocp_4_20_ai_maas_dns_starting_csv }}" -n openshift-operators \
+      -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Succeeded || exit 1
+  args:
+    executable: /bin/bash
+  register: _sub_op_result
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until: _sub_op_result.rc == 0
+  changed_when: false
+
+# --- Step 4: RHCL operator (v1.3.4, Manual) ---
+
+- name: Create RHCL Subscription (v1.3.4, Manual)
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: rhcl-operator
+        namespace: openshift-operators
+      spec:
+        channel: stable
+        installPlanApproval: Manual
+        name: rhcl-operator
+        source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
+        sourceNamespace: openshift-marketplace
+        startingCSV: "{{ ocp_4_20_ai_maas_rhcl_starting_csv }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Approve install plans and wait for RHCL CSV
+  ansible.builtin.shell: |
+    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    # Approve unapproved install plans that do not contain the reject version
+    oc get installplan -n openshift-operators -o json 2>/dev/null | \
+      jq -r '.items[] | select(.spec.approved == false) |
+        select((.spec.clusterServiceVersionNames | join(",") | contains("{{ ocp_4_20_ai_maas_reject_version }}")) | not) |
+        .metadata.name' 2>/dev/null | \
+      while read -r plan; do
+        oc patch installplan "$plan" -n openshift-operators \
+          --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
+      done || true
+    # Check RHCL CSV is Succeeded (any version via label selector)
+    oc get csv -n openshift-operators \
+      -l operators.coreos.com/rhcl-operator.openshift-operators \
+      -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Succeeded
+  args:
+    executable: /bin/bash
+  register: _rhcl_result
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until: _rhcl_result.rc == 0
+  changed_when: false
+
+# --- Step 5: Leader Worker Set ---
+
+- name: Create LWS namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-lws-operator
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Create LWS OperatorGroup
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: openshift-lws-operator
+        namespace: openshift-lws-operator
+      spec:
+        targetNamespaces:
+          - openshift-lws-operator
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Create LWS Subscription
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: leader-worker-set
+        namespace: openshift-lws-operator
+      spec:
+        channel: "{{ ocp_4_20_ai_maas_lws_channel }}"
+        installPlanApproval: Automatic
+        name: leader-worker-set
+        source: "{{ ocp_4_20_ai_maas_lws_source }}"
+        sourceNamespace: openshift-marketplace
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for LWS CSV
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: leader-worker-set
+    namespace: openshift-lws-operator
+  register: _lws_sub
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until:
+    - _lws_sub.resources | length > 0
+    - _lws_sub.resources[0].status.installedCSV is defined
+
+# --- Step 6: RHOAI 3.4 ---
+
+- name: Create RHOAI namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: redhat-ods-operator
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Create RHOAI OperatorGroup
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: redhat-ods-operator
+        namespace: redhat-ods-operator
+      spec: {}
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Create RHOAI Subscription
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: rhods-operator
+        namespace: redhat-ods-operator
+      spec:
+        channel: "{{ ocp_4_20_ai_maas_rhoai_channel }}"
+        installPlanApproval: Automatic
+        name: rhods-operator
+        source: "{{ ocp_4_20_ai_maas_rhoai_source }}"
+        sourceNamespace: openshift-marketplace
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for RHOAI CSV
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: rhods-operator
+    namespace: redhat-ods-operator
+  register: _rhoai_sub
+  retries: "{{ ocp_4_20_ai_maas_long_retries }}"
+  delay: 10
+  until:
+    - _rhoai_sub.resources | length > 0
+    - _rhoai_sub.resources[0].status.installedCSV is defined
+
+# --- Step 7: DSCInitialization + DataScienceCluster ---
+
+- name: Wait for DSCInitialization to be ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: dscinitialization.opendatahub.io/v1
+    kind: DSCInitialization
+    name: default-dsci
+  register: _dsci
+  retries: "{{ ocp_4_20_ai_maas_long_retries }}"
+  delay: 10
+  ignore_errors: true
+  until:
+    - _dsci.resources is defined
+    - _dsci.resources | length > 0
+    - _dsci.resources[0].status.phase | default('') == 'Ready'
+
+- name: Fail if DSCInitialization never became ready
+  ansible.builtin.fail:
+    msg: >-
+      DSCInitialization did not become ready after {{ ocp_4_20_ai_maas_long_retries }} retries.
+      Check that the RHOAI operator is installed and running.
+  when: >-
+    _dsci.resources is not defined
+    or _dsci.resources | length == 0
+    or _dsci.resources[0].status.phase | default('') != 'Ready'
+
+- name: Wait for RHOAI webhook endpoints ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: v1
+    kind: Endpoints
+    name: rhods-operator-service
+    namespace: redhat-ods-operator
+  register: _webhook_ep
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until:
+    - _webhook_ep.resources | length > 0
+    - (_webhook_ep.resources[0].subsets | default([])) | length > 0
+
+- name: Build DSC components spec
+  ansible.builtin.set_fact:
+    _dsc_components: >-
+      {{ dict(ocp_4_20_ai_maas_dsc_components | dict2items
+         | map(attribute='key') | list
+         | zip(ocp_4_20_ai_maas_dsc_components | dict2items
+               | map(attribute='value')
+               | map('community.general.dict_kv', 'managementState')
+               | list)) }}
+
+- name: Create DataScienceCluster
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: datasciencecluster.opendatahub.io/v1
+      kind: DataScienceCluster
+      metadata:
+        name: default-dsc
+      spec:
+        components: "{{ _dsc_components }}"
+  register: _dsc_create
+  retries: 12
+  delay: 10
+  until: _dsc_create is not failed
+
+- name: Wait for DataScienceCluster Ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: datasciencecluster.opendatahub.io/v1
+    kind: DataScienceCluster
+    name: default-dsc
+  register: _dsc
+  retries: "{{ ocp_4_20_ai_maas_dsc_retries }}"
+  delay: 10
+  ignore_errors: true
+  until:
+    - _dsc.resources is defined
+    - _dsc.resources | length > 0
+    - _dsc.resources[0].status.phase | default('') == 'Ready'
+
+- name: Fail if DataScienceCluster never became ready
+  ansible.builtin.fail:
+    msg: >-
+      DataScienceCluster did not become ready after {{ ocp_4_20_ai_maas_dsc_retries }} retries.
+      Check RHOAI operator logs and webhook service status.
+  when: >-
+    _dsc.resources is not defined
+    or _dsc.resources | length == 0
+    or _dsc.resources[0].status.phase | default('') != 'Ready'
+
+- name: Scale up Ingress Operator
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ingress-operator
+        namespace: openshift-ingress-operator
+      spec:
+        replicas: 1
+    merge_type: merge
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Report operator installation complete
+  ansible.builtin.debug:
+    msg:
+      - "BOM Phase 2 complete — all operators installed"
+      - "SM: {{ ocp_4_20_ai_maas_sm_starting_csv }}"
+      - "RHCL: {{ ocp_4_20_ai_maas_rhcl_starting_csv }}"
+      - "DSC: Ready"

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/noop.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/noop.yaml
@@ -1,0 +1,5 @@
+---
+- name: No-op placeholder for hook overrides
+  ansible.builtin.debug:
+    msg: "No-op hook — no action taken"
+  changed_when: false

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
@@ -1,0 +1,25 @@
+---
+# Post-install hook: called by ocp_4_17_small after cluster is provisioned.
+# Orchestrates: operator installation → MaaS configuration → verification.
+# Uses admin_kubeconfig from the parent pipeline (retrieved at step 5).
+
+- name: Verify admin_kubeconfig is available
+  ansible.builtin.assert:
+    that:
+      - admin_kubeconfig is defined
+      - admin_kubeconfig | length > 0
+    fail_msg: >-
+      admin_kubeconfig is not set. In production, this is provided by the
+      ocp_4_17_small pipeline. For local testing, set KUBECONFIG env var
+      or pass admin_kubeconfig as a playbook variable.
+
+- name: Install platform operators (BOM Phase 2 + 3)
+  ansible.builtin.include_tasks: install_operators.yaml
+
+- name: Configure MaaS platform (Phases 1-5)
+  ansible.builtin.include_tasks: configure_maas.yaml
+  when: ocp_4_20_ai_maas_enable_maas | default(true)
+
+- name: Run verification smoke tests
+  ansible.builtin.include_tasks: verify.yaml
+  when: ocp_4_20_ai_maas_run_verify | default(true)

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
@@ -136,6 +136,8 @@
     namespace: openshift-operators
   register: _all_csvs
 
+# TEMPORARY WORKAROUND: Remove this assertion once RHCL v1.4.0 compatibility
+# with SM is resolved and version pinning is no longer needed.
 - name: Assert no v1.4.0 CSVs installed
   ansible.builtin.assert:
     that:

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
@@ -1,0 +1,219 @@
+---
+# Smoke tests: auth enforcement, API key creation, inference, version pinning.
+
+- name: Get cluster ingress domain (if not already set)
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: _verify_ingress
+  when: _cluster_domain is not defined
+
+- name: Set cluster domain from ingress
+  ansible.builtin.set_fact:
+    _cluster_domain: "{{ _verify_ingress.resources[0].spec.domain }}"
+  when: _cluster_domain is not defined
+
+- name: Set MaaS API URL
+  ansible.builtin.set_fact:
+    _maas_api_url: "https://{{ ocp_4_20_ai_maas_gateway_hostname }}.{{ _cluster_domain }}"
+    _keycloak_url: "https://{{ ocp_4_20_ai_maas_keycloak_namespace }}.{{ _cluster_domain }}"
+
+- name: Derive test users from tiers
+  ansible.builtin.set_fact:
+    _premium_tier: "{{ ocp_4_20_ai_maas_tiers | selectattr('priority', 'greaterthan', 0) | first }}"
+    _free_tier: "{{ ocp_4_20_ai_maas_tiers | selectattr('priority', 'equalto', 0) | first }}"
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+# --- Test 1: Unauthenticated inference must return 401 ---
+
+- name: Test unauthenticated inference (expect 401)
+  ansible.builtin.uri:
+    url: "{{ _maas_api_url }}/llm/{{ ocp_4_20_ai_maas_model_name }}/v1/chat/completions"
+    method: POST
+    body_format: json
+    body:
+      model: "{{ ocp_4_20_ai_maas_model_id }}"
+      messages:
+        - role: user
+          content: "Hello"
+      max_tokens: 10
+    status_code:
+      - 401
+      - 403
+    validate_certs: false
+  register: _unauth_test
+
+- name: Report auth enforcement
+  ansible.builtin.debug:
+    msg: "Auth enforcement: HTTP {{ _unauth_test.status }} (401=auth rejected, 403=OPA denied — both confirm enforcement)"
+
+# --- Test 2: API key creation with Keycloak JWT ---
+
+- name: Get Keycloak JWT
+  ansible.builtin.uri:
+    url: "{{ _keycloak_url }}/realms/{{ ocp_4_20_ai_maas_keycloak_realm }}/protocol/openid-connect/token"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      client_id: "{{ ocp_4_20_ai_maas_keycloak_client_id }}"
+      client_secret: "{{ ocp_4_20_ai_maas_keycloak_client_secret }}"
+      username: "testuser-{{ _premium_tier.name | regex_replace('-subscription$', '') }}"
+      password: "{{ ocp_4_20_ai_maas_keycloak_test_password }}"
+      grant_type: password
+    validate_certs: false
+  no_log: true
+  register: _jwt_response
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+- name: Create API key
+  ansible.builtin.uri:
+    url: "{{ _maas_api_url }}/maas-api/v1/api-keys"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _jwt_response.json.access_token }}"
+    body_format: json
+    body:
+      name: verify-key
+      description: Automated verification
+    status_code: 201
+    validate_certs: false
+  no_log: true
+  register: _api_key_response
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+- name: Report API key creation
+  ansible.builtin.debug:
+    msg: "API key created: {{ _api_key_response.json.keyPrefix | default('N/A') }} subscription={{ _api_key_response.json.subscription | default('N/A') }}"
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+# --- Test 3: Inference with API key ---
+
+- name: Test inference with API key
+  ansible.builtin.uri:
+    url: "{{ _maas_api_url }}/llm/{{ ocp_4_20_ai_maas_model_name }}/v1/chat/completions"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _api_key_response.json.key }}"
+    body_format: json
+    body:
+      model: "{{ ocp_4_20_ai_maas_model_id }}"
+      messages:
+        - role: user
+          content: "Hello"
+      max_tokens: 10
+    status_code:
+      - 200
+      - 403
+    validate_certs: false
+  no_log: true
+  register: _inference_test
+  retries: 6
+  delay: 10
+  until: _inference_test.status == 200
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+- name: Fail if inference never succeeded
+  ansible.builtin.fail:
+    msg: "Inference test failed — last status {{ _inference_test.status }}. Auth pipeline may not be ready."
+  when:
+    - ocp_4_20_ai_maas_enable_keycloak | default(true)
+    - _inference_test.status != 200
+
+- name: Report inference
+  ansible.builtin.debug:
+    msg: "Inference: HTTP {{ _inference_test.status }} tokens={{ _inference_test.json.usage.total_tokens | default('?') }}"
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+# --- Test 4: Version pinning ---
+
+- name: Check RHCL operator versions
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    namespace: openshift-operators
+  register: _all_csvs
+
+- name: Assert no v1.4.0 CSVs installed
+  ansible.builtin.assert:
+    that:
+      - _all_csvs.resources | selectattr('metadata.name', 'search', 'v1.4.0') | list | length == 0
+    fail_msg: "RHCL v1.4.0 detected — version pinning failed"
+    success_msg: "All RHCL operators at v1.3.x — version pinning held"
+
+# --- Test 5: Token rate limiting (free tier) ---
+
+- name: Get free-tier Keycloak JWT
+  ansible.builtin.uri:
+    url: "{{ _keycloak_url }}/realms/{{ ocp_4_20_ai_maas_keycloak_realm }}/protocol/openid-connect/token"
+    method: POST
+    body_format: form-urlencoded
+    body:
+      client_id: "{{ ocp_4_20_ai_maas_keycloak_client_id }}"
+      client_secret: "{{ ocp_4_20_ai_maas_keycloak_client_secret }}"
+      username: "testuser-{{ _free_tier.name | regex_replace('-subscription$', '') }}"
+      password: "{{ ocp_4_20_ai_maas_keycloak_test_password }}"
+      grant_type: password
+    validate_certs: false
+  no_log: true
+  register: _free_jwt
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+- name: Create free-tier API key
+  ansible.builtin.uri:
+    url: "{{ _maas_api_url }}/maas-api/v1/api-keys"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _free_jwt.json.access_token }}"
+    body_format: json
+    body:
+      name: verify-free-key
+      description: Rate limit verification
+    status_code: 201
+    validate_certs: false
+  no_log: true
+  register: _free_key_response
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+- name: Send requests to exhaust free tier (100 tokens/min)
+  ansible.builtin.uri:
+    url: "{{ _maas_api_url }}/llm/{{ ocp_4_20_ai_maas_model_name }}/v1/chat/completions"
+    method: POST
+    headers:
+      Authorization: "Bearer {{ _free_key_response.json.key }}"
+    body_format: json
+    body:
+      model: "{{ ocp_4_20_ai_maas_model_id }}"
+      messages:
+        - role: user
+          content: "Tell me a long story about dragons and knights in a magical kingdom far away"
+      max_tokens: 50
+    status_code:
+      - 200
+      - 429
+    validate_certs: false
+  no_log: true
+  register: _rate_limit_results
+  loop: "{{ range(1, 11) | list }}"
+  loop_control:
+    label: "request {{ item }}"
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+- name: Assert rate limiting was enforced
+  ansible.builtin.assert:
+    that:
+      - _rate_limit_results.results | selectattr('status', 'equalto', 429) | list | length > 0
+    fail_msg: "Rate limiting NOT enforced — no 429 responses in 10 requests"
+    success_msg: >-
+      Rate limiting enforced — {{ _rate_limit_results.results
+      | selectattr('status', 'equalto', 429) | list | length }} of 10 requests returned 429
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+
+- name: Report verification complete
+  ansible.builtin.debug:
+    msg: >-
+      All verification tests passed —
+      Auth: {{ _unauth_test.status }},
+      {{ 'API key: created, Inference: 200, Rate limiting: 429, ' if (ocp_4_20_ai_maas_enable_keycloak | default(true)) else '' }}Versions: all v1.3.x pinned

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/gateway-resources.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/gateway-resources.yaml.j2
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maas-gateway-options
+  namespace: openshift-ingress
+data:
+  deployment: |
+    spec:
+      template:
+        spec:
+          containers:
+          - name: istio-proxy
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                cpu: "2"
+                memory: "{{ ocp_4_20_ai_maas_gateway_memory_limit }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/gateway.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/gateway.yaml.j2
@@ -1,0 +1,36 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: maas-default-gateway
+  namespace: openshift-ingress
+  annotations:
+    opendatahub.io/managed: "false"
+    security.opendatahub.io/authorino-tls-bootstrap: "true"
+spec:
+  gatewayClassName: data-science-gateway-class
+  infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: maas-gateway-options
+  listeners:
+  - name: http
+    hostname: "{{ ocp_4_20_ai_maas_gateway_hostname }}.{{ _cluster_domain }}"
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+  - name: https
+    hostname: "{{ ocp_4_20_ai_maas_gateway_hostname }}.{{ _cluster_domain }}"
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: "{{ _cert_name }}"
+      mode: Terminate

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/keycloak-realm-maas.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/keycloak-realm-maas.yaml.j2
@@ -1,0 +1,85 @@
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: KeycloakRealmImport
+metadata:
+  name: maas-realm
+  namespace: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+spec:
+  keycloakCRName: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+  realm:
+    realm: "{{ ocp_4_20_ai_maas_keycloak_realm }}"
+    enabled: true
+
+    clientScopes:
+    - name: groups
+      description: Group membership claim
+      protocol: openid-connect
+      attributes:
+        include.in.token.scope: "false"
+        display.on.consent.screen: "true"
+      protocolMappers:
+      - name: groups
+        protocol: openid-connect
+        protocolMapper: oidc-group-membership-mapper
+        consentRequired: false
+        config:
+          full.path: "false"
+          introspection.token.claim: "true"
+          multivalued: "true"
+          userinfo.token.claim: "true"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: groups
+      - name: username
+        protocol: openid-connect
+        protocolMapper: oidc-usermodel-attribute-mapper
+        consentRequired: false
+        config:
+          user.attribute: username
+          claim.name: preferred_username
+          id.token.claim: "true"
+          access.token.claim: "true"
+          jsonType.label: String
+
+    defaultDefaultClientScopes:
+    - basic
+    - groups
+
+    clients:
+    - clientId: "{{ ocp_4_20_ai_maas_keycloak_client_id }}"
+      name: MaaS Client
+      enabled: true
+      publicClient: false
+      clientAuthenticatorType: client-secret
+      secret: "{{ ocp_4_20_ai_maas_keycloak_client_secret }}"
+      standardFlowEnabled: true
+      directAccessGrantsEnabled: true
+      serviceAccountsEnabled: false
+      protocol: openid-connect
+      defaultClientScopes:
+      - basic
+      - profile
+      - groups
+      redirectUris:
+      - http://localhost
+      - http://localhost:8080/callback
+
+    groups:
+{% for tier in ocp_4_20_ai_maas_tiers %}
+    - name: "{{ tier.group }}"
+{% endfor %}
+
+    users:
+{% for tier in ocp_4_20_ai_maas_tiers %}
+    - username: "testuser-{{ tier.name | regex_replace('-subscription$', '') }}"
+      firstName: Test
+      lastName: "{{ tier.name | regex_replace('-subscription$', '') | capitalize }}"
+      email: "testuser-{{ tier.name | regex_replace('-subscription$', '') }}@test.com"
+      emailVerified: true
+      enabled: true
+      credentials:
+      - type: password
+        value: "{{ ocp_4_20_ai_maas_keycloak_test_password }}"
+        temporary: false
+      groups:
+      - "{{ tier.group }}"
+{% endfor %}

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/keycloak.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/keycloak.yaml.j2
@@ -1,0 +1,147 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: rhbk-operator-group
+  namespace: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+spec:
+  targetNamespaces:
+  - {{ ocp_4_20_ai_maas_keycloak_namespace }}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: rhbk-operator
+  namespace: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+spec:
+  channel: "{{ ocp_4_20_ai_maas_keycloak_channel }}"
+  installPlanApproval: Automatic
+  name: rhbk-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-db-credentials
+  namespace: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+type: Opaque
+stringData:
+  username: keycloak
+  password: "{{ ocp_4_20_ai_maas_keycloak_db_password }}"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak-postgres
+  namespace: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: keycloak-postgres
+  template:
+    metadata:
+      labels:
+        app: keycloak-postgres
+    spec:
+      containers:
+      - name: postgres
+        image: {{ ocp_4_20_ai_maas_db_image }}
+        env:
+        - name: POSTGRESQL_USER
+          value: keycloak
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-db-credentials
+              key: password
+        - name: POSTGRESQL_DATABASE
+          value: keycloak
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/pgsql/data
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+      volumes:
+      - name: postgres-data
+        persistentVolumeClaim:
+          claimName: keycloak-postgres-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keycloak-postgres-pvc
+  namespace: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ ocp_4_20_ai_maas_keycloak_db_storage }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgres
+  namespace: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+spec:
+  selector:
+    app: keycloak-postgres
+  ports:
+  - port: 5432
+    targetPort: 5432
+---
+apiVersion: k8s.keycloak.org/v2alpha1
+kind: Keycloak
+metadata:
+  name: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+  namespace: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+spec:
+  instances: {{ ocp_4_20_ai_maas_keycloak_instances }}
+  db:
+    vendor: postgres
+    host: keycloak-postgres
+    port: 5432
+    database: keycloak
+    usernameSecret:
+      name: keycloak-db-credentials
+      key: username
+    passwordSecret:
+      name: keycloak-db-credentials
+      key: password
+  http:
+    httpEnabled: true
+  hostname:
+    hostname: "{{ ocp_4_20_ai_maas_keycloak_namespace }}.{{ _cluster_domain }}"
+  proxy:
+    headers: xforwarded
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+  namespace: {{ ocp_4_20_ai_maas_keycloak_namespace }}
+spec:
+  host: "{{ ocp_4_20_ai_maas_keycloak_namespace }}.{{ _cluster_domain }}"
+  to:
+    kind: Service
+    name: {{ ocp_4_20_ai_maas_keycloak_namespace }}-service
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/maas-auth-policy.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/maas-auth-policy.yaml.j2
@@ -1,0 +1,14 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: keycloak-model-access
+  namespace: models-as-a-service
+spec:
+  modelRefs:
+  - name: "{{ ocp_4_20_ai_maas_model_name }}"
+    namespace: "{{ ocp_4_20_ai_maas_model_namespace }}"
+  subjects:
+    groups:
+{% for tier in ocp_4_20_ai_maas_tiers %}
+    - name: "{{ tier.group }}"
+{% endfor %}

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/maas-model-ref.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/maas-model-ref.yaml.j2
@@ -1,0 +1,9 @@
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: "{{ ocp_4_20_ai_maas_model_name }}"
+  namespace: "{{ ocp_4_20_ai_maas_model_namespace }}"
+spec:
+  modelRef:
+    kind: LLMInferenceService
+    name: "{{ ocp_4_20_ai_maas_model_name }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/maas-subscriptions.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/maas-subscriptions.yaml.j2
@@ -1,0 +1,21 @@
+{% for tier in ocp_4_20_ai_maas_tiers %}
+{% if not loop.first %}
+---
+{% endif %}
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: "{{ tier.name }}"
+  namespace: models-as-a-service
+spec:
+  owner:
+    groups:
+    - name: "{{ tier.group }}"
+  modelRefs:
+  - name: "{{ ocp_4_20_ai_maas_model_name }}"
+    namespace: "{{ ocp_4_20_ai_maas_model_namespace }}"
+    tokenRateLimits:
+    - limit: {{ tier.token_limit }}
+      window: "{{ tier.window }}"
+  priority: {{ tier.priority }}
+{% endfor %}

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/model.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/model.yaml.j2
@@ -1,0 +1,71 @@
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceService
+metadata:
+  name: "{{ ocp_4_20_ai_maas_model_name }}"
+  namespace: "{{ ocp_4_20_ai_maas_model_namespace }}"
+spec:
+  model:
+    name: "{{ ocp_4_20_ai_maas_model_id }}"
+    uri: "{{ ocp_4_20_ai_maas_model_uri }}"
+  storageInitializer:
+    enabled: false
+  replicas: {{ ocp_4_20_ai_maas_model_replicas }}
+  router:
+    route: {}
+    gateway:
+      refs:
+        - name: maas-default-gateway
+          namespace: openshift-ingress
+  template:
+    containers:
+    - name: main
+      image: "{{ ocp_4_20_ai_maas_model_image }}"
+      imagePullPolicy: Always
+      command: ["/app/llm-d-inference-sim"]
+      args:
+      - --port
+      - "8000"
+      - --model
+      - "{{ ocp_4_20_ai_maas_model_id }}"
+      - --mode
+      - random
+      - --ssl-certfile
+      - /var/run/kserve/tls/tls.crt
+      - --ssl-keyfile
+      - /var/run/kserve/tls/tls.key
+      env:
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.name
+      - name: POD_NAMESPACE
+        valueFrom:
+          fieldRef:
+            apiVersion: v1
+            fieldPath: metadata.namespace
+      ports:
+      - containerPort: 8000
+        name: https
+        protocol: TCP
+      livenessProbe:
+        httpGet:
+          path: /health
+          port: https
+          scheme: HTTPS
+      readinessProbe:
+        httpGet:
+          path: /ready
+          port: https
+          scheme: HTTPS
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      volumeMounts:
+      - mountPath: /var/run/kserve/tls
+        name: tls-certs
+        readOnly: true

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/postgres-maas.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/postgres-maas.yaml.j2
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: maas-db
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: maas-postgres-pvc
+  namespace: maas-db
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ ocp_4_20_ai_maas_db_storage }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: maas-postgres-credentials
+  namespace: maas-db
+type: Opaque
+stringData:
+  POSTGRES_USER: "{{ ocp_4_20_ai_maas_db_user }}"
+  POSTGRES_PASSWORD: "{{ ocp_4_20_ai_maas_db_password }}"
+  POSTGRES_DB: "{{ ocp_4_20_ai_maas_db_name }}"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maas-postgres
+  namespace: maas-db
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: maas-postgres
+  template:
+    metadata:
+      labels:
+        app: maas-postgres
+    spec:
+      containers:
+      - name: postgres
+        image: {{ ocp_4_20_ai_maas_db_image }}
+        env:
+        - name: POSTGRESQL_USER
+          valueFrom:
+            secretKeyRef:
+              name: maas-postgres-credentials
+              key: POSTGRES_USER
+        - name: POSTGRESQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: maas-postgres-credentials
+              key: POSTGRES_PASSWORD
+        - name: POSTGRESQL_DATABASE
+          valueFrom:
+            secretKeyRef:
+              name: maas-postgres-credentials
+              key: POSTGRES_DB
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: postgres-data
+          mountPath: /var/lib/pgsql/data
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+      volumes:
+      - name: postgres-data
+        persistentVolumeClaim:
+          claimName: maas-postgres-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: maas-postgres
+  namespace: maas-db
+spec:
+  selector:
+    app: maas-postgres
+  ports:
+  - port: 5432
+    targetPort: 5432

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/user-workload-monitoring.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/user-workload-monitoring.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      retention: {{ ocp_4_20_ai_maas_monitoring_retention }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/playbook_osac_create_maas_deployment.yml
+++ b/playbook_osac_create_maas_deployment.yml
@@ -1,0 +1,72 @@
+---
+# Playbook: deploy MaaS on RHOAI 3.4 via ocp_4_20_ai_maas template role.
+# Runs the role's task files directly against a live cluster.
+#
+# Usage:
+#   ansible-playbook playbook_osac_create_maas_deployment.yml --tags all -v
+#   ansible-playbook playbook_osac_create_maas_deployment.yml --tags operators
+#   ansible-playbook playbook_osac_create_maas_deployment.yml --tags maas
+#   ansible-playbook playbook_osac_create_maas_deployment.yml --tags verify
+#   ansible-playbook playbook_osac_create_maas_deployment.yml --tags cleanup
+
+- name: Deploy MaaS on RHOAI 3.4
+  hosts: localhost
+  gather_facts: false
+  connection: local
+
+  vars:
+    # Simulate admin_kubeconfig (normally set by ocp_4_17_small pipeline)
+    admin_kubeconfig: "{{ lookup('env', 'KUBECONFIG') | default('~/.kube/config', true) }}"
+
+  tasks:
+    # --- Install Operators (BOM Phase 2 + 3) ---
+    - name: Install platform operators
+      ansible.builtin.include_role:
+        name: osac.templates.ocp_4_20_ai_maas
+        tasks_from: install_operators.yaml
+        apply:
+          tags:
+            - operators
+            - all
+      tags:
+        - operators
+        - all
+
+    # --- Configure MaaS (Phases 1-5) ---
+    - name: Configure MaaS platform
+      ansible.builtin.include_role:
+        name: osac.templates.ocp_4_20_ai_maas
+        tasks_from: configure_maas.yaml
+        apply:
+          tags:
+            - maas
+            - all
+      tags:
+        - maas
+        - all
+
+    # --- Verification ---
+    - name: Run verification tests
+      ansible.builtin.include_role:
+        name: osac.templates.ocp_4_20_ai_maas
+        tasks_from: verify.yaml
+        apply:
+          tags:
+            - verify
+            - all
+      tags:
+        - verify
+        - all
+
+    # --- Cleanup ---
+    - name: Undeploy everything
+      ansible.builtin.include_role:
+        name: osac.templates.ocp_4_20_ai_maas
+        tasks_from: delete.yaml
+        apply:
+          tags:
+            - cleanup
+            - never
+      tags:
+        - cleanup
+        - never


### PR DESCRIPTION
## Summary

- New AAP template role `ocp_4_20_ai_maas` that automates the full BOM + MaaS deployment via the `ocp_4_17_small` post-install hook pattern
- Installs 7 operators (cert-manager, SM 3.2, RHCL 1.3.4 + sub-operators, LWS, RHOAI 3.4) with RHCL version pinning per [Red Hat KCS](https://access.redhat.com/solutions/7144055)
- Deploys MaaS end-to-end: Keycloak SSO, gateway, model (CPU-only simulator), 3-tier subscriptions
- Verification tests: auth enforcement (401/403), API key creation, inference, rate limiting, version pinning
- ~50 parameterized variables with `meta/argument_specs.yaml` for documentation and validation
- Playbook `playbook_osac_create_maas_deployment.yml` for standalone testing
- Security: `no_log` on credential tasks, version filter validation, secretKeyRef for DB passwords, PVC for Keycloak PostgreSQL

## Test Plan

- [x] `ansible-lint` — 0 failures, 0 warnings, production profile
- [x] `ansible-playbook --syntax-check` — passes
- [x] Full `--tags all` run on clean OCP 4.19 cluster — all tasks pass
- [x] `--tags operators` — all BOM operators installed with correct versions
- [x] `--tags maas` — MaaS deployed with Keycloak SSO, model, subscriptions
- [x] `--tags verify` — auth (401/403), API key (201), inference (200), rate limiting (429), version pinning (no v1.4.0)
- [x] `--tags cleanup` — MaaS resources removed cleanly
- [ ] OSAC pipeline test (ClusterOrder -> AAP) — deferred to OSAC team

## Also Modified

- `.gitignore`: Added `.idea/` and `*.iml` (JetBrains IDE files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenShift 4.20 MaaS (RHOAI 3.4) deployment role/template with pinned operator/CSV settings, MaaS gateway and PostgreSQL-backed services, and model serving via `LLMInferenceService`.
  * Included optional Keycloak authentication with realm import, tier-based groups, API access policies, and MaaS subscriptions.
  * Added an end-to-end create/deploy playbook with phased install, optional post-deployment smoke verification, and MaaS-focused cleanup.
  * Added configurable role inputs (argument specs) and defaults.
* **Chores**
  * Updated ignore rules to properly exclude JetBrains IDE artifacts and module files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->