### PR TITLE
OSAC-1558: add bm_host_metal3_provisioning template role

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/create.yaml
@@ -18,6 +18,11 @@
     bmh_namespace: "{{ bare_metal_instance.spec.externalHostID.split('/')[0] }}"
     bmh_name: "{{ bare_metal_instance.spec.externalHostID.split('/')[1] }}"
 
+- name: Extract SSH key and userDataSecret from template parameters
+  ansible.builtin.set_fact:
+    ssh_key: "{{ template_params.sshKey | default('') }}"
+    user_data_secret_ref: "{{ template_params.userDataSecret | default('') }}"
+
 - name: Get BareMetalHost
   kubernetes.core.k8s_info:
     api_version: metal3.io/v1alpha1
@@ -55,6 +60,84 @@
 - name: Provision BMH
   when: not (already_provisioned | bool)
   block:
+    - name: Build userData content
+      when: ssh_key | length > 0 or user_data_secret_ref | length > 0
+      block:
+        - name: Read userDataSecret from BareMetalInstance namespace
+          when: user_data_secret_ref | length > 0
+          block:
+            - name: Fetch userDataSecret
+              kubernetes.core.k8s_info:
+                api_version: v1
+                kind: Secret
+                namespace: "{{ bare_metal_instance.metadata.namespace }}"
+                name: "{{ user_data_secret_ref }}"
+              register: user_data_secret_result
+
+            - name: Fail if userDataSecret not found
+              ansible.builtin.fail:
+                msg: >-
+                  Secret '{{ user_data_secret_ref }}' not found in namespace
+                  '{{ bare_metal_instance.metadata.namespace }}'
+              when: user_data_secret_result.resources | length == 0
+
+            - name: Extract user data content from Secret
+              ansible.builtin.set_fact:
+                existing_user_data: "{{ user_data_secret_result.resources[0].data.userdata | b64decode }}"
+
+        - name: Generate cloud-init with SSH key only
+          when:
+            - ssh_key | length > 0
+            - user_data_secret_ref | length == 0
+          ansible.builtin.set_fact:
+            final_user_data: |
+              #cloud-config
+              ssh_authorized_keys:
+                - {{ ssh_key }}
+
+        - name: Use existing user data as-is (no SSH key to merge)
+          when:
+            - ssh_key | length == 0
+            - user_data_secret_ref | length > 0
+          ansible.builtin.set_fact:
+            final_user_data: "{{ existing_user_data }}"
+
+        - name: Merge SSH key into existing cloud-init user data
+          when:
+            - ssh_key | length > 0
+            - user_data_secret_ref | length > 0
+          block:
+            - name: Fail if user data is not cloud-config format
+              ansible.builtin.fail:
+                msg: >-
+                  Cannot inject SSH key into user data that is not cloud-config format.
+                  User data must start with '#cloud-config' to support SSH key injection.
+                  Either remove the ssh_key parameter or provide user data in cloud-config
+                  format with ssh_authorized_keys included.
+              when: not (existing_user_data | trim is match('^#cloud-config'))
+
+            - name: Parse existing cloud-init and merge SSH key
+              ansible.builtin.set_fact:
+                final_user_data: >-
+                  #cloud-config
+                  {{ (existing_user_data | regex_replace('^#cloud-config\s*\n?', '') | from_yaml | default({}))
+                     | combine({'ssh_authorized_keys':
+                         ((existing_user_data | regex_replace('^#cloud-config\s*\n?', '') | from_yaml | default({})).ssh_authorized_keys | default([]))
+                         + [ssh_key]})
+                     | to_nice_yaml }}
+
+        - name: Create userData Secret in BMH namespace
+          kubernetes.core.k8s:
+            state: present
+            definition:
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: "{{ bmh_name }}-user-data"
+                namespace: "{{ bmh_namespace }}"
+              stringData:
+                userData: "{{ final_user_data }}"
+
     - name: Create networkData Secret
       when: template_params.networkData | default('') | length > 0
       kubernetes.core.k8s:
@@ -68,30 +151,41 @@
           stringData:
             networkData: "{{ template_params.networkData }}"
 
-    - name: Build BMH patch with networkData
+    - name: Build base BMH patch
+      ansible.builtin.set_fact:
+        bmh_patch:
+          spec:
+            image:
+              url: "{{ template_params.imageURL }}"
+              checksum: "{{ template_params.imageChecksum | default('') }}"
+              checksumType: "{{ template_params.checksumType | default('auto') }}"
+            online: true
+
+    - name: Add networkData to BMH patch
       when: template_params.networkData | default('') | length > 0
       ansible.builtin.set_fact:
-        bmh_patch:
-          spec:
-            image:
-              url: "{{ template_params.imageURL }}"
-              checksum: "{{ template_params.imageChecksum | default('') }}"
-              checksumType: "{{ template_params.checksumType | default('auto') }}"
-            online: true
-            networkData:
-              name: "{{ bmh_name }}-network-data"
-              namespace: "{{ bmh_namespace }}"
+        bmh_patch: >-
+          {{ bmh_patch | combine({
+               'spec': bmh_patch.spec | combine({
+                 'networkData': {
+                   'name': bmh_name ~ '-network-data',
+                   'namespace': bmh_namespace
+                 }
+               })
+             }, recursive=True) }}
 
-    - name: Build BMH patch without networkData
-      when: template_params.networkData | default('') | length == 0
+    - name: Add userData to BMH patch
+      when: final_user_data is defined
       ansible.builtin.set_fact:
-        bmh_patch:
-          spec:
-            image:
-              url: "{{ template_params.imageURL }}"
-              checksum: "{{ template_params.imageChecksum | default('') }}"
-              checksumType: "{{ template_params.checksumType | default('auto') }}"
-            online: true
+        bmh_patch: >-
+          {{ bmh_patch | combine({
+               'spec': bmh_patch.spec | combine({
+                 'userData': {
+                   'name': bmh_name ~ '-user-data',
+                   'namespace': bmh_namespace
+                 }
+               })
+             }, recursive=True) }}
 
     - name: Patch BareMetalHost with image and provisioning settings
       kubernetes.core.k8s:

--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/create.yaml
@@ -1,0 +1,118 @@
+---
+- name: Fail if host class is not metal3
+  ansible.builtin.fail:
+    msg: "bm_host_metal3_provisioning requires hostClass 'metal3', got '{{ bare_metal_instance.spec.hostClass | default('') }}'"
+  when: bare_metal_instance.spec.hostClass | default('') != "metal3"
+
+- name: Parse template parameters
+  ansible.builtin.set_fact:
+    template_params: "{{ bare_metal_instance.spec.templateParameters | from_json }}"
+
+- name: Fail if image URL is missing
+  ansible.builtin.fail:
+    msg: "templateParameters.imageURL is required for Metal3 provisioning"
+  when: template_params.imageURL | default('') | length == 0
+
+- name: Parse externalHostID into namespace and name
+  ansible.builtin.set_fact:
+    bmh_namespace: "{{ bare_metal_instance.spec.externalHostID.split('/')[0] }}"
+    bmh_name: "{{ bare_metal_instance.spec.externalHostID.split('/')[1] }}"
+
+- name: Get BareMetalHost
+  kubernetes.core.k8s_info:
+    api_version: metal3.io/v1alpha1
+    kind: BareMetalHost
+    namespace: "{{ bmh_namespace }}"
+    name: "{{ bmh_name }}"
+  register: bmh_result
+
+- name: Fail if BareMetalHost not found
+  ansible.builtin.fail:
+    msg: "BareMetalHost '{{ bmh_namespace }}/{{ bmh_name }}' not found"
+  when: bmh_result.resources | length == 0
+
+- name: Extract BMH info
+  ansible.builtin.set_fact:
+    bmh_info: "{{ bmh_result.resources[0] }}"
+
+- name: Display current BMH state
+  ansible.builtin.debug:
+    msg:
+      - "BMH: {{ bmh_namespace }}/{{ bmh_name }}"
+      - "Provisioning State: {{ bmh_info.status.provisioning.state | default('unknown') }}"
+
+- name: Check if BMH is already provisioned with the correct image
+  ansible.builtin.set_fact:
+    already_provisioned: >-
+      {{ (bmh_info.status.provisioning.state | default('') == 'provisioned') and
+         (bmh_info.status.provisioning.image.url | default('') == template_params.imageURL) }}
+
+- name: Skip provisioning when BMH already has the desired image
+  when: already_provisioned | bool
+  ansible.builtin.debug:
+    msg: "BMH {{ bmh_namespace }}/{{ bmh_name }} is already provisioned with the desired image, skipping"
+
+- name: Provision BMH
+  when: not (already_provisioned | bool)
+  block:
+    - name: Create networkData Secret
+      when: template_params.networkData | default('') | length > 0
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ bmh_name }}-network-data"
+            namespace: "{{ bmh_namespace }}"
+          stringData:
+            networkData: "{{ template_params.networkData }}"
+
+    - name: Build BMH patch with networkData
+      when: template_params.networkData | default('') | length > 0
+      ansible.builtin.set_fact:
+        bmh_patch:
+          spec:
+            image:
+              url: "{{ template_params.imageURL }}"
+              checksum: "{{ template_params.imageChecksum | default('') }}"
+              checksumType: "{{ template_params.checksumType | default('auto') }}"
+            online: true
+            networkData:
+              name: "{{ bmh_name }}-network-data"
+              namespace: "{{ bmh_namespace }}"
+
+    - name: Build BMH patch without networkData
+      when: template_params.networkData | default('') | length == 0
+      ansible.builtin.set_fact:
+        bmh_patch:
+          spec:
+            image:
+              url: "{{ template_params.imageURL }}"
+              checksum: "{{ template_params.imageChecksum | default('') }}"
+              checksumType: "{{ template_params.checksumType | default('auto') }}"
+            online: true
+
+    - name: Patch BareMetalHost with image and provisioning settings
+      kubernetes.core.k8s:
+        api_version: metal3.io/v1alpha1
+        kind: BareMetalHost
+        namespace: "{{ bmh_namespace }}"
+        name: "{{ bmh_name }}"
+        state: present
+        definition: "{{ bmh_patch }}"
+
+    - name: Wait for BMH to reach provisioned state
+      kubernetes.core.k8s_info:
+        api_version: metal3.io/v1alpha1
+        kind: BareMetalHost
+        namespace: "{{ bmh_namespace }}"
+        name: "{{ bmh_name }}"
+      register: bmh_provision_status
+      until: bmh_provision_status.resources[0].status.provisioning.state | default('') == "provisioned"
+      retries: 120
+      delay: 30
+
+- name: Metal3 provisioning completed
+  ansible.builtin.debug:
+    msg: "Metal3 provisioning completed for BMH {{ bmh_namespace }}/{{ bmh_name }}"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/delete.yaml
@@ -36,7 +36,7 @@
     - name: Remove image and networkData from BMH
       when: bmh_has_image | bool
       block:
-        - name: Patch BareMetalHost to remove image and networkData
+        - name: Patch BareMetalHost to remove image, networkData, and userData
           kubernetes.core.k8s:
             api_version: metal3.io/v1alpha1
             kind: BareMetalHost
@@ -47,6 +47,7 @@
               spec:
                 image: null
                 networkData: null
+                userData: null
 
         - name: Wait for BMH to reach available or ready state
           kubernetes.core.k8s_info:
@@ -65,6 +66,14 @@
         kind: Secret
         namespace: "{{ bmh_namespace }}"
         name: "{{ bmh_name }}-network-data"
+        state: absent
+
+    - name: Delete userData Secret
+      kubernetes.core.k8s:
+        api_version: v1
+        kind: Secret
+        namespace: "{{ bmh_namespace }}"
+        name: "{{ bmh_name }}-user-data"
         state: absent
 
 - name: Metal3 deprovisioning completed

--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/delete.yaml
@@ -1,0 +1,72 @@
+---
+- name: Parse externalHostID into namespace and name
+  ansible.builtin.set_fact:
+    bmh_namespace: "{{ bare_metal_instance.spec.externalHostID.split('/')[0] }}"
+    bmh_name: "{{ bare_metal_instance.spec.externalHostID.split('/')[1] }}"
+
+- name: Get BareMetalHost
+  kubernetes.core.k8s_info:
+    api_version: metal3.io/v1alpha1
+    kind: BareMetalHost
+    namespace: "{{ bmh_namespace }}"
+    name: "{{ bmh_name }}"
+  register: bmh_result
+
+- name: Skip deprovisioning if BareMetalHost not found
+  when: bmh_result.resources | length == 0
+  ansible.builtin.debug:
+    msg: "BareMetalHost '{{ bmh_namespace }}/{{ bmh_name }}' not found, skipping deprovisioning"
+
+- name: Deprovision BMH
+  when: bmh_result.resources | length > 0
+  block:
+    - name: Extract BMH info
+      ansible.builtin.set_fact:
+        bmh_info: "{{ bmh_result.resources[0] }}"
+
+    - name: Check if BMH has an image set
+      ansible.builtin.set_fact:
+        bmh_has_image: "{{ bmh_info.spec.image is defined and bmh_info.spec.image.url is defined and bmh_info.spec.image.url | length > 0 }}"
+
+    - name: Skip deprovisioning when no image is set
+      when: not (bmh_has_image | bool)
+      ansible.builtin.debug:
+        msg: "BMH {{ bmh_namespace }}/{{ bmh_name }} has no image set, skipping deprovisioning"
+
+    - name: Remove image and networkData from BMH
+      when: bmh_has_image | bool
+      block:
+        - name: Patch BareMetalHost to remove image and networkData
+          kubernetes.core.k8s:
+            api_version: metal3.io/v1alpha1
+            kind: BareMetalHost
+            namespace: "{{ bmh_namespace }}"
+            name: "{{ bmh_name }}"
+            state: present
+            definition:
+              spec:
+                image: null
+                networkData: null
+
+        - name: Wait for BMH to reach available or ready state
+          kubernetes.core.k8s_info:
+            api_version: metal3.io/v1alpha1
+            kind: BareMetalHost
+            namespace: "{{ bmh_namespace }}"
+            name: "{{ bmh_name }}"
+          register: bmh_deprovision_status
+          until: bmh_deprovision_status.resources[0].status.provisioning.state | default('') in ["available", "ready"]
+          retries: 120
+          delay: 30
+
+    - name: Delete networkData Secret
+      kubernetes.core.k8s:
+        api_version: v1
+        kind: Secret
+        namespace: "{{ bmh_namespace }}"
+        name: "{{ bmh_name }}-network-data"
+        state: absent
+
+- name: Metal3 deprovisioning completed
+  ansible.builtin.debug:
+    msg: "Metal3 deprovisioning completed for BMH {{ bmh_namespace }}/{{ bmh_name }}"


### PR DESCRIPTION
## Summary

Adds the `bm_host_metal3_provisioning` template role for provisioning and deprovisioning bare metal hosts via the Metal3/BMO backend.

**create.yaml:**
- Validates `hostClass == "metal3"`, parses `templateParameters` for `imageURL`, `imageChecksum`, `checksumType`, `networkData`, `sshKey`, and `userDataSecret`
- Creates `networkData` and `userData` Secrets in the BMH namespace as needed
- Patches BMH `spec.image`, `spec.networkData`, and `spec.userData`, then waits for `provisioned` state
- Idempotent — skips provisioning if BMH already has the correct image
- SSH key injection: generates cloud-init with `ssh_authorized_keys`, or merges into existing cloud-config user data
- Fails if SSH key injection is requested but user data is not in cloud-config format

**delete.yaml:**
- Patches BMH to remove `spec.image`, `spec.networkData`, and `spec.userData`
- Waits for BMH to return to `available`/`ready` state
- Deletes `networkData` and `userData` Secrets

## Test plan

Validated end-to-end on ostest cluster:

- [x] Provision BMH with image only — BMI reaches `Ready`, BMH reaches `provisioned`
- [x] Deprovision — BMH returns to `available`, image cleared, Secrets cleaned up
- [x] Provision with `sshKey` — userData Secret created with cloud-init `ssh_authorized_keys`, BMH `spec.userData` set
- [x] SSH connectivity verified (`ssh fedora@<host>` using injected key)
- [x] Deprovision with userData — Secret deleted, `spec.userData` cleared
- [x] `ansible-lint` passes

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Metal3 BareMetalHost provisioning workflow with image configuration, user data, and network data management.
  * Added Metal3 BareMetalHost deprovisioning workflow with automatic resource cleanup and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->