### PR TITLE
NO-ISSUE: Fix NMStateConfig, nmstate apply, and DNS zone override

### DIFF
--- a/collections/ansible_collections/netris/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/netris/steps/roles/cluster_infra/tasks/create.yaml
@@ -229,7 +229,7 @@
     nmstate_config_state: present
     nmstate_config_cluster_name: "{{ cluster_infra_name }}"
     nmstate_config_agents: "{{ cluster_agents_for_netris.resources }}"
-    nmstate_config_interface_names: "{{ server_cluster_template_server_nics }}"
+    nmstate_config_interface_names: "{{ _server_vpc_interfaces }}"
     nmstate_config_server_interfaces: "{{ _server_vpc_interfaces }}"
     nmstate_config_mgmt_interface: "{{ _server_mgmt_interface }}"
     nmstate_config_apply_live: false
@@ -241,7 +241,7 @@
     nmstate_config_state: present
     nmstate_config_cluster_name: "{{ cluster_infra_name }}"
     nmstate_config_agents: "{{ _newly_added_agents }}"
-    nmstate_config_interface_names: "{{ server_cluster_template_server_nics }}"
+    nmstate_config_interface_names: "{{ _server_vpc_interfaces }}"
     nmstate_config_server_interfaces: "{{ _server_vpc_interfaces }}"
     nmstate_config_mgmt_interface: "{{ _server_mgmt_interface }}"
   when: _newly_added_agents | length > 0

--- a/collections/ansible_collections/netris/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/netris/steps/roles/external_access/tasks/create.yaml
@@ -142,7 +142,7 @@
     name: dns.api.dns
     tasks_from: create
   vars:
-    dns_zone: "{{ external_access_base_domain }}"
+    dns_zone: "{{ lookup('env', 'DNS_ZONE') | default(external_access_base_domain, true) }}"
     dns_record_name: "{{ item.name }}"
     dns_record_type: A
     dns_record_ttl: "{{ external_access_dns_ttl }}"

--- a/collections/ansible_collections/netris/steps/roles/external_access/tasks/delete.yaml
+++ b/collections/ansible_collections/netris/steps/roles/external_access/tasks/delete.yaml
@@ -53,7 +53,7 @@
     name: dns.api.dns
     tasks_from: delete
   vars:
-    dns_zone: "{{ external_access_base_domain }}"
+    dns_zone: "{{ lookup('env', 'DNS_ZONE') | default(external_access_base_domain, true) }}"
     dns_record_name: "{{ item }}"
     dns_record_type: A
   loop:

--- a/collections/ansible_collections/osac/service/roles/nmstate_config/tasks/apply_single.yaml
+++ b/collections/ansible_collections/osac/service/roles/nmstate_config/tasks/apply_single.yaml
@@ -37,6 +37,17 @@
     dest: "/tmp/nmstate-{{ _nmstate_apply_assignment.agent.metadata.name }}.yaml"
     mode: "0644"
 
+- name: "Disable rp_filter on agent {{ _nmstate_apply_assignment.agent.metadata.name }}"
+  ansible.builtin.shell:
+    cmd: |
+      ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 \
+        -o 'ProxyCommand=ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 -i {{ nmstate_config_ssh_bastion_key }} -W %h:%p {{ nmstate_config_ssh_bastion_user }}@{{ nmstate_config_ssh_bastion_host }}' \
+        -i {{ nmstate_config_ssh_key }} \
+        {{ nmstate_config_ssh_user }}@{{ _nmstate_apply_mgmt_ip }} \
+        'sudo sysctl -qw net.ipv4.conf.all.rp_filter=0 net.ipv4.conf.{{ nmstate_config_mgmt_interface }}.rp_filter=0'
+  changed_when: false
+  no_log: true
+
 - name: "Copy nmstate config to agent {{ _nmstate_apply_assignment.agent.metadata.name }}"
   ansible.builtin.shell:
     cmd: |
@@ -55,7 +66,7 @@
         -o 'ProxyCommand=ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=30 -i {{ nmstate_config_ssh_bastion_key }} -W %h:%p {{ nmstate_config_ssh_bastion_user }}@{{ nmstate_config_ssh_bastion_host }}' \
         -i {{ nmstate_config_ssh_key }} \
         {{ nmstate_config_ssh_user }}@{{ _nmstate_apply_mgmt_ip }} \
-        'sudo nmstatectl apply /tmp/nmstate-config.yaml'
+        'nohup sudo nmstatectl apply /tmp/nmstate-config.yaml > /tmp/nmstate-apply.log 2>&1 &'
   changed_when: true
   no_log: true
 

--- a/collections/ansible_collections/osac/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/osac/steps/roles/external_access/tasks/create.yaml
@@ -73,7 +73,7 @@
     name: dns.api.dns
     tasks_from: create
   vars:
-    dns_zone: "{{ external_access_base_domain }}"
+    dns_zone: "{{ lookup('env', 'DNS_ZONE') | default(external_access_base_domain, true) }}"
     dns_record_name: "{{ item.name }}"
     dns_record_type: A
     dns_record_ttl: "{{ external_access_dns_ttl }}"

--- a/collections/ansible_collections/osac/steps/roles/external_access/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/steps/roles/external_access/tasks/delete.yaml
@@ -13,7 +13,7 @@
     name: dns.api.dns
     tasks_from: delete
   vars:
-    dns_zone: "{{ external_access_base_domain }}"
+    dns_zone: "{{ lookup('env', 'DNS_ZONE') | default(external_access_base_domain, true) }}"
     dns_record_name: "{{ item }}"
     dns_record_type: A
   loop:


### PR DESCRIPTION
## Summary

- Fix NMStateConfig MAC mapping to use Linux interface names (`ens5`) instead of hardware NIC names from the server cluster template
- Run `nmstatectl apply` detached with `nohup` to survive SSH connection drop when network config changes disconnect the management interface
- Disable `rp_filter` on mgmt interface before NMState apply to maintain SSH connectivity through the bastion
- Allow `DNS_ZONE` env var to override the Route 53 hosted zone in external_access roles, enabling split-zone setups where the hosted zone differs from the cluster base domain (e.g., records under `lab.example.com` in hosted zone `example.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)