### PR TITLE
OSAC-1326: adds VAST RBAC Realm and restricted Role for CSI credential

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
@@ -31,6 +31,13 @@ vast_storage_vip_pool_subnet_cidr: "{{ lookup('env', 'VAST_VIP_POOL_SUBNET_CIDR'
 vast_storage_vip_pool_gw_ip: "{{ lookup('env', 'VAST_VIP_POOL_GW_IP') | default('', true) }}"
 vast_storage_vip_pool_gw_ipv6: "{{ lookup('env', 'VAST_VIP_POOL_GW_IPV6') | default('', true) }}"
 
+# Client IP ranges for tenant NFS access on shared VIP pools.
+# Required when using shared (tenant_id=null) VIP pools — VAST resolves the
+# tenant by matching the NFS client's source IP against each tenant's ranges.
+# Without this, NFS access is denied for non-default tenants.
+# Format: JSON array of [start, end] pairs, e.g. '[["10.0.0.1","10.0.0.10"]]'
+vast_storage_client_ip_ranges: "{{ lookup('env', 'VAST_CLIENT_IP_RANGES') | default('', true) }}"
+
 # Local provider naming — each tenant gets its own identity provider.
 vast_storage_local_provider_prefix: "lp-"
 

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
@@ -25,6 +25,7 @@ vast_storage_api_timeout: 30
 # Tenant isolation relies on source-based access control, not per-pool separation.
 # The pool is created idempotently during the first tenant setup.
 vast_storage_vip_pool_name: "{{ lookup('env', 'VAST_VIP_POOL_NAME') | default('osac-shared', true) }}"
+vast_storage_vip_pool_fqdn: "{{ lookup('env', 'VAST_VIP_POOL_FQDN') | default('', true) }}"
 vast_storage_vip_pool_ip_ranges: "{{ lookup('env', 'VAST_VIP_POOL_IP_RANGES') | default('', true) }}"
 vast_storage_vip_pool_subnet_cidr: "{{ lookup('env', 'VAST_VIP_POOL_SUBNET_CIDR') | default('', true) }}"
 vast_storage_vip_pool_gw_ip: "{{ lookup('env', 'VAST_VIP_POOL_GW_IP') | default('', true) }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
@@ -31,6 +31,9 @@ vast_storage_vip_pool_subnet_cidr: "{{ lookup('env', 'VAST_VIP_POOL_SUBNET_CIDR'
 vast_storage_vip_pool_gw_ip: "{{ lookup('env', 'VAST_VIP_POOL_GW_IP') | default('', true) }}"
 vast_storage_vip_pool_gw_ipv6: "{{ lookup('env', 'VAST_VIP_POOL_GW_IPV6') | default('', true) }}"
 
+# Local provider naming — each tenant gets its own identity provider.
+vast_storage_local_provider_prefix: "lp-"
+
 # CSI Operator installation via OLM
 vast_storage_csi_operator_namespace: "vast-csi-system"
 vast_storage_csi_operator_channel: "stable"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_qos_policy.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_qos_policy.yaml
@@ -1,6 +1,10 @@
 ---
 # Creates per-tier QoS policies on VAST via REST API for tiers that define qos_policy.
 # Uses ansible.builtin.uri because the vendored collection has no QoS module.
+# NOTE: VAST 5.4.x only supports policy_type VIEW and USER — no VOLUME type.
+# Block StorageClasses must NOT reference qos_policy (the CSI driver rejects
+# VIEW-type policies on volumes). QoS for block is deferred until VAST adds
+# VOLUME-type QoS support.
 #
 # Requires in scope:
 #   _vast_vms_conn      — VAST VMS connection dict (admin or tenant manager)
@@ -10,9 +14,9 @@
 # Sets output fact:
 #   _vast_qos_policy_names — list of created QoS policy names
 
-- name: Filter tiers with qos_policy defined
+- name: Filter NFS tiers with qos_policy defined (block QoS not supported on VAST 5.4.x)
   ansible.builtin.set_fact:
-    _vast_qos_tiers: "{{ _provider_tiers | selectattr('qos_policy', 'defined') | list }}"
+    _vast_qos_tiers: "{{ _provider_tiers | selectattr('qos_policy', 'defined') | rejectattr('protocol', 'equalto', 'block') | list }}"
 
 - name: Skip QoS policy creation when no tiers define qos_policy
   when: _vast_qos_tiers | length == 0

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_tenant_manager.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_tenant_manager.yaml
@@ -1,17 +1,13 @@
 ---
-# Creates a per-tenant VMS Manager as TENANT_ADMIN with a Custom Realm
-# that restricts the CSI credential from creating Views. The Realm excludes
-# 'view' from its object types — CRUD permissions (create_/edit_/delete_)
-# only apply to objects within the Realm. Read-only access to all objects
-# (including views) is granted via the built-in 'view_logical' permission.
+# Creates a per-tenant VMS Manager as TENANT_ADMIN with logical CRUD permissions.
 #
 # TENANT_ADMIN auth requires the X-Tenant-Name header on /api/token/.
 # The CSI Secret MUST include the 'tenant' field so the CSI driver sets
 # this header automatically.
 #
-# Flow: auth as admin → create realm → create role → create manager.
+# Flow: auth as admin → create role → create manager.
 # Uses ansible.builtin.uri because vastdata.vms has no modules for
-# realms/roles/managers.
+# roles/managers.
 #
 # Requires in scope (set by setup.yaml before calling this file):
 #   vast_endpoint                            — VMS API hostname
@@ -29,7 +25,6 @@
 #   _vast_tenant_manager_password
 #   _vast_tenant_manager_id
 #   _vast_tenant_role_id
-#   _vast_tenant_realm_id
 
 - name: Assert VAST tenant ID is available
   ansible.builtin.assert:
@@ -64,7 +59,6 @@
     _vast_tenant_manager_password: "{{ _vast_tenant_secret_check.resources[0].data.tenant_manager_password | b64decode }}"
     _vast_tenant_manager_id: "{{ (_vast_tenant_secret_check.resources[0].data.tenant_manager_id | default('') | b64decode) }}"
     _vast_tenant_role_id: "{{ (_vast_tenant_secret_check.resources[0].data.tenant_role_id | default('') | b64decode) }}"
-    _vast_tenant_realm_id: "{{ (_vast_tenant_secret_check.resources[0].data.tenant_realm_id | default('') | b64decode) }}"
     _vast_tenant_manager_already_exists: true
   no_log: true
 
@@ -73,7 +67,7 @@
   ansible.builtin.debug:
     msg: "Tenant manager for '{{ tenant_name }}' already exists in hub Secret — skipping creation."
 
-- name: Create per-tenant VMS Manager with Custom Realm and restricted Role
+- name: Create per-tenant VMS Manager with CSI role
   when: not (_vast_tenant_manager_already_exists | default(false))
   block:
     - name: Set tenant manager name
@@ -103,74 +97,7 @@
       register: _vast_admin_auth
       no_log: true
 
-    # --- Custom Realm ---
-    # The Realm excludes 'view' so CRUD permissions cannot create Views.
-    # Objects not in the Realm are still readable via 'view_logical'.
-
-    - name: Check if tenant CSI realm already exists
-      ansible.builtin.uri:
-        url: "https://{{ vast_endpoint }}/api/realms/?name=osac-csi-{{ tenant_name }}"
-        method: GET
-        headers:
-          Authorization: "Bearer {{ _vast_admin_auth.json.access }}"
-        validate_certs: "{{ vast_storage_validate_certs }}"
-        timeout: "{{ vast_storage_api_timeout | int }}"
-        status_code: [200]
-      register: _vast_realm_check
-      no_log: true
-
-    - name: Create Custom Realm for per-tenant CSI credential
-      when: _vast_realm_check.json | length == 0
-      ansible.builtin.uri:
-        url: "https://{{ vast_endpoint }}/api/realms/"
-        method: POST
-        body_format: json
-        body:
-          name: "osac-csi-{{ tenant_name }}"
-          object_types:
-            - blockhost
-            - dns
-            - globalsnapstream
-            - kafkabroker
-            - nativereplicationremotetarget
-            - openfilesquery
-            - protectedpath
-            - protectionpolicy
-            - quota
-            - quotaentityinfo
-            - replicationrestorepoint
-            - replicationstream
-            - replicationtarget
-            - s3lifecyclerule
-            - snapshot
-            - userquota
-            - volume
-          tenant_id: "{{ _vast_tenant_result.tenants.id | int }}"
-        headers:
-          Authorization: "Bearer {{ _vast_admin_auth.json.access }}"
-        validate_certs: "{{ vast_storage_validate_certs }}"
-        timeout: "{{ vast_storage_api_timeout | int }}"
-        status_code: [200, 201]
-      register: _vast_realm_create_result
-      no_log: true
-
-    - name: Set realm ID from creation or existing lookup
-      ansible.builtin.set_fact:
-        _vast_tenant_realm_id: >-
-          {{ (_vast_realm_create_result.json.id | default(''))
-             if (_vast_realm_check.json | length == 0)
-             else (_vast_realm_check.json[0].id | default('')) }}
-
-    - name: Fail if realm ID is not available
-      ansible.builtin.fail:
-        msg: "Failed to create or find CSI realm 'osac-csi-{{ tenant_name }}'. Check VMS API permissions."
-      when: _vast_tenant_realm_id | string | length == 0
-
-    - name: Log CSI realm status
-      ansible.builtin.debug:
-        msg: "CSI realm 'osac-csi-{{ tenant_name }}' {{ 'created' if (_vast_realm_check.json | length == 0) else 'already exists' }} (id: {{ _vast_tenant_realm_id }})"
-
-    # --- Role with realm-scoped permissions ---
+    # --- Role with logical CRUD permissions ---
 
     - name: Check if tenant CSI role already exists
       ansible.builtin.uri:
@@ -184,7 +111,7 @@
       register: _vast_role_check
       no_log: true
 
-    - name: Create CSI role with realm-scoped permissions
+    - name: Create CSI role with logical CRUD permissions
       when: _vast_role_check.json | length == 0
       ansible.builtin.uri:
         url: "https://{{ vast_endpoint }}/api/roles/"
@@ -192,14 +119,12 @@
         body_format: json
         body:
           name: "osac-csi-{{ tenant_name }}"
-          realm_id: "{{ _vast_tenant_realm_id | int }}"
           tenant_id: "{{ _vast_tenant_result.tenants.id | int }}"
           permissions_list:
-            - "create_osac-csi-{{ tenant_name }}"
-            - "view_osac-csi-{{ tenant_name }}"
-            - "edit_osac-csi-{{ tenant_name }}"
-            - "delete_osac-csi-{{ tenant_name }}"
+            - create_logical
             - view_logical
+            - edit_logical
+            - delete_logical
         headers:
           Authorization: "Bearer {{ _vast_admin_auth.json.access }}"
         validate_certs: "{{ vast_storage_validate_certs }}"
@@ -285,8 +210,6 @@
     - name: Clear intermediate auth facts
       ansible.builtin.set_fact:
         _vast_admin_auth: {}
-        _vast_realm_check: {}
-        _vast_realm_create_result: {}
         _vast_role_check: {}
         _vast_role_create_result: {}
         _vast_manager_check: {}
@@ -295,5 +218,5 @@
 
 - name: Log tenant manager creation outcome
   ansible.builtin.debug:
-    msg: "VMS manager 'osac-{{ tenant_name }}' created as TENANT_ADMIN with realm 'osac-csi-{{ tenant_name }}'"
+    msg: "VMS manager 'osac-{{ tenant_name }}' created as TENANT_ADMIN with logical CRUD permissions"
   when: not (_vast_tenant_manager_already_exists | default(false))

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_tenant_manager.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_tenant_manager.yaml
@@ -1,16 +1,17 @@
 ---
-# Creates a per-tenant VMS Manager with a CSI role for storage operations.
-# The manager is NOT created as TENANT_ADMIN — it defaults to SUPER_ADMIN.
-# TENANT_ADMIN users are blocked from /api/v1/versions/ (hard VMS restriction,
-# not a permission issue), which the CSI driver's @requisite(semver="5.3.0")
-# decorator requires before any storage operation. The tenant scoping comes
-# from the role's tenant_id and the tenant_name StorageClass parameter instead.
-# The CSI Secret intentionally omits the 'tenant' field — including it causes
-# the CSI driver to set X-Tenant-Name on the /api/v1/token/ login call, which
-# tenant-scopes the JWT and blocks /api/v1/versions/ even for SUPER_ADMIN users.
+# Creates a per-tenant VMS Manager as TENANT_ADMIN with a Custom Realm
+# that restricts the CSI credential from creating Views. The Realm excludes
+# 'view' from its object types — CRUD permissions (create_/edit_/delete_)
+# only apply to objects within the Realm. Read-only access to all objects
+# (including views) is granted via the built-in 'view_logical' permission.
 #
-# Flow: auth as admin → create role → create manager.
-# Uses ansible.builtin.uri because vastdata.vms has no modules for managers/roles.
+# TENANT_ADMIN auth requires the X-Tenant-Name header on /api/token/.
+# The CSI Secret MUST include the 'tenant' field so the CSI driver sets
+# this header automatically.
+#
+# Flow: auth as admin → create realm → create role → create manager.
+# Uses ansible.builtin.uri because vastdata.vms has no modules for
+# realms/roles/managers.
 #
 # Requires in scope (set by setup.yaml before calling this file):
 #   vast_endpoint                            — VMS API hostname
@@ -28,6 +29,7 @@
 #   _vast_tenant_manager_password
 #   _vast_tenant_manager_id
 #   _vast_tenant_role_id
+#   _vast_tenant_realm_id
 
 - name: Assert VAST tenant ID is available
   ansible.builtin.assert:
@@ -62,6 +64,7 @@
     _vast_tenant_manager_password: "{{ _vast_tenant_secret_check.resources[0].data.tenant_manager_password | b64decode }}"
     _vast_tenant_manager_id: "{{ (_vast_tenant_secret_check.resources[0].data.tenant_manager_id | default('') | b64decode) }}"
     _vast_tenant_role_id: "{{ (_vast_tenant_secret_check.resources[0].data.tenant_role_id | default('') | b64decode) }}"
+    _vast_tenant_realm_id: "{{ (_vast_tenant_secret_check.resources[0].data.tenant_realm_id | default('') | b64decode) }}"
     _vast_tenant_manager_already_exists: true
   no_log: true
 
@@ -70,7 +73,7 @@
   ansible.builtin.debug:
     msg: "Tenant manager for '{{ tenant_name }}' already exists in hub Secret — skipping creation."
 
-- name: Create per-tenant VMS Manager with CSI role
+- name: Create per-tenant VMS Manager with Custom Realm and restricted Role
   when: not (_vast_tenant_manager_already_exists | default(false))
   block:
     - name: Set tenant manager name
@@ -100,7 +103,76 @@
       register: _vast_admin_auth
       no_log: true
 
-    # Idempotency for partial failures: check if role already exists in VMS
+    # --- Custom Realm ---
+    # The Realm excludes 'view' so CRUD permissions cannot create Views.
+    # Objects not in the Realm are still readable via 'view_logical'.
+
+    - name: Check if tenant CSI realm already exists
+      ansible.builtin.uri:
+        url: "https://{{ vast_endpoint }}/api/realms/?name=osac-csi-{{ tenant_name }}"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ _vast_admin_auth.json.access }}"
+        validate_certs: "{{ vast_storage_validate_certs }}"
+        timeout: "{{ vast_storage_api_timeout | int }}"
+        status_code: [200]
+      register: _vast_realm_check
+      no_log: true
+
+    - name: Create Custom Realm for per-tenant CSI credential
+      when: _vast_realm_check.json | length == 0
+      ansible.builtin.uri:
+        url: "https://{{ vast_endpoint }}/api/realms/"
+        method: POST
+        body_format: json
+        body:
+          name: "osac-csi-{{ tenant_name }}"
+          object_types:
+            - blockhost
+            - dns
+            - globalsnapstream
+            - kafkabroker
+            - nativereplicationremotetarget
+            - openfilesquery
+            - protectedpath
+            - protectionpolicy
+            - quota
+            - quotaentityinfo
+            - replicationrestorepoint
+            - replicationstream
+            - replicationtarget
+            - s3lifecyclerule
+            - snapshot
+            - userquota
+            - volume
+            - tenant
+          tenant_id: "{{ _vast_tenant_result.tenants.id | int }}"
+        headers:
+          Authorization: "Bearer {{ _vast_admin_auth.json.access }}"
+        validate_certs: "{{ vast_storage_validate_certs }}"
+        timeout: "{{ vast_storage_api_timeout | int }}"
+        status_code: [200, 201]
+      register: _vast_realm_create_result
+      no_log: true
+
+    - name: Set realm ID from creation or existing lookup
+      ansible.builtin.set_fact:
+        _vast_tenant_realm_id: >-
+          {{ (_vast_realm_create_result.json.id | default(''))
+             if (_vast_realm_check.json | length == 0)
+             else (_vast_realm_check.json[0].id | default('')) }}
+
+    - name: Fail if realm ID is not available
+      ansible.builtin.fail:
+        msg: "Failed to create or find CSI realm 'osac-csi-{{ tenant_name }}'. Check VMS API permissions."
+      when: _vast_tenant_realm_id | string | length == 0
+
+    - name: Log CSI realm status
+      ansible.builtin.debug:
+        msg: "CSI realm 'osac-csi-{{ tenant_name }}' {{ 'created' if (_vast_realm_check.json | length == 0) else 'already exists' }} (id: {{ _vast_tenant_realm_id }})"
+
+    # --- Role with realm-scoped permissions ---
+
     - name: Check if tenant CSI role already exists
       ansible.builtin.uri:
         url: "https://{{ vast_endpoint }}/api/roles/?name=osac-csi-{{ tenant_name }}"
@@ -113,7 +185,7 @@
       register: _vast_role_check
       no_log: true
 
-    - name: Create CSI role for per-tenant manager
+    - name: Create CSI role with realm-scoped permissions
       when: _vast_role_check.json | length == 0
       ansible.builtin.uri:
         url: "https://{{ vast_endpoint }}/api/roles/"
@@ -121,12 +193,14 @@
         body_format: json
         body:
           name: "osac-csi-{{ tenant_name }}"
-          # tenant_id: "{{ _vast_tenant_result.tenants.id | int }}"
+          realm_id: "{{ _vast_tenant_realm_id | int }}"
+          tenant_id: "{{ _vast_tenant_result.tenants.id | int }}"
           permissions_list:
-            - create_logical
+            - "create_osac-csi-{{ tenant_name }}"
+            - "view_osac-csi-{{ tenant_name }}"
+            - "edit_osac-csi-{{ tenant_name }}"
+            - "delete_osac-csi-{{ tenant_name }}"
             - view_logical
-            - edit_logical
-            - delete_logical
         headers:
           Authorization: "Bearer {{ _vast_admin_auth.json.access }}"
         validate_certs: "{{ vast_storage_validate_certs }}"
@@ -151,7 +225,8 @@
       ansible.builtin.debug:
         msg: "CSI role 'osac-csi-{{ tenant_name }}' {{ 'created' if (_vast_role_check.json | length == 0) else 'already exists' }} (id: {{ _vast_tenant_role_id }})"
 
-    # Idempotency for partial failures: check if manager already exists in VMS
+    # --- Manager as TENANT_ADMIN ---
+
     - name: Check if tenant manager already exists in VMS
       ansible.builtin.uri:
         url: "https://{{ vast_endpoint }}/api/managers/?username=osac-{{ tenant_name }}"
@@ -164,7 +239,7 @@
       register: _vast_manager_check
       no_log: true
 
-    - name: Create per-tenant manager (SUPER_ADMIN default, NOT TENANT_ADMIN)
+    - name: Create per-tenant manager as TENANT_ADMIN
       when: _vast_manager_check.json | length == 0
       ansible.builtin.uri:
         url: "https://{{ vast_endpoint }}/api/managers/"
@@ -173,8 +248,8 @@
         body:
           username: "osac-{{ tenant_name }}"
           password: "{{ _vast_tenant_manager_password }}"
-          # user_type: TENANT_ADMIN
-          # tenant_id: "{{ _vast_tenant_result.tenants.id | int }}"
+          user_type: TENANT_ADMIN
+          tenant_id: "{{ _vast_tenant_result.tenants.id | int }}"
           roles:
             - "{{ _vast_tenant_role_id | int }}"
           password_expiration_disabled: true
@@ -211,6 +286,8 @@
     - name: Clear intermediate auth facts
       ansible.builtin.set_fact:
         _vast_admin_auth: {}
+        _vast_realm_check: {}
+        _vast_realm_create_result: {}
         _vast_role_check: {}
         _vast_role_create_result: {}
         _vast_manager_check: {}
@@ -219,5 +296,5 @@
 
 - name: Log tenant manager creation outcome
   ansible.builtin.debug:
-    msg: "VMS manager 'osac-{{ tenant_name }}' created with role 'osac-csi-{{ tenant_name }}'"
+    msg: "VMS manager 'osac-{{ tenant_name }}' created as TENANT_ADMIN with realm 'osac-csi-{{ tenant_name }}'"
   when: not (_vast_tenant_manager_already_exists | default(false))

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_tenant_manager.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_tenant_manager.yaml
@@ -145,7 +145,6 @@
             - snapshot
             - userquota
             - volume
-            - tenant
           tenant_id: "{{ _vast_tenant_result.tenants.id | int }}"
         headers:
           Authorization: "Bearer {{ _vast_admin_auth.json.access }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/delete_tenant_manager.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/delete_tenant_manager.yaml
@@ -1,6 +1,6 @@
 ---
-# Deletes the per-tenant VMS Manager, CSI role, and Custom Realm during teardown.
-# Uses ansible.builtin.uri because vastdata.vms has no modules for managers/roles/realms.
+# Deletes the per-tenant VMS Manager and CSI role during teardown.
+# Uses ansible.builtin.uri because vastdata.vms has no modules for managers/roles.
 # ignore_errors throughout — best-effort cleanup, resources may already be deleted.
 #
 # Requires in scope (set by teardown.yaml before calling this file):
@@ -100,36 +100,6 @@
       ignore_errors: true
       no_log: true
 
-    # Delete the Custom Realm
-    - name: Look up tenant CSI realm
-      ansible.builtin.uri:
-        url: "https://{{ vast_endpoint }}/api/realms/?name=osac-csi-{{ tenant_name }}"
-        method: GET
-        headers:
-          Authorization: "Bearer {{ _vast_admin_auth.json.access }}"
-        validate_certs: "{{ vast_storage_validate_certs }}"
-        timeout: "{{ vast_storage_api_timeout | int }}"
-        status_code: [200]
-      register: _vast_realm_lookup
-      ignore_errors: true
-      no_log: true
-
-    - name: Delete tenant CSI realm
-      when:
-        - _vast_realm_lookup is not failed
-        - _vast_realm_lookup.json | length > 0
-      ansible.builtin.uri:
-        url: "https://{{ vast_endpoint }}/api/realms/{{ _vast_realm_lookup.json[0].id }}/"
-        method: DELETE
-        headers:
-          Authorization: "Bearer {{ _vast_admin_auth.json.access }}"
-        validate_certs: "{{ vast_storage_validate_certs }}"
-        timeout: "{{ vast_storage_api_timeout | int }}"
-        status_code: [200, 204, 404]
-      register: _vast_realm_delete_result
-      ignore_errors: true
-      no_log: true
-
     - name: Set manager deletion result fact for caller
       ansible.builtin.set_fact:
         _vast_manager_delete_failed: >-
@@ -141,7 +111,6 @@
         _vast_admin_auth: {}
         _vast_manager_lookup: {}
         _vast_role_lookup: {}
-        _vast_realm_lookup: {}
       no_log: true
 
 - name: Log tenant manager deletion outcome

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/delete_tenant_manager.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/delete_tenant_manager.yaml
@@ -1,6 +1,6 @@
 ---
-# Deletes the per-tenant VMS Manager and its CSI role during teardown.
-# Uses ansible.builtin.uri because vastdata.vms has no modules for managers/roles.
+# Deletes the per-tenant VMS Manager, CSI role, and Custom Realm during teardown.
+# Uses ansible.builtin.uri because vastdata.vms has no modules for managers/roles/realms.
 # ignore_errors throughout — best-effort cleanup, resources may already be deleted.
 #
 # Requires in scope (set by teardown.yaml before calling this file):
@@ -100,6 +100,36 @@
       ignore_errors: true
       no_log: true
 
+    # Delete the Custom Realm
+    - name: Look up tenant CSI realm
+      ansible.builtin.uri:
+        url: "https://{{ vast_endpoint }}/api/realms/?name=osac-csi-{{ tenant_name }}"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ _vast_admin_auth.json.access }}"
+        validate_certs: "{{ vast_storage_validate_certs }}"
+        timeout: "{{ vast_storage_api_timeout | int }}"
+        status_code: [200]
+      register: _vast_realm_lookup
+      ignore_errors: true
+      no_log: true
+
+    - name: Delete tenant CSI realm
+      when:
+        - _vast_realm_lookup is not failed
+        - _vast_realm_lookup.json | length > 0
+      ansible.builtin.uri:
+        url: "https://{{ vast_endpoint }}/api/realms/{{ _vast_realm_lookup.json[0].id }}/"
+        method: DELETE
+        headers:
+          Authorization: "Bearer {{ _vast_admin_auth.json.access }}"
+        validate_certs: "{{ vast_storage_validate_certs }}"
+        timeout: "{{ vast_storage_api_timeout | int }}"
+        status_code: [200, 204, 404]
+      register: _vast_realm_delete_result
+      ignore_errors: true
+      no_log: true
+
     - name: Set manager deletion result fact for caller
       ansible.builtin.set_fact:
         _vast_manager_delete_failed: >-
@@ -111,6 +141,7 @@
         _vast_admin_auth: {}
         _vast_manager_lookup: {}
         _vast_role_lookup: {}
+        _vast_realm_lookup: {}
       no_log: true
 
 - name: Log tenant manager deletion outcome

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_csi_operator.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_csi_operator.yaml
@@ -127,6 +127,7 @@
           spec:
             driverType: "{{ item }}"
             disableUsageStats: true
+            truncateVolumeName: null
       loop: "{{ _vast_required_protocols }}"
 
     - name: Wait for all required VAST CSI drivers to be registered

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_csi_operator.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_csi_operator.yaml
@@ -126,6 +126,7 @@
             namespace: "{{ vast_storage_csi_operator_namespace }}"
           spec:
             driverType: "{{ item }}"
+            disableUsageStats: true
       loop: "{{ _vast_required_protocols }}"
 
     - name: Wait for all required VAST CSI drivers to be registered

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -264,8 +264,7 @@
                           'tenant_name': tenant_name})
                | combine({'csi.storage.k8s.io/node-stage-secret-name': _vast_csi_secret_ref.name})
                | combine({'csi.storage.k8s.io/node-stage-secret-namespace': _vast_csi_secret_ref.namespace})
-               | combine(_vast_sc_block_encryption_params | default({}))
-               | combine(({'qos_policy': item.qos_policy} if item.qos_policy is defined else {})) }}
+               | combine(_vast_sc_block_encryption_params | default({})) }}
           reclaimPolicy: Delete
           volumeBindingMode: WaitForFirstConsumer
       loop: "{{ _vast_block_tiers }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -125,18 +125,16 @@
       no_log: true
 
     # CSI Secret uses per-tenant Manager username/password — NEVER admin creds.
-    # The 'tenant' field is intentionally OMITTED. Including it causes the CSI
-    # driver to set X-Tenant-Name on the /api/v1/token/ login call, which
-    # tenant-scopes the JWT and blocks GET /api/v1/versions/ — a prerequisite
-    # check the driver makes before every storage operation. Tenant scoping is
-    # handled by the tenant_name StorageClass parameter and the role permissions.
+    # The 'tenant' field is REQUIRED — TENANT_ADMIN users must authenticate
+    # with X-Tenant-Name, and the CSI driver sets this header from the Secret's
+    # tenant field on /api/v1/token/ login calls.
     - name: Build CSI Secret data
       ansible.builtin.set_fact:
         _vast_csi_secret_data:
           username: "{{ _vast_tenant_csi_username }}"
           password: "{{ _vast_tenant_csi_password }}"
           endpoint: "{{ _vast_tenant_endpoint }}"
-          # tenant: "{{ tenant_name }}"
+          tenant: "{{ tenant_name }}"
       no_log: true
 
     - name: Add passphrase to CSI Secret data for block encryption

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -165,20 +165,28 @@
           name: "{{ _vast_csi_secret_name }}"
           namespace: "{{ tenant_namespace }}"
 
+    - name: Build VIP pool parameters for StorageClass
+      ansible.builtin.set_fact:
+        _vast_sc_vip_params: >-
+          {{ {'vip_pool_fqdn': _vast_tenant_vip_pool_fqdn, 'vip_pool_fqdn_random_prefix': 'false'}
+             if (_vast_tenant_vip_pool_fqdn | default('') | length > 0)
+             else {'vip_pool_name': _vast_tenant_vip_pool} }}
+
     - name: Build base StorageClass parameters (shared by NFS and block)
       ansible.builtin.set_fact:
-        _vast_sc_base_params:
-          vip_pool_name: "{{ _vast_tenant_vip_pool }}"
-          csi.storage.k8s.io/provisioner-secret-name: "{{ _vast_csi_secret_ref.name }}"
-          csi.storage.k8s.io/provisioner-secret-namespace: "{{ _vast_csi_secret_ref.namespace }}"
-          csi.storage.k8s.io/controller-publish-secret-name: "{{ _vast_csi_secret_ref.name }}"
-          csi.storage.k8s.io/controller-publish-secret-namespace: "{{ _vast_csi_secret_ref.namespace }}"
-          csi.storage.k8s.io/node-publish-secret-name: "{{ _vast_csi_secret_ref.name }}"
-          csi.storage.k8s.io/node-publish-secret-namespace: "{{ _vast_csi_secret_ref.namespace }}"
-          csi.storage.k8s.io/controller-expand-secret-name: "{{ _vast_csi_secret_ref.name }}"
-          csi.storage.k8s.io/controller-expand-secret-namespace: "{{ _vast_csi_secret_ref.namespace }}"
-          csi.storage.k8s.io/node-expand-secret-name: "{{ _vast_csi_secret_ref.name }}"
-          csi.storage.k8s.io/node-expand-secret-namespace: "{{ _vast_csi_secret_ref.namespace }}"
+        _vast_sc_base_params: >-
+          {{ _vast_sc_vip_params | combine({
+          'csi.storage.k8s.io/provisioner-secret-name': _vast_csi_secret_ref.name,
+          'csi.storage.k8s.io/provisioner-secret-namespace': _vast_csi_secret_ref.namespace,
+          'csi.storage.k8s.io/controller-publish-secret-name': _vast_csi_secret_ref.name,
+          'csi.storage.k8s.io/controller-publish-secret-namespace': _vast_csi_secret_ref.namespace,
+          'csi.storage.k8s.io/node-publish-secret-name': _vast_csi_secret_ref.name,
+          'csi.storage.k8s.io/node-publish-secret-namespace': _vast_csi_secret_ref.namespace,
+          'csi.storage.k8s.io/controller-expand-secret-name': _vast_csi_secret_ref.name,
+          'csi.storage.k8s.io/controller-expand-secret-namespace': _vast_csi_secret_ref.namespace,
+          'csi.storage.k8s.io/node-expand-secret-name': _vast_csi_secret_ref.name,
+          'csi.storage.k8s.io/node-expand-secret-namespace': _vast_csi_secret_ref.namespace
+          }) }}
 
     - name: Build block host encryption JSON when passphrase is available
       ansible.builtin.set_fact:
@@ -313,6 +321,8 @@
         _vast_tenant_csi_password: ""
         _vast_tenant_endpoint: ""
         _vast_tenant_vip_pool: ""
+        _vast_tenant_vip_pool_fqdn: ""
+        _vast_sc_vip_params: {}
         _vast_tenant_config_secret: {}
         _vast_vms_conn: {}
         _vast_block_encryption_passphrase: ""

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
@@ -6,9 +6,9 @@
 #
 # CALLER CONTRACT: After using this file, callers MUST clear these facts in their always block:
 #   _vast_tenant_csi_username, _vast_tenant_csi_password, _vast_tenant_vip_pool,
-#   _vast_tenant_endpoint, _vast_view_policy_name, _vast_view_policy_names,
-#   _vast_view_policy_names_raw, _vast_tenant_block_encryption_passphrase,
-#   _vast_tenant_uid_hash
+#   _vast_tenant_vip_pool_fqdn, _vast_tenant_endpoint, _vast_view_policy_name,
+#   _vast_view_policy_names, _vast_view_policy_names_raw,
+#   _vast_tenant_block_encryption_passphrase, _vast_tenant_uid_hash
 # Failure to clear leaves credentials in play-scoped facts for the remainder of the play.
 #
 # Requires:
@@ -22,6 +22,7 @@
 #   _vast_tenant_csi_username
 #   _vast_tenant_csi_password
 #   _vast_tenant_vip_pool
+#   _vast_tenant_vip_pool_fqdn
 #   _vast_tenant_endpoint
 #   _vast_view_policy_name
 #   _vast_tenant_block_encryption_passphrase

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
@@ -63,6 +63,7 @@
     _vast_tenant_csi_username: "{{ _vast_tenant_config_secret.resources[0].data.tenant_manager_username | b64decode }}"
     _vast_tenant_csi_password: "{{ _vast_tenant_config_secret.resources[0].data.tenant_manager_password | b64decode }}"
     _vast_tenant_vip_pool: "{{ _vast_tenant_config_secret.resources[0].data.vip_pool_name | b64decode }}"
+    _vast_tenant_vip_pool_fqdn: "{{ (_vast_tenant_config_secret.resources[0].data.vip_pool_fqdn | default('') | b64decode) | default('', true) }}"
     _vast_tenant_endpoint: "{{ _vast_tenant_config_secret.resources[0].data.vast_endpoint | b64decode }}"
     _vast_view_policy_name: "{{ _vast_tenant_config_secret.resources[0].data.view_policy_name | default('') | b64decode }}"
     _vast_tenant_block_encryption_passphrase: "{{ _vast_tenant_config_secret.resources[0].data.block_encryption_passphrase | default('') | b64decode | default('', true) }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -159,50 +159,6 @@
           ansible.builtin.debug:
             msg: "Created VIP pool '{{ vast_storage_vip_pool_name }}' (id: {{ _vast_vip_pool_result.vippools.id | default('unknown') }})"
 
-        - name: Authenticate for VIP pool post-configuration
-          ansible.builtin.uri:
-            url: "https://{{ vast_endpoint }}/api/token/"
-            method: POST
-            body_format: json
-            body:
-              username: "{{ vast_username }}"
-              password: "{{ vast_password }}"
-            validate_certs: "{{ vast_storage_validate_certs }}"
-            timeout: "{{ vast_storage_api_timeout | int }}"
-            status_code: [200, 201]
-          register: _vast_pool_auth
-          no_log: true
-
-        - name: Query active CNodes for VIP pool assignment
-          ansible.builtin.uri:
-            url: "https://{{ vast_endpoint }}/api/latest/cnodes/"
-            method: GET
-            headers:
-              Authorization: "Bearer {{ _vast_pool_auth.json.access }}"
-            validate_certs: "{{ vast_storage_validate_certs }}"
-            timeout: "{{ vast_storage_api_timeout | int }}"
-            status_code: [200]
-          register: _vast_cnode_list
-          no_log: true
-
-        - name: Assign active CNodes to VIP pool
-          ansible.builtin.uri:
-            url: "https://{{ vast_endpoint }}/api/latest/vippools/{{ _vast_vip_pool_result.vippools.id }}/"
-            method: PATCH
-            body_format: json
-            body:
-              cnode_ids: "{{ _vast_cnode_list.json | selectattr('state', 'equalto', 'ACTIVE') | map(attribute='id') | list }}"
-            headers:
-              Authorization: "Bearer {{ _vast_pool_auth.json.access }}"
-            validate_certs: "{{ vast_storage_validate_certs }}"
-            timeout: "{{ vast_storage_api_timeout | int }}"
-            status_code: [200]
-          no_log: true
-
-        - name: Log VIP pool post-configuration
-          ansible.builtin.debug:
-            msg: "VIP pool: assigned {{ _vast_cnode_list.json | selectattr('state', 'equalto', 'ACTIVE') | list | length }} active CNode(s)"
-
     - name: Ensure VAST CSI Operator is installed
       ansible.builtin.include_tasks: ensure_csi_operator.yaml
 
@@ -520,8 +476,6 @@
         _vast_lp_create_result: {}
         _vast_client_ip_ranges: []
         _vast_node_list: {}
-        _vast_pool_auth: {}
-        _vast_cnode_list: {}
         _vast_vip_pool_lookup: {}
         _vast_vip_pool_match: {}
       no_log: true

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -214,6 +214,7 @@
                 vast_tenant_id: "{{ _vast_tenant_result.tenants.id | string }}"
                 vast_local_provider_id: "{{ _vast_local_provider_id | string }}"
                 vip_pool_name: "{{ vast_storage_vip_pool_name }}"
+                vip_pool_fqdn: "{{ vast_storage_vip_pool_fqdn | default('') }}"
                 vast_endpoint: "{{ vast_endpoint }}"
                 storage_provider_type: "vast"
                 tenant_manager_name: "{{ _vast_tenant_manager_name }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -256,6 +256,60 @@
           ansible.builtin.set_fact:
             _vast_tenant_id: "{{ _vast_tenant_result.tenants.id | string }}"
 
+        - name: Configure tenant client IP ranges for shared VIP pool NFS access
+          block:
+            - name: Parse explicit client IP ranges when provided
+              when: vast_storage_client_ip_ranges | length > 0
+              ansible.builtin.set_fact:
+                _vast_client_ip_ranges: >-
+                  {{ vast_storage_client_ip_ranges if (vast_storage_client_ip_ranges is not string)
+                     else (vast_storage_client_ip_ranges | from_json) }}
+
+            - name: Auto-detect node IPs when client IP ranges not configured
+              when: vast_storage_client_ip_ranges | length == 0
+              block:
+                - name: Get cluster node internal IPs
+                  kubernetes.core.k8s_info:
+                    api_version: v1
+                    kind: Node
+                  register: _vast_node_list
+
+                - name: Build client IP ranges from node InternalIP addresses
+                  ansible.builtin.set_fact:
+                    _vast_client_ip_ranges: >-
+                      {{ _vast_node_list.resources
+                         | map(attribute='status.addresses')
+                         | map('selectattr', 'type', 'equalto', 'InternalIP')
+                         | map('map', attribute='address')
+                         | flatten
+                         | map('regex_replace', '^(.*)$', '["\1","\1"]')
+                         | map('from_json')
+                         | list }}
+
+                - name: Log auto-detected node IPs
+                  ansible.builtin.debug:
+                    msg: "Auto-detected {{ _vast_client_ip_ranges | length }} node IP(s) for client_ip_ranges"
+
+            - name: Set client_ip_ranges on VAST tenant
+              when: _vast_client_ip_ranges | default([]) | length > 0
+              ansible.builtin.uri:
+                url: "https://{{ vast_endpoint }}/api/tenants/{{ _vast_tenant_id }}/"
+                method: PATCH
+                body_format: json
+                body:
+                  client_ip_ranges: "{{ _vast_client_ip_ranges }}"
+                headers:
+                  Authorization: "Bearer {{ _vast_setup_auth.json.access }}"
+                validate_certs: "{{ vast_storage_validate_certs }}"
+                timeout: "{{ vast_storage_api_timeout | int }}"
+                status_code: [200]
+              no_log: true
+
+            - name: Log client IP ranges configuration
+              ansible.builtin.debug:
+                msg: "Set client_ip_ranges on tenant '{{ tenant_name }}': {{ _vast_client_ip_ranges }}"
+              when: _vast_client_ip_ranges | default([]) | length > 0
+
         - name: Create per-tenant VMS manager with CSI role
           ansible.builtin.include_tasks: create_tenant_manager.yaml
 
@@ -400,6 +454,8 @@
         _vast_setup_auth: {}
         _vast_lp_check: {}
         _vast_lp_create_result: {}
+        _vast_client_ip_ranges: []
+        _vast_node_list: {}
         _vast_vip_pool_lookup: {}
         _vast_vip_pool_match: {}
       no_log: true

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -164,10 +164,77 @@
 
     - name: Provision VAST VMS resources
       block:
-        - name: Create VAST tenant
+        # ── Local provider: explicit lifecycle ──
+        # VAST auto-creates a local provider per tenant, but we create it
+        # explicitly for naming control and clean teardown without force_remove.
+
+        - name: Authenticate to VAST VMS as admin for local provider setup
+          ansible.builtin.uri:
+            url: "https://{{ vast_endpoint }}/api/token/"
+            method: POST
+            body_format: json
+            body:
+              username: "{{ vast_username }}"
+              password: "{{ vast_password }}"
+            validate_certs: "{{ vast_storage_validate_certs }}"
+            timeout: "{{ vast_storage_api_timeout | int }}"
+            status_code: [200, 201]
+          register: _vast_setup_auth
+          no_log: true
+
+        - name: Set local provider name
+          ansible.builtin.set_fact:
+            _vast_local_provider_name: "{{ vast_storage_local_provider_prefix }}{{ tenant_name }}"
+
+        - name: Check if local provider already exists
+          ansible.builtin.uri:
+            url: "https://{{ vast_endpoint }}/api/localproviders/?name={{ _vast_local_provider_name }}"
+            method: GET
+            headers:
+              Authorization: "Bearer {{ _vast_setup_auth.json.access }}"
+            validate_certs: "{{ vast_storage_validate_certs }}"
+            timeout: "{{ vast_storage_api_timeout | int }}"
+            status_code: [200]
+          register: _vast_lp_check
+          no_log: true
+
+        - name: Create local provider for tenant
+          when: _vast_lp_check.json | length == 0
+          ansible.builtin.uri:
+            url: "https://{{ vast_endpoint }}/api/localproviders/"
+            method: POST
+            body_format: json
+            body:
+              name: "{{ _vast_local_provider_name }}"
+            headers:
+              Authorization: "Bearer {{ _vast_setup_auth.json.access }}"
+            validate_certs: "{{ vast_storage_validate_certs }}"
+            timeout: "{{ vast_storage_api_timeout | int }}"
+            status_code: [200, 201]
+          register: _vast_lp_create_result
+          no_log: true
+
+        - name: Set local provider ID from creation or existing lookup
+          ansible.builtin.set_fact:
+            _vast_local_provider_id: >-
+              {{ (_vast_lp_create_result.json.id | string)
+                 if (_vast_lp_check.json | length == 0)
+                 else (_vast_lp_check.json[0].id | string) }}
+
+        - name: Log local provider status
+          ansible.builtin.debug:
+            msg: >-
+              Local provider '{{ _vast_local_provider_name }}'
+              {{ 'created' if (_vast_lp_check.json | length == 0) else 'already exists' }}
+              (id: {{ _vast_local_provider_id }})
+
+        # ── Tenant creation with explicit local provider ──
+
+        - name: Create VAST tenant with explicit local provider
           vastdata.vms.tenants:
             vms: "{{ _vast_vms_conn }}"
             name: "{{ tenant_name }}"
+            local_provider_id: "{{ _vast_local_provider_id | int }}"
             state: present
           register: _vast_tenant_result
           no_log: true
@@ -183,15 +250,11 @@
 
         - name: Log VAST tenant creation result
           ansible.builtin.debug:
-            msg: "VAST tenant '{{ tenant_name }}' provisioned with ID: {{ _vast_tenant_result.tenants.id }}"
+            msg: "VAST tenant '{{ tenant_name }}' provisioned with ID: {{ _vast_tenant_result.tenants.id }}, local provider: {{ _vast_local_provider_name }}"
 
         - name: Set tenant ID for downstream tasks
           ansible.builtin.set_fact:
             _vast_tenant_id: "{{ _vast_tenant_result.tenants.id | string }}"
-
-        - name: Resolve local_provider_id from VAST tenant result
-          ansible.builtin.set_fact:
-            _vast_local_provider_id: "{{ _vast_tenant_result.tenants.local_provider_id }}"
 
         - name: Create per-tenant VMS manager with CSI role
           ansible.builtin.include_tasks: create_tenant_manager.yaml
@@ -276,12 +339,11 @@
             _vast_cleanup_tenant_id: "{{ _vast_tenant_result.tenants.id }}"
           ignore_errors: true  # noqa: ignore-errors
 
-        - name: Rollback - delete VAST tenant (retry for async cleanup)
+        - name: Rollback - delete VAST tenant
           vastdata.vms.tenants:
             vms: "{{ _vast_vms_conn }}"
             name: "{{ tenant_name }}"
             state: absent
-            force_remove: true
           retries: 3
           delay: 10
           until: _vast_rollback_tenant_result is not failed
@@ -289,6 +351,23 @@
           ignore_errors: true  # noqa: ignore-errors
           no_log: true
           when: _vast_vms_conn is defined
+
+        - name: Rollback - delete local provider
+          when:
+            - _vast_local_provider_id is defined
+            - _vast_local_provider_id | string | length > 0
+            - _vast_setup_auth is defined
+            - _vast_setup_auth is not failed
+          ansible.builtin.uri:
+            url: "https://{{ vast_endpoint }}/api/localproviders/{{ _vast_local_provider_id }}/"
+            method: DELETE
+            headers:
+              Authorization: "Bearer {{ _vast_setup_auth.json.access }}"
+            validate_certs: "{{ vast_storage_validate_certs }}"
+            timeout: "{{ vast_storage_api_timeout | int }}"
+            status_code: [200, 204, 404]
+          ignore_errors: true  # noqa: ignore-errors
+          no_log: true
 
         - name: Report VAST API failure with tenant context
           ansible.builtin.fail:
@@ -317,6 +396,10 @@
         _vast_tenant_manager_id: ""
         _vast_tenant_role_id: ""
         _vast_local_provider_id: ""
+        _vast_local_provider_name: ""
+        _vast_setup_auth: {}
+        _vast_lp_check: {}
+        _vast_lp_create_result: {}
         _vast_vip_pool_lookup: {}
         _vast_vip_pool_match: {}
       no_log: true

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -187,6 +187,7 @@
                 tenant_manager_password: "{{ _vast_tenant_manager_password }}"
                 tenant_manager_id: "{{ _vast_tenant_manager_id | default('') | string }}"
                 tenant_role_id: "{{ _vast_tenant_role_id | default('') | string }}"
+                tenant_realm_id: "{{ _vast_tenant_realm_id | default('') | string }}"
                 block_encryption_passphrase: "{{ storage_provider_block_encryption_passphrase | default('') }}"
           no_log: true
 
@@ -281,6 +282,7 @@
         _vast_tenant_manager_password: ""
         _vast_tenant_manager_id: ""
         _vast_tenant_role_id: ""
+        _vast_tenant_realm_id: ""
         _vast_local_provider_id: ""
       no_log: true
 

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -103,27 +103,61 @@
           {{ vast_storage_vip_pool_ip_ranges if (vast_storage_vip_pool_ip_ranges is not string)
              else (vast_storage_vip_pool_ip_ranges | from_json) }}
 
-    - name: Ensure shared VIP pool exists
-      vastdata.vms.vippools:
-        vms:
-          host: "{{ vast_endpoint }}"
-          username: "{{ vast_username }}"
-          password: "{{ vast_password }}"
-          validate_certs: "{{ vast_storage_validate_certs }}"
-          timeout: "{{ vast_storage_api_timeout }}"
-        name: "{{ vast_storage_vip_pool_name }}"
-        ip_ranges: "{{ _vast_vip_pool_ip_ranges }}"
-        subnet_cidr: "{{ vast_storage_vip_pool_subnet_cidr | int }}"
-        gw_ip: "{{ vast_storage_vip_pool_gw_ip if (vast_storage_vip_pool_gw_ip | default('') | length > 0) else omit }}"
-        gw_ipv6: "{{ vast_storage_vip_pool_gw_ipv6 if (vast_storage_vip_pool_gw_ipv6 | default('') | length > 0) else omit }}"
-        role: PROTOCOLS
-        state: present
-      register: _vast_vip_pool_result
+    - name: Look up existing VIP pools to find one matching the configured IP ranges
+      ansible.builtin.uri:
+        url: "https://{{ vast_endpoint }}/api/latest/vippools/"
+        method: GET
+        url_username: "{{ vast_username }}"
+        url_password: "{{ vast_password }}"
+        force_basic_auth: true
+        validate_certs: "{{ vast_storage_validate_certs }}"
+        timeout: "{{ vast_storage_api_timeout | int }}"
+        status_code: [200]
+      register: _vast_vip_pool_lookup
       no_log: true
 
-    - name: Log shared VIP pool status
-      ansible.builtin.debug:
-        msg: "Shared VIP pool '{{ vast_storage_vip_pool_name }}' ensured (id: {{ _vast_vip_pool_result.vippools.id | default('existing') }})"
+    - name: Check if any existing pool matches the configured IP ranges
+      ansible.builtin.set_fact:
+        _vast_vip_pool_match: >-
+          {{ _vast_vip_pool_lookup.json
+             | selectattr('ip_ranges', 'equalto', _vast_vip_pool_ip_ranges)
+             | list | first | default({}) }}
+
+    - name: Use existing VIP pool when IP ranges match
+      when: _vast_vip_pool_match | length > 0
+      block:
+        - name: Override VIP pool name to match existing pool
+          ansible.builtin.set_fact:
+            vast_storage_vip_pool_name: "{{ _vast_vip_pool_match.name }}"
+
+        - name: Log existing VIP pool reuse
+          ansible.builtin.debug:
+            msg: "Found existing VIP pool '{{ vast_storage_vip_pool_name }}' (id: {{ _vast_vip_pool_match.id }}) with matching IP ranges — reusing."
+
+    - name: Create shared VIP pool when no match exists
+      when: _vast_vip_pool_match | length == 0
+      block:
+        - name: Create VIP pool with configured name and ranges
+          vastdata.vms.vippools:
+            vms:
+              host: "{{ vast_endpoint }}"
+              username: "{{ vast_username }}"
+              password: "{{ vast_password }}"
+              validate_certs: "{{ vast_storage_validate_certs }}"
+              timeout: "{{ vast_storage_api_timeout }}"
+            name: "{{ vast_storage_vip_pool_name }}"
+            ip_ranges: "{{ _vast_vip_pool_ip_ranges }}"
+            subnet_cidr: "{{ vast_storage_vip_pool_subnet_cidr | int }}"
+            gw_ip: "{{ vast_storage_vip_pool_gw_ip if (vast_storage_vip_pool_gw_ip | default('') | length > 0) else omit }}"
+            gw_ipv6: "{{ vast_storage_vip_pool_gw_ipv6 if (vast_storage_vip_pool_gw_ipv6 | default('') | length > 0) else omit }}"
+            role: PROTOCOLS
+            state: present
+          register: _vast_vip_pool_result
+          no_log: true
+
+        - name: Log VIP pool creation
+          ansible.builtin.debug:
+            msg: "Created VIP pool '{{ vast_storage_vip_pool_name }}' (id: {{ _vast_vip_pool_result.vippools.id | default('unknown') }})"
 
     - name: Ensure VAST CSI Operator is installed
       ansible.builtin.include_tasks: ensure_csi_operator.yaml
@@ -284,6 +318,8 @@
         _vast_tenant_role_id: ""
         _vast_tenant_realm_id: ""
         _vast_local_provider_id: ""
+        _vast_vip_pool_lookup: {}
+        _vast_vip_pool_match: {}
       no_log: true
 
 - name: Set storage_provider_tenant_config output fact

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -159,6 +159,50 @@
           ansible.builtin.debug:
             msg: "Created VIP pool '{{ vast_storage_vip_pool_name }}' (id: {{ _vast_vip_pool_result.vippools.id | default('unknown') }})"
 
+        - name: Authenticate for VIP pool post-configuration
+          ansible.builtin.uri:
+            url: "https://{{ vast_endpoint }}/api/token/"
+            method: POST
+            body_format: json
+            body:
+              username: "{{ vast_username }}"
+              password: "{{ vast_password }}"
+            validate_certs: "{{ vast_storage_validate_certs }}"
+            timeout: "{{ vast_storage_api_timeout | int }}"
+            status_code: [200, 201]
+          register: _vast_pool_auth
+          no_log: true
+
+        - name: Query active CNodes for VIP pool assignment
+          ansible.builtin.uri:
+            url: "https://{{ vast_endpoint }}/api/latest/cnodes/"
+            method: GET
+            headers:
+              Authorization: "Bearer {{ _vast_pool_auth.json.access }}"
+            validate_certs: "{{ vast_storage_validate_certs }}"
+            timeout: "{{ vast_storage_api_timeout | int }}"
+            status_code: [200]
+          register: _vast_cnode_list
+          no_log: true
+
+        - name: Assign all active CNodes to the VIP pool
+          ansible.builtin.uri:
+            url: "https://{{ vast_endpoint }}/api/latest/vippools/{{ _vast_vip_pool_result.vippools.id }}/"
+            method: PATCH
+            body_format: json
+            body:
+              cnode_ids: "{{ _vast_cnode_list.json | selectattr('state', 'equalto', 'ACTIVE') | map(attribute='id') | list }}"
+            headers:
+              Authorization: "Bearer {{ _vast_pool_auth.json.access }}"
+            validate_certs: "{{ vast_storage_validate_certs }}"
+            timeout: "{{ vast_storage_api_timeout | int }}"
+            status_code: [200]
+          no_log: true
+
+        - name: Log CNode assignment
+          ansible.builtin.debug:
+            msg: "Assigned {{ _vast_cnode_list.json | selectattr('state', 'equalto', 'ACTIVE') | list | length }} active CNode(s) to VIP pool"
+
     - name: Ensure VAST CSI Operator is installed
       ansible.builtin.include_tasks: ensure_csi_operator.yaml
 
@@ -456,6 +500,8 @@
         _vast_lp_create_result: {}
         _vast_client_ip_ranges: []
         _vast_node_list: {}
+        _vast_pool_auth: {}
+        _vast_cnode_list: {}
         _vast_vip_pool_lookup: {}
         _vast_vip_pool_match: {}
       no_log: true

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -258,12 +258,13 @@
           register: _vast_lp_create_result
           no_log: true
 
-        - name: Set local provider ID from creation or existing lookup
+        - name: Set local provider ID and creation flag
           ansible.builtin.set_fact:
             _vast_local_provider_id: >-
               {{ (_vast_lp_create_result.json.id | string)
                  if (_vast_lp_check.json | length == 0)
                  else (_vast_lp_check.json[0].id | string) }}
+            _vast_local_provider_created: "{{ _vast_lp_check.json | length == 0 }}"
 
         - name: Log local provider status
           ansible.builtin.debug:
@@ -274,6 +275,15 @@
 
         # ── Tenant creation with explicit local provider ──
 
+        - name: Check if VAST tenant already exists
+          vastdata.vms.tenants:
+            vms: "{{ _vast_vms_conn }}"
+            name: "{{ tenant_name }}"
+            state: present
+          register: _vast_tenant_check
+          ignore_errors: true
+          no_log: true
+
         - name: Create VAST tenant with explicit local provider
           vastdata.vms.tenants:
             vms: "{{ _vast_vms_conn }}"
@@ -282,6 +292,10 @@
             state: present
           register: _vast_tenant_result
           no_log: true
+
+        - name: Track whether tenant was created by this run
+          ansible.builtin.set_fact:
+            _vast_tenant_created: "{{ _vast_tenant_check is failed or _vast_tenant_check.tenants.id is not defined }}"
 
         - name: Fail if VAST tenant creation did not return an ID
           ansible.builtin.fail:
@@ -351,7 +365,7 @@
 
             - name: Log client IP ranges configuration
               ansible.builtin.debug:
-                msg: "Set client_ip_ranges on tenant '{{ tenant_name }}': {{ _vast_client_ip_ranges }}"
+                msg: "Set {{ _vast_client_ip_ranges | length }} client_ip_range(s) on tenant '{{ tenant_name }}'"
               when: _vast_client_ip_ranges | default([]) | length > 0
 
         - name: Create per-tenant VMS manager with CSI role
@@ -437,7 +451,28 @@
             _vast_cleanup_tenant_id: "{{ _vast_tenant_result.tenants.id }}"
           ignore_errors: true  # noqa: ignore-errors
 
+        - name: Rollback - delete local provider
+          when:
+            - _vast_local_provider_created | default(false) | bool
+            - _vast_local_provider_id is defined
+            - _vast_local_provider_id | string | length > 0
+            - _vast_rollback_auth is defined
+            - _vast_rollback_auth is not failed
+          ansible.builtin.uri:
+            url: "https://{{ vast_endpoint }}/api/localproviders/{{ _vast_local_provider_id }}/"
+            method: DELETE
+            headers:
+              Authorization: "Bearer {{ _vast_rollback_auth.json.access }}"
+            validate_certs: "{{ vast_storage_validate_certs }}"
+            timeout: "{{ vast_storage_api_timeout | int }}"
+            status_code: [200, 204, 404]
+          ignore_errors: true  # noqa: ignore-errors
+          no_log: true
+
         - name: Rollback - delete VAST tenant
+          when:
+            - _vast_vms_conn is defined
+            - _vast_tenant_created | default(false) | bool
           vastdata.vms.tenants:
             vms: "{{ _vast_vms_conn }}"
             name: "{{ tenant_name }}"
@@ -446,24 +481,6 @@
           delay: 10
           until: _vast_rollback_tenant_result is not failed
           register: _vast_rollback_tenant_result
-          ignore_errors: true  # noqa: ignore-errors
-          no_log: true
-          when: _vast_vms_conn is defined
-
-        - name: Rollback - delete local provider
-          when:
-            - _vast_local_provider_id is defined
-            - _vast_local_provider_id | string | length > 0
-            - _vast_setup_auth is defined
-            - _vast_setup_auth is not failed
-          ansible.builtin.uri:
-            url: "https://{{ vast_endpoint }}/api/localproviders/{{ _vast_local_provider_id }}/"
-            method: DELETE
-            headers:
-              Authorization: "Bearer {{ _vast_setup_auth.json.access }}"
-            validate_certs: "{{ vast_storage_validate_certs }}"
-            timeout: "{{ vast_storage_api_timeout | int }}"
-            status_code: [200, 204, 404]
           ignore_errors: true  # noqa: ignore-errors
           no_log: true
 
@@ -495,6 +512,9 @@
         _vast_tenant_role_id: ""
         _vast_local_provider_id: ""
         _vast_local_provider_name: ""
+        _vast_local_provider_created: false
+        _vast_tenant_created: false
+        _vast_tenant_check: {}
         _vast_setup_auth: {}
         _vast_lp_check: {}
         _vast_lp_create_result: {}

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -185,7 +185,7 @@
           register: _vast_cnode_list
           no_log: true
 
-        - name: Assign all active CNodes to the VIP pool
+        - name: Assign active CNodes to VIP pool
           ansible.builtin.uri:
             url: "https://{{ vast_endpoint }}/api/latest/vippools/{{ _vast_vip_pool_result.vippools.id }}/"
             method: PATCH
@@ -199,9 +199,9 @@
             status_code: [200]
           no_log: true
 
-        - name: Log CNode assignment
+        - name: Log VIP pool post-configuration
           ansible.builtin.debug:
-            msg: "Assigned {{ _vast_cnode_list.json | selectattr('state', 'equalto', 'ACTIVE') | list | length }} active CNode(s) to VIP pool"
+            msg: "VIP pool: assigned {{ _vast_cnode_list.json | selectattr('state', 'equalto', 'ACTIVE') | list | length }} active CNode(s)"
 
     - name: Ensure VAST CSI Operator is installed
       ansible.builtin.include_tasks: ensure_csi_operator.yaml

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -105,7 +105,7 @@
 
     - name: Look up existing VIP pools to find one matching the configured IP ranges
       ansible.builtin.uri:
-        url: "https://{{ vast_endpoint }}/api/latest/vippools/"
+        url: "https://{{ vast_endpoint }}/api/vippools/"
         method: GET
         url_username: "{{ vast_username }}"
         url_password: "{{ vast_password }}"
@@ -232,13 +232,20 @@
         # ── Tenant creation with explicit local provider ──
 
         - name: Check if VAST tenant already exists
-          vastdata.vms.tenants:
-            vms: "{{ _vast_vms_conn }}"
-            name: "{{ tenant_name }}"
-            state: present
+          ansible.builtin.uri:
+            url: "https://{{ vast_endpoint }}/api/tenants/?name={{ tenant_name }}"
+            method: GET
+            headers:
+              Authorization: "Bearer {{ _vast_setup_auth.json.access }}"
+            validate_certs: "{{ vast_storage_validate_certs }}"
+            timeout: "{{ vast_storage_api_timeout | int }}"
+            status_code: [200]
           register: _vast_tenant_check
-          ignore_errors: true
           no_log: true
+
+        - name: Track whether tenant needs to be created
+          ansible.builtin.set_fact:
+            _vast_tenant_created: "{{ _vast_tenant_check.json | length == 0 }}"
 
         - name: Create VAST tenant with explicit local provider
           vastdata.vms.tenants:
@@ -248,10 +255,6 @@
             state: present
           register: _vast_tenant_result
           no_log: true
-
-        - name: Track whether tenant was created by this run
-          ansible.builtin.set_fact:
-            _vast_tenant_created: "{{ _vast_tenant_check is failed or _vast_tenant_check.tenants.id is not defined }}"
 
         - name: Fail if VAST tenant creation did not return an ID
           ansible.builtin.fail:
@@ -307,7 +310,7 @@
             - name: Set client_ip_ranges on VAST tenant
               when: _vast_client_ip_ranges | default([]) | length > 0
               ansible.builtin.uri:
-                url: "https://{{ vast_endpoint }}/api/latest/tenants/{{ _vast_tenant_id }}/"
+                url: "https://{{ vast_endpoint }}/api/tenants/{{ _vast_tenant_id }}/"
                 method: PATCH
                 body_format: json
                 body:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -221,7 +221,6 @@
                 tenant_manager_password: "{{ _vast_tenant_manager_password }}"
                 tenant_manager_id: "{{ _vast_tenant_manager_id | default('') | string }}"
                 tenant_role_id: "{{ _vast_tenant_role_id | default('') | string }}"
-                tenant_realm_id: "{{ _vast_tenant_realm_id | default('') | string }}"
                 block_encryption_passphrase: "{{ storage_provider_block_encryption_passphrase | default('') }}"
           no_log: true
 
@@ -316,7 +315,6 @@
         _vast_tenant_manager_password: ""
         _vast_tenant_manager_id: ""
         _vast_tenant_role_id: ""
-        _vast_tenant_realm_id: ""
         _vast_local_provider_id: ""
         _vast_vip_pool_lookup: {}
         _vast_vip_pool_match: {}

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -293,7 +293,7 @@
             - name: Set client_ip_ranges on VAST tenant
               when: _vast_client_ip_ranges | default([]) | length > 0
               ansible.builtin.uri:
-                url: "https://{{ vast_endpoint }}/api/tenants/{{ _vast_tenant_id }}/"
+                url: "https://{{ vast_endpoint }}/api/latest/tenants/{{ _vast_tenant_id }}/"
                 method: PATCH
                 body_format: json
                 body:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/teardown_backend.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/teardown_backend.yaml
@@ -207,7 +207,8 @@
         _vast_teardown_clean: >-
           {{ not (_vast_cleanup_results | default({}) | dict2items | selectattr('value.failed', 'defined') | selectattr('value.failed') | list | length > 0)
              and not (_vast_teardown_tenant_result.failed | default(false))
-             and not (_vast_manager_delete_failed | default(false)) }}
+             and not (_vast_manager_delete_failed | default(false))
+             and not (_vast_teardown_lp_result.failed | default(false)) }}
 
     - name: Delete tenant config Secret from hub cluster (only when cleanup succeeded)
       when: >-
@@ -258,5 +259,6 @@
       Backend teardown for tenant '{{ tenant_name }}' complete.
       VMS: {% for r, v in (_vast_cleanup_results | default({})).items() %}{{ v.queried }} {{ r }}{{ ', ' if not loop.last else '' }}{% endfor %} deleted.
       Tenant: {{ 'ok' if not (_vast_teardown_tenant_result.failed | default(false)) else 'failed' }},
-      Manager: {{ 'ok' if not (_vast_manager_delete_failed | default(false)) else 'failed' }}.
+      Manager: {{ 'ok' if not (_vast_manager_delete_failed | default(false)) else 'failed' }},
+      Local provider: {{ 'ok' if not (_vast_teardown_lp_result.failed | default(false)) else 'failed' }}.
       Hub Secret: {{ 'deleted' if (_vast_teardown_clean | default(false) | bool) else 'preserved' }}.

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/teardown_backend.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/teardown_backend.yaml
@@ -27,12 +27,14 @@
   no_log: true
   failed_when: false
 
-- name: Extract tenant ID from hub Secret (if available)
+- name: Extract tenant ID and local provider ID from hub Secret (if available)
   when:
     - _vast_teardown_config.resources | length > 0
     - _vast_teardown_config.resources[0].data.vast_tenant_id is defined
   ansible.builtin.set_fact:
     _vast_teardown_tenant_id: "{{ _vast_teardown_config.resources[0].data.vast_tenant_id | b64decode }}"
+    _vast_teardown_local_provider_id: >-
+      {{ _vast_teardown_config.resources[0].data.vast_local_provider_id | default('') | b64decode }}
   no_log: true
 
 - name: Cleanup VAST backend resources
@@ -117,51 +119,88 @@
     - name: Delete per-tenant VMS manager
       ansible.builtin.include_tasks: delete_tenant_manager.yaml
 
-    - name: Delete VAST tenant (retry for async view cleanup)
-      vastdata.vms.tenants:
-        vms: "{{ _vast_vms_conn }}"
-        name: "{{ tenant_name }}"
-        state: absent
-        force_remove: true
-      register: _vast_teardown_tenant_result
-      retries: 3
-      delay: 10
-      until: _vast_teardown_tenant_result is not failed
-      ignore_errors: true  # noqa: ignore-errors
-      no_log: true
+    # ── Local provider: delete before tenant for clean lifecycle ──
+    # The LP must be deleted after the manager (which uses it) but before
+    # the tenant (which references it). This avoids needing force_remove
+    # on tenant deletion.
 
-    - name: Clean up orphaned local provider after tenant deletion
+    - name: Delete local provider
       when:
         - _vast_teardown_auth is defined
         - _vast_teardown_auth is not failed
       block:
-        - name: Query local provider by tenant name
-          ansible.builtin.uri:
-            url: "https://{{ vast_endpoint }}/api/localproviders/?name=provider-{{ tenant_name }}"
-            method: GET
-            headers:
-              Authorization: "Bearer {{ _vast_teardown_auth.json.access }}"
-            validate_certs: "{{ vast_storage_validate_certs }}"
-            timeout: "{{ vast_storage_api_timeout | int }}"
-            status_code: [200]
-          register: _vast_teardown_lp
-          ignore_errors: true
-          no_log: true
+        - name: Resolve local provider ID (from hub Secret or by name lookup)
+          when: _vast_teardown_local_provider_id | default('') | length == 0
+          block:
+            - name: Look up local provider by naming convention
+              ansible.builtin.uri:
+                url: "https://{{ vast_endpoint }}/api/localproviders/?name={{ vast_storage_local_provider_prefix }}{{ tenant_name }}"
+                method: GET
+                headers:
+                  Authorization: "Bearer {{ _vast_teardown_auth.json.access }}"
+                validate_certs: "{{ vast_storage_validate_certs }}"
+                timeout: "{{ vast_storage_api_timeout | int }}"
+                status_code: [200]
+              register: _vast_teardown_lp_lookup
+              ignore_errors: true
+              no_log: true
 
-        - name: Delete orphaned local provider
-          when:
-            - _vast_teardown_lp is not failed
-            - _vast_teardown_lp.json | default([]) | length > 0
+            - name: Also check legacy auto-created naming convention
+              when: _vast_teardown_lp_lookup.json | default([]) | length == 0
+              ansible.builtin.uri:
+                url: "https://{{ vast_endpoint }}/api/localproviders/?name=provider-{{ tenant_name }}"
+                method: GET
+                headers:
+                  Authorization: "Bearer {{ _vast_teardown_auth.json.access }}"
+                validate_certs: "{{ vast_storage_validate_certs }}"
+                timeout: "{{ vast_storage_api_timeout | int }}"
+                status_code: [200]
+              register: _vast_teardown_lp_legacy
+              ignore_errors: true
+              no_log: true
+
+            - name: Set local provider ID from lookup
+              ansible.builtin.set_fact:
+                _vast_teardown_local_provider_id: >-
+                  {{ (_vast_teardown_lp_lookup.json[0].id | default(''))
+                     if (_vast_teardown_lp_lookup.json | default([]) | length > 0)
+                     else ((_vast_teardown_lp_legacy.json[0].id | default(''))
+                           if (_vast_teardown_lp_legacy is defined and _vast_teardown_lp_legacy.json | default([]) | length > 0)
+                           else '') }}
+
+        - name: Delete local provider by ID
+          when: _vast_teardown_local_provider_id | default('') | string | length > 0
           ansible.builtin.uri:
-            url: "https://{{ vast_endpoint }}/api/localproviders/{{ _vast_teardown_lp.json[0].id }}/"
+            url: "https://{{ vast_endpoint }}/api/localproviders/{{ _vast_teardown_local_provider_id }}/"
             method: DELETE
             headers:
               Authorization: "Bearer {{ _vast_teardown_auth.json.access }}"
             validate_certs: "{{ vast_storage_validate_certs }}"
             timeout: "{{ vast_storage_api_timeout | int }}"
             status_code: [200, 204, 404]
+          register: _vast_teardown_lp_result
           ignore_errors: true  # noqa: ignore-errors
           no_log: true
+
+        - name: Log local provider deletion result
+          ansible.builtin.debug:
+            msg: >-
+              Local provider deletion:
+              {{ 'deleted (id: ' ~ _vast_teardown_local_provider_id ~ ')'
+                 if (_vast_teardown_lp_result is defined and _vast_teardown_lp_result is not failed)
+                 else ('not found — skipping' if (_vast_teardown_local_provider_id | default('') | length == 0) else 'failed (ignored)') }}
+
+    - name: Delete VAST tenant (retry for async view cleanup)
+      vastdata.vms.tenants:
+        vms: "{{ _vast_vms_conn }}"
+        name: "{{ tenant_name }}"
+        state: absent
+      register: _vast_teardown_tenant_result
+      retries: 3
+      delay: 10
+      until: _vast_teardown_tenant_result is not failed
+      ignore_errors: true  # noqa: ignore-errors
+      no_log: true
 
     - name: Set VAST cleanup success flag
       ansible.builtin.set_fact:
@@ -207,6 +246,10 @@
         _vast_teardown_config: {}
         _vast_teardown_auth: {}
         _vast_teardown_tenant_id: ""
+        _vast_teardown_local_provider_id: ""
+        _vast_teardown_lp_lookup: {}
+        _vast_teardown_lp_legacy: {}
+        _vast_teardown_lp_result: {}
       no_log: true
 
 - name: Report backend teardown summary

--- a/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -266,9 +266,10 @@
           - (_csi_secret.resources[0].data.password | b64decode) == "test-csi-password"
           - _csi_secret.resources[0].data.endpoint is defined
           - (_csi_secret.resources[0].data.endpoint | b64decode) == "127.0.0.1:18443"
-          - _csi_secret.resources[0].data.tenant is not defined
+          - _csi_secret.resources[0].data.tenant is defined
+          - (_csi_secret.resources[0].data.tenant | b64decode) == "test-ensuresc"
         fail_msg: "CSI Secret does not contain expected manager credentials"
-        success_msg: "CSI Secret contains tenant manager credentials (tenant field omitted)"
+        success_msg: "CSI Secret contains tenant manager credentials with tenant field"
 
     - name: Assert CSI Secret labels
       ansible.builtin.assert:

--- a/tests/integration/targets/storage_provider_teardown/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_teardown/tasks/main.yml
@@ -397,34 +397,12 @@
         fail_msg: "No role API call found in mock call log"
         success_msg: "Role API call detected"
 
-    - name: Assert local provider cleanup was attempted
-      ansible.builtin.assert:
-        that:
-          - _call_log | selectattr('path', 'search', 'localproviders') | selectattr('method', 'equalto', 'GET') | list | length > 0
-        fail_msg: "No local provider lookup found in mock call log — orphaned providers would persist"
-        success_msg: "Local provider cleanup attempted"
-
-    - name: Assert local provider was deleted
+    - name: Assert local provider was deleted by ID (from hub Secret)
       ansible.builtin.assert:
         that:
           - _call_log | selectattr('path', 'search', 'localproviders/') | selectattr('method', 'equalto', 'DELETE') | list | length > 0
         fail_msg: "No local provider DELETE call found — orphaned provider not cleaned up"
-        success_msg: "Local provider deleted"
-
-    - name: Verify mock VMS has no remaining local providers for this tenant
-      ansible.builtin.uri:
-        url: "https://127.0.0.1:18443/api/localproviders/?name=provider-test-teardown"
-        validate_certs: false
-        method: GET
-        return_content: true
-      register: _td_lp_check
-
-    - name: Assert no orphaned local providers remain
-      ansible.builtin.assert:
-        that:
-          - _td_lp_check.json | length == 0
-        fail_msg: "Orphaned local provider 'provider-test-teardown' still exists in VMS"
-        success_msg: "No orphaned local providers"
+        success_msg: "Local provider deleted by ID from hub Secret"
 
 # ── Cleanup: Best-effort removal of any remaining resources ──
 - name: "Storage Provider Teardown - Final cleanup"


### PR DESCRIPTION
## Summary
- Restricts the VAST CSI credential by creating a Custom Realm that excludes view from its object types, preventing the CSI driver from JIT-creating Views via View.ensure()
- Switches the per-tenant VMS Manager from SUPER_ADMIN to TENANT_ADMIN for proper tenant isolation, and adds the tenant field to the CSI Secret (required for TENANT_ADMIN auth)
- Adds Custom Realm cleanup to the teardown flow and persists tenant_realm_id in the Hub Secret for idempotent re-runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant managers are now provisioned as **TENANT_ADMIN** with tenant-scoped access and logical CRUD permissions.
  * Shared VIP pool provisioning reuses an existing pool when IP ranges exactly match the configured values.
* **Improvements**
  * CSI Secret data now includes the required **tenant** field for correct authentication scoping.
  * Hub/tenant configuration Secrets now include **vip_pool_fqdn**.
  * Storage setup/teardown now fully manage the **local provider** lifecycle (including rollback and safer cleanup ordering).
* **Bug Fixes**
  * Tenant cleanup no longer uses forced removal; local provider deletion is handled earlier to prevent leftovers.
* **Chores**
  * Usage stats are disabled for newly created CSI driver resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->