### PR TITLE
Add config-as-code Secret template to Helm chart

### DIFF
--- a/charts/aap/templates/config-as-code-secret.yaml
+++ b/charts/aap/templates/config-as-code-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.configAsCode.eeImage }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.configAsCode.secret }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-aap.labels" . | nindent 4 }}
+stringData:
+  AAP_EE_IMAGE: {{ .Values.configAsCode.eeImage | quote }}
+  AAP_PROJECT_GIT_URI: {{ .Values.configAsCode.projectGitUri | quote }}
+  AAP_PROJECT_GIT_BRANCH: {{ .Values.configAsCode.projectGitBranch | quote }}
+{{- end }}

--- a/charts/aap/values.yaml
+++ b/charts/aap/values.yaml
@@ -23,6 +23,9 @@ bootstrap:
 configAsCode:
   manifestSecret: "config-as-code-manifest-ig"
   secret: "config-as-code-ig"
+  eeImage: ""
+  projectGitUri: ""
+  projectGitBranch: ""
 
 serviceAccounts:
   osacSa: "osac-sa"


### PR DESCRIPTION
## Summary

- Adds `charts/aap/templates/config-as-code-secret.yaml` — creates the `config-as-code-ig` Secret from Helm values
- The secret contains `AAP_EE_IMAGE`, `AAP_PROJECT_GIT_URI`, `AAP_PROJECT_GIT_BRANCH` which `prepare-fulfillment-service.sh` reads to sync the AAP project
- Guarded by `configAsCode.eeImage` being set — kustomize-path users (where the secret is created by `secretGenerator`) are unaffected
- Adds `eeImage`, `projectGitUri`, `projectGitBranch` to `charts/aap/values.yaml` under `configAsCode`

Needed for the Helm-based CI deployment path (osac-project/osac-installer#296).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Helm template for configuration-as-code secret management, enabling deployment of automation environment image and Git project configuration details through Kubernetes secrets.
  * Extended values configuration with new fields for environment image, project Git URI, and branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->