### PR TITLE
NO-ISSUE: Add netris.controller collection roles for lab integration

### DIFF
--- a/collections/ansible_collections/netris/controller/galaxy.yml
+++ b/collections/ansible_collections/netris/controller/galaxy.yml
@@ -5,3 +5,8 @@ description: Ansible collection for Netris controller API
 authors:
   - Netris
 readme: README.md
+license:
+  - Apache-2.0
+repository: https://github.com/osac-project/osac-aap
+tags:
+  - networking

--- a/collections/ansible_collections/netris/controller/galaxy.yml
+++ b/collections/ansible_collections/netris/controller/galaxy.yml
@@ -3,7 +3,7 @@ name: controller
 version: 1.0.0
 description: Ansible collection for Netris controller API
 authors:
-  - Netris
+  - Dan Manor
 readme: README.md
 license:
   - Apache-2.0

--- a/collections/ansible_collections/netris/controller/galaxy.yml
+++ b/collections/ansible_collections/netris/controller/galaxy.yml
@@ -1,0 +1,7 @@
+namespace: netris
+name: controller
+version: 1.0.0
+description: Ansible collection for Netris controller API
+authors:
+  - Netris
+readme: README.md

--- a/collections/ansible_collections/netris/controller/meta/runtime.yml
+++ b/collections/ansible_collections/netris/controller/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.14.0"

--- a/collections/ansible_collections/netris/controller/roles/ebgp/defaults/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/ebgp/defaults/main.yaml
@@ -1,0 +1,1 @@
+ebgp_state: read

--- a/collections/ansible_collections/netris/controller/roles/ebgp/tasks/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/ebgp/tasks/main.yaml
@@ -1,0 +1,4 @@
+---
+- name: Read E-BGP sessions
+  ansible.builtin.include_tasks: read.yaml
+  when: ebgp_state == 'read'

--- a/collections/ansible_collections/netris/controller/roles/ebgp/tasks/read.yaml
+++ b/collections/ansible_collections/netris/controller/roles/ebgp/tasks/read.yaml
@@ -1,0 +1,22 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Get E-BGP sessions
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/ebgp"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    validate_certs: "{{ netris_validate_certs }}"
+    timeout: "{{ netris_timeout }}"
+    status_code: 200
+  register: _ebgp_resp
+
+- name: Set E-BGP facts
+  ansible.builtin.set_fact:
+    netris_ebgp_sessions: "{{ _ebgp_resp.json.data }}"
+    netris_ebgp_total: "{{ _ebgp_resp.json.data | length }}"
+    netris_ebgp_established: "{{ _ebgp_resp.json.data | selectattr('bgp_state', 'defined') | selectattr('bgp_state', 'equalto', 'Established') | list | length }}"

--- a/collections/ansible_collections/netris/controller/roles/general/defaults/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/general/defaults/main.yaml
@@ -1,0 +1,1 @@
+general_state: read

--- a/collections/ansible_collections/netris/controller/roles/general/tasks/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/general/tasks/main.yaml
@@ -1,0 +1,4 @@
+---
+- name: Read general settings
+  ansible.builtin.include_tasks: read.yaml
+  when: general_state == 'read'

--- a/collections/ansible_collections/netris/controller/roles/general/tasks/read.yaml
+++ b/collections/ansible_collections/netris/controller/roles/general/tasks/read.yaml
@@ -1,0 +1,21 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Get general settings
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/general"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    validate_certs: "{{ netris_validate_certs }}"
+    timeout: "{{ netris_timeout }}"
+    status_code: 200
+  register: _general_resp
+
+- name: Set general facts
+  ansible.builtin.set_fact:
+    netris_general_settings: "{{ _general_resp.json.data }}"
+    netris_auth_token: "{{ _general_resp.json.data | selectattr('name', 'equalto', 'netris_auth_token') | map(attribute='value') | first | default('') }}"

--- a/collections/ansible_collections/netris/controller/roles/inventory/defaults/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/inventory/defaults/main.yaml
@@ -1,0 +1,1 @@
+inventory_state: read

--- a/collections/ansible_collections/netris/controller/roles/inventory/tasks/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/inventory/tasks/main.yaml
@@ -1,0 +1,4 @@
+---
+- name: Read inventory
+  ansible.builtin.include_tasks: read.yaml
+  when: inventory_state == 'read'

--- a/collections/ansible_collections/netris/controller/roles/inventory/tasks/read.yaml
+++ b/collections/ansible_collections/netris/controller/roles/inventory/tasks/read.yaml
@@ -1,0 +1,41 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Get inventory
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/hw?showHealth=true"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    validate_certs: "{{ netris_validate_certs }}"
+    timeout: "{{ netris_timeout }}"
+    status_code: 200
+  register: _inventory_resp
+
+- name: Set inventory facts
+  ansible.builtin.set_fact:
+    netris_inventory: "{{ _inventory_resp.json.data }}"
+    netris_inventory_total: "{{ _inventory_resp.json.data | length }}"
+    netris_inventory_healthy: >-
+      {{ _inventory_resp.json.data | selectattr('health', 'defined')
+         | selectattr('health.ok', 'defined')
+         | selectattr('health.ok', 'greaterthan', 0)
+         | list | length }}
+    netris_inventory_by_type: >-
+      {%- set result = {} -%}
+      {%- for item in _inventory_resp.json.data -%}
+        {%- set t = item.type | default('unknown') -%}
+        {%- set h = item.health | default({}) -%}
+        {%- set is_ok = (h.get('ok', 0) | int > 0) if h else false -%}
+        {%- if t not in result -%}
+          {%- set _ = result.update({t: {'total': 0, 'ok': 0}}) -%}
+        {%- endif -%}
+        {%- set _ = result[t].update({'total': result[t].total + 1}) -%}
+        {%- if is_ok -%}
+          {%- set _ = result[t].update({'ok': result[t].ok + 1}) -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {{ result }}

--- a/collections/ansible_collections/netris/controller/roles/license/defaults/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/license/defaults/main.yaml
@@ -1,0 +1,1 @@
+license_state: read

--- a/collections/ansible_collections/netris/controller/roles/license/tasks/apply.yaml
+++ b/collections/ansible_collections/netris/controller/roles/license/tasks/apply.yaml
@@ -1,0 +1,42 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Check current license
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/license"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    validate_certs: "{{ netris_validate_certs }}"
+    timeout: "{{ netris_timeout }}"
+    status_code: [200, 400, 404]
+  register: _license_check
+
+- name: Read license key file
+  when: not (_license_check.json.isSuccess | default(false))
+  ansible.builtin.slurp:
+    src: "{{ license_key_file }}"
+  register: _license_key_raw
+
+- name: Apply license key
+  when: not (_license_check.json.isSuccess | default(false))
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/license"
+    method: PUT
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      key: "{{ _license_key_raw.content | b64decode | trim }}"
+    validate_certs: "{{ netris_validate_certs }}"
+    timeout: "{{ netris_timeout }}"
+    status_code: [200, 400]
+  register: _license_apply_resp
+
+- name: Set license facts
+  ansible.builtin.set_fact:
+    netris_license_valid: "{{ _license_apply_resp.json.isSuccess | default(_license_check.json.isSuccess | default(false)) }}"

--- a/collections/ansible_collections/netris/controller/roles/license/tasks/main.yaml
+++ b/collections/ansible_collections/netris/controller/roles/license/tasks/main.yaml
@@ -1,0 +1,8 @@
+---
+- name: Read license
+  ansible.builtin.include_tasks: read.yaml
+  when: license_state == 'read'
+
+- name: Apply license
+  ansible.builtin.include_tasks: apply.yaml
+  when: license_state == 'present'

--- a/collections/ansible_collections/netris/controller/roles/license/tasks/read.yaml
+++ b/collections/ansible_collections/netris/controller/roles/license/tasks/read.yaml
@@ -1,0 +1,21 @@
+---
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Get license status
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/license"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    validate_certs: "{{ netris_validate_certs }}"
+    timeout: "{{ netris_timeout }}"
+    status_code: [200, 400, 404]
+  register: _license_resp
+
+- name: Set license facts
+  ansible.builtin.set_fact:
+    netris_license_valid: "{{ _license_resp.json.isSuccess | default(false) }}"
+    netris_license_message: "{{ _license_resp.json.message | default('No license') }}"


### PR DESCRIPTION
## Summary
- Add `galaxy.yml` to the netris.controller collection
- Add four new roles for Netris controller API operations:
  - **ebgp**: read E-BGP session status
  - **general**: read global settings (auth token retrieval)
  - **inventory**: read hardware inventory with health status
  - **license**: read and apply license keys

These roles are used by the netris-lab project for deployment verification and softgate provisioning.