### PR TITLE
Add bare metal template publishing support

### DIFF
--- a/collections/ansible_collections/osac/service/playbooks/publish_templates.yaml
+++ b/collections/ansible_collections/osac/service/playbooks/publish_templates.yaml
@@ -35,6 +35,10 @@
       ansible.builtin.debug:
         var: osac_compute_instance_templates
 
+    - name: Print BareMetalInstance templates found.
+      ansible.builtin.debug:
+        var: osac_bare_metal_instance_templates
+
     - name: Print NetworkClass definitions found.
       ansible.builtin.debug:
         var: osac_network_classes

--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -265,6 +265,7 @@ class TemplateTypeEnum(StrEnum):
     compute_instance = "compute_instance"
     network = "network"
     storage_provider = "storage_provider"
+    bare_metal_instance = "bare_metal_instance"
 
 
 class NetworkClassCapabilities(Base):
@@ -346,6 +347,16 @@ class ComputeInstanceTemplate(BaseTemplate):
         default=TemplateTypeEnum.compute_instance, exclude=True
     )
     spec_defaults: ComputeInstanceTemplateSpecDefaults | None = None
+
+
+class BareMetalInstanceTemplate(BaseTemplate):
+    """Template for BareMetalInstance deployments"""
+
+    template_type: Literal[TemplateTypeEnum.bare_metal_instance] = pydantic.Field(
+        default=TemplateTypeEnum.bare_metal_instance, exclude=True
+    )
+    # BareMetalInstanceTemplate API does not support parameters field
+    parameters: list[TemplateParameter] = pydantic.Field(default_factory=list, exclude=True)
 
 
 class NetworkClassTemplate(Base):
@@ -544,8 +555,15 @@ class Collection(Base):
                             f"Skipping storage_provider role '{path.name}' in collection '{self.name}'"
                         )
                         continue
-                    else:
+                    elif metadata.template_type == TemplateTypeEnum.bare_metal_instance:
+                        yield BareMetalInstanceTemplate(**common)
+                    elif metadata.template_type == TemplateTypeEnum.compute_instance:
                         yield ComputeInstanceTemplate(**common, spec_defaults=metadata.spec_defaults)
+                    else:
+                        display.warning(
+                            f"Unknown template_type '{metadata.template_type}' for role '{path.name}' "
+                            f"in collection '{self.name}'"
+                        )
                 except Exception as e:
                     display.warning(
                         f"Failed to create template for role '{path.name}' in collection '{self.name}': {e}"
@@ -709,6 +727,7 @@ class FilterModule:
         return {
             "find_cluster_template_roles": find_template_roles_filter(TemplateTypeEnum.cluster),
             "find_compute_instance_template_roles": find_template_roles_filter(TemplateTypeEnum.compute_instance),
+            "find_bare_metal_instance_template_roles": find_template_roles_filter(TemplateTypeEnum.bare_metal_instance),
             "find_network_class_roles": find_network_class_roles_filter,
         }
 
@@ -716,15 +735,15 @@ class FilterModule:
 if __name__ == "__main__":
     import sys
 
-    # Usage: python find_template_roles.py --type cluster|compute_instance|network collection1 collection2 ...
+    # Usage: python find_template_roles.py --type cluster|compute_instance|bare_metal_instance|network collection1 collection2 ...
     if "--type" not in sys.argv:
         print("Error: --type parameter is required", file=sys.stderr)
-        print("Usage: python find_template_roles.py --type cluster|compute_instance|network collection1 collection2 ...", file=sys.stderr)
+        print("Usage: python find_template_roles.py --type cluster|compute_instance|bare_metal_instance|network collection1 collection2 ...", file=sys.stderr)
         sys.exit(1)
 
     type_idx = sys.argv.index("--type")
     if type_idx + 1 >= len(sys.argv):
-        print("Error: --type requires a value (cluster, compute_instance, or network)", file=sys.stderr)
+        print("Error: --type requires a value (cluster, compute_instance, bare_metal_instance, or network)", file=sys.stderr)
         sys.exit(1)
 
     template_type = sys.argv[type_idx + 1]
@@ -732,17 +751,19 @@ if __name__ == "__main__":
 
     if not collections:
         print("Error: At least one collection name is required", file=sys.stderr)
-        print("Usage: python find_template_roles.py --type cluster|compute_instance|network collection1 collection2 ...", file=sys.stderr)
+        print("Usage: python find_template_roles.py --type cluster|compute_instance|bare_metal_instance|network collection1 collection2 ...", file=sys.stderr)
         sys.exit(1)
 
     if template_type == TemplateTypeEnum.cluster:
         filter_func = find_template_roles_filter(TemplateTypeEnum.cluster)
     elif template_type == TemplateTypeEnum.compute_instance:
         filter_func = find_template_roles_filter(TemplateTypeEnum.compute_instance)
+    elif template_type == TemplateTypeEnum.bare_metal_instance:
+        filter_func = find_template_roles_filter(TemplateTypeEnum.bare_metal_instance)
     elif template_type == TemplateTypeEnum.network:
         filter_func = find_network_class_roles_filter
     else:
-        print(f"Error: Invalid template type '{template_type}'. Must be 'cluster', 'compute_instance', or 'network'", file=sys.stderr)
+        print(f"Error: Invalid template type '{template_type}'. Must be 'cluster', 'compute_instance', 'bare_metal_instance', or 'network'", file=sys.stderr)
         sys.exit(1)
 
     found = filter_func(collections)

--- a/collections/ansible_collections/osac/service/roles/enumerate_templates/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/enumerate_templates/tasks/main.yaml
@@ -6,6 +6,10 @@
   ansible.builtin.set_fact:
     osac_compute_instance_templates: "{{ osac_template_collections | osac.service.find_compute_instance_template_roles }}"
 
+- name: Enumerate BareMetalInstance templates
+  ansible.builtin.set_fact:
+    osac_bare_metal_instance_templates: "{{ osac_template_collections | osac.service.find_bare_metal_instance_template_roles }}"
+
 - name: Enumerate NetworkClass definitions
   ansible.builtin.set_fact:
     osac_network_classes: "{{ osac_template_collections | osac.service.find_network_class_roles }}"

--- a/collections/ansible_collections/osac/service/roles/publish_templates/defaults/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/defaults/main.yaml
@@ -1,4 +1,5 @@
 ---
 publish_templates_cluster_api_endpoint: "{{ osac_fulfillment_service_uri }}/api/private/v1/cluster_templates"
 publish_templates_compute_instance_api_endpoint: "{{ osac_fulfillment_service_uri }}/api/private/v1/compute_instance_templates"
+publish_templates_bare_metal_instance_api_endpoint: "{{ osac_fulfillment_service_uri }}/api/private/v1/baremetal_instance_templates"
 publish_templates_network_class_api_endpoint: "{{ osac_fulfillment_service_uri }}/api/private/v1/network_classes"

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tasks/bare_metal_instances.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tasks/bare_metal_instances.yaml
@@ -1,0 +1,45 @@
+- name: Get list of existing BareMetalInstance templates
+  ansible.builtin.uri:
+    url: "{{ publish_templates_bare_metal_instance_api_endpoint }}"
+    validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
+    headers:
+      authorization: Bearer {{ osac_fulfillment_service_token }}
+  register: bare_metal_instance_template_check
+
+- name: Create list of existing BareMetalInstance template IDs
+  ansible.builtin.set_fact:
+    bare_metal_instance_template_ids: >-
+      {{
+      bare_metal_instance_template_check | json_query("json.items[].id")
+      }}
+  when: bare_metal_instance_template_check is success and bare_metal_instance_template_check.json.get('items', []) | length > 0
+
+- name: Update existing BareMetalInstance template
+  loop: "{{ osac_bare_metal_instance_templates }}"
+  loop_control:
+    label: "{{ template.id }}"
+    loop_var: template
+  when: bare_metal_instance_template_ids is defined and template.id in bare_metal_instance_template_ids
+  ansible.builtin.uri:
+    url: "{{ publish_templates_bare_metal_instance_api_endpoint }}/{{ template.id }}"
+    validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
+    method: PATCH
+    headers:
+      authorization: Bearer {{ osac_fulfillment_service_token }}
+    body_format: json
+    body: "{{ template }}"
+
+- name: Create new BareMetalInstance template
+  loop: "{{ osac_bare_metal_instance_templates }}"
+  loop_control:
+    label: "{{ template.id }}"
+    loop_var: template
+  when: bare_metal_instance_template_ids is not defined or template.id not in bare_metal_instance_template_ids
+  ansible.builtin.uri:
+    url: "{{ publish_templates_bare_metal_instance_api_endpoint }}"
+    validate_certs: "{{ publish_templates_validate_certs | default(true) | bool }}"
+    method: POST
+    headers:
+      authorization: Bearer {{ osac_fulfillment_service_token }}
+    body_format: json
+    body: "{{ template }}"

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tasks/main.yaml
@@ -5,5 +5,8 @@
 - name: Apply templates for compute instances
   ansible.builtin.import_tasks: compute_instances.yaml
 
+- name: Apply templates for bare metal instances
+  ansible.builtin.import_tasks: bare_metal_instances.yaml
+
 - name: Apply network classes
   ansible.builtin.import_tasks: network_classes.yaml

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/defaults/main.yaml
@@ -1,0 +1,5 @@
+---
+# Default values for bare metal host agent provisioning
+
+# Default provisioning network
+provisioningNetwork: "provisioning"

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/meta/osac.yaml
@@ -1,0 +1,9 @@
+# Define the display name and description of the template
+title: Bare Metal Host Agent Provisioning
+description: >
+  Provisions bare metal hosts with agent-based images using OpenStack Ironic.
+  Requires hostClass 'openstack' and networkClass 'openstack'.
+  Supports ramdisk-based deployment with custom ISO images.
+
+# Specify this is a BareMetalInstance template
+template_type: bare_metal_instance


### PR DESCRIPTION
- Add BareMetalInstanceTemplate class to find_template_roles.py
- Create meta/osac.yaml for bm_host_agent_provisioning role
- Create defaults/main.yaml with default provisioning network
- Add bare_metal_instance to TemplateTypeEnum
- Update template generation logic to handle bare_metal_instance type
- Add find_bare_metal_instance_template_roles filter
- Update enumerate_templates role to discover bare metal templates
- Create publish_templates/tasks/bare_metal_instances.yaml
- Update publish_templates to publish bare metal templates
- Add API endpoint for bare_metal_instance_templates

This enables the bm_host_agent_provisioning role to be discovered and published as a BareMetalInstance template through the standard template publishing workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bare metal instance template type support for discovery, filtering, and enumeration.
  * Added publication workflow for bare metal instance templates, including configurable endpoint and create/update logic.
  * Introduced “Bare Metal Host Agent Provisioning” template with default `provisioningNetwork`.
* **Bug Fixes**
  * Enhanced the publish playbook with additional debug output to display discovered bare metal instance templates before publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->