### PR TITLE
Use configurable SA names in Helm chart to match playbooks

### DIFF
--- a/charts/aap/templates/osac-sa.yaml
+++ b/charts/aap/templates/osac-sa.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "osac-aap.fullname" . }}-sa
+  name: {{ .Values.serviceAccounts.osacSa }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "osac-aap.labels" . | nindent 4 }}
@@ -9,7 +9,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "osac-aap.fullname" . }}-sa
+  name: {{ .Values.serviceAccounts.osacSa }}-{{ .Release.Namespace }}
   labels:
     {{- include "osac-aap.labels" . | nindent 4 }}
 roleRef:
@@ -18,5 +18,5 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: {{ include "osac-aap.fullname" . }}-sa
+    name: {{ .Values.serviceAccounts.osacSa }}
     namespace: {{ .Release.Namespace }}

--- a/charts/aap/templates/template-publisher.yaml
+++ b/charts/aap/templates/template-publisher.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "osac-aap.fullname" . }}-template-publisher
+  name: {{ .Values.serviceAccounts.templatePublisher }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "osac-aap.labels" . | nindent 4 }}
@@ -10,28 +10,28 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "osac-aap.fullname" . }}-create-controller-token
+  name: create-controller-token
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "osac-aap.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
-    resourceNames: ["{{ include "osac-aap.fullname" . }}-template-publisher"]
+    resourceNames: ["{{ .Values.serviceAccounts.templatePublisher }}"]
     verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "osac-aap.fullname" . }}-template-publisher
+  name: {{ .Values.serviceAccounts.templatePublisher }}-binding
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "osac-aap.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "osac-aap.fullname" . }}-create-controller-token
+  name: create-controller-token
 subjects:
   - kind: ServiceAccount
-    name: {{ include "osac-aap.fullname" . }}-template-publisher
+    name: {{ .Values.serviceAccounts.templatePublisher }}
     namespace: {{ .Release.Namespace }}

--- a/charts/aap/values.yaml
+++ b/charts/aap/values.yaml
@@ -23,3 +23,7 @@ bootstrap:
 configAsCode:
   manifestSecret: "config-as-code-manifest-ig"
   secret: "config-as-code-ig"
+
+serviceAccounts:
+  osacSa: "osac-sa"
+  templatePublisher: "template-publisher"


### PR DESCRIPTION
## Summary

- Makes ServiceAccount names in the AAP Helm subchart configurable via `serviceAccounts.osacSa` and `serviceAccounts.templatePublisher` values
- Defaults to `osac-sa` and `template-publisher` — the names hardcoded in the config-as-code playbooks (controller.yml pod_spec_override)
- Previously the chart prefixed them with the release name (`osac-aap-sa`, `osac-aap-template-publisher`), requiring the osac-installer umbrella chart to create duplicate SAs as a workaround

Once merged and the submodule is bumped, the `charts/osac/templates/aap-service-accounts.yaml` workaround in osac-installer can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)