### PR TITLE
NO-ISSUE: Fix race condition in bare metal template roles

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_deprovisioning/tasks/delete.yaml
@@ -11,7 +11,7 @@
 
 - name: Detach all networks and delete neutron ports
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ bare_metal_instance.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/tasks/create.yaml
@@ -87,7 +87,7 @@
 
     - name: Set provisioning network for node
       ansible.builtin.include_role:
-        name: massopencloud.esi.l2
+        name: osac.esi.l2
         tasks_from: set_networks_for_node
       vars:
         node: "{{ bare_metal_instance.spec.externalHostID }}"
@@ -113,7 +113,7 @@
 
 - name: Ensure node is on agent private network
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ bare_metal_instance.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/create.yaml
@@ -18,9 +18,17 @@
     msg: "templateParameters.privateNetwork is required"
   when: template_params.privateNetwork | default('') | length == 0
 
+- name: Wait for private network to exist in OpenStack
+  openstack.cloud.networks_info:
+    name: "{{ template_params.privateNetwork }}"
+  register: private_network_check
+  until: private_network_check.networks | length > 0
+  retries: 30
+  delay: 10
+
 - name: Attach node to private network
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ bare_metal_instance.spec.externalHostID }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_private_network/tasks/delete.yaml
@@ -15,20 +15,30 @@
 
 - name: Detach node from private network
   ansible.builtin.include_role:
-    name: massopencloud.esi.l2
+    name: osac.esi.l2
     tasks_from: set_networks_for_node
   vars:
     node: "{{ bare_metal_instance.spec.externalHostID }}"
     networks: []
 
 - name: Attach node to network after detach
-  ansible.builtin.include_role:
-    name: massopencloud.esi.l2
-    tasks_from: set_networks_for_node
-  vars:
-    node: "{{ bare_metal_instance.spec.externalHostID }}"
-    networks: "{{ [template_params.networkAfterDelete] }}"
-  when: template_params.networkAfterDelete is defined
+  when: template_params.networkAfterDelete | default('') | length > 0
+  block:
+    - name: Wait for network to exist
+      openstack.cloud.networks_info:
+        name: "{{ template_params.networkAfterDelete }}"
+      register: private_network_check
+      until: private_network_check.networks | length > 0
+      retries: 30
+      delay: 10
+
+    - name: Attach node to network
+      ansible.builtin.include_role:
+        name: osac.esi.l2
+        tasks_from: set_networks_for_node
+      vars:
+        node: "{{ bare_metal_instance.spec.externalHostID }}"
+        networks: "{{ [template_params.networkAfterDelete] }}"
 
 - name: Network detachment completed
   ansible.builtin.debug:

--- a/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/create_openstack.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/create_openstack.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Create OpenStack network for BareMetalPool
   ansible.builtin.include_role:
-    name: massopencloud.esi.network
+    name: osac.esi.network
   vars:
     network_state: present
     network_suffix: "{{ bare_metal_pool.metadata.name }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/delete_openstack.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_private_network/tasks/delete_openstack.yaml
@@ -1,7 +1,25 @@
 ---
+- name: Look up private network for BareMetalPool
+  openstack.cloud.networks_info:
+    name: "network-{{ bare_metal_pool.metadata.name }}"
+  register: pool_network_info
+
+- name: Wait for all node VIFs to be detached before deleting network
+  when: pool_network_info.networks | length > 0
+  block:
+    - name: Wait for node VIF ports to be removed from network
+      openstack.cloud.port_info:
+        filters:
+          network_id: "{{ pool_network_info.networks[0].id }}"
+          device_owner: "baremetal:none"
+      register: vif_ports
+      until: vif_ports.ports | length == 0
+      retries: 30
+      delay: 10
+
 - name: Delete OpenStack network for BareMetalPool
   ansible.builtin.include_role:
-    name: massopencloud.esi.network
+    name: osac.esi.network
   vars:
     network_state: absent
     network_suffix: "{{ bare_metal_pool.metadata.name }}"


### PR DESCRIPTION
Add network readiness checks so roles can run in any order: wait for the private network to exist in OpenStack before attaching a node (bm_host_private_network), and wait for all VIF ports to drain before deleting the network (bm_private_network). Also migrates role references from massopencloud.esi to osac.esi.

Assisted-by: Claude Code <noreply@anthropic.com>

Closes osac-project/issues#400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Network attachment operations now include retry logic with explicit wait steps for network availability.
  * Network deletion now waits for all attached ports to be detached before proceeding.
  * Enhanced network configuration workflow stability with improved synchronization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->