### PR TITLE
OSAC-1483: Add ExternalIP AAP playbooks and metallb_l2 role tasks

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_external_ip.yaml
@@ -1,0 +1,255 @@
+---
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Validate ExternalIPAttachment fields and annotations
+  ansible.builtin.assert:
+    that:
+      - external_ip_attachment.metadata is defined
+      - external_ip_attachment.metadata.name is defined
+      - external_ip_attachment.metadata.name | length > 0
+      - external_ip_attachment.metadata.namespace is defined
+      - external_ip_attachment.metadata.namespace | length > 0
+      - external_ip_attachment.metadata.annotations is defined
+      - "'osac.openshift.io/externalippool-name' in external_ip_attachment.metadata.annotations"
+      - external_ip_attachment.metadata.annotations['osac.openshift.io/externalippool-name'] | length > 0
+      - "'osac.openshift.io/externalip-target-namespace' in external_ip_attachment.metadata.annotations"
+      - external_ip_attachment.metadata.annotations['osac.openshift.io/externalip-target-namespace'] | length > 0
+      - external_ip_attachment.spec is defined
+      - external_ip_attachment.spec.computeInstance is defined
+      - external_ip_attachment.spec.computeInstance | length > 0
+    fail_msg: >-
+      ExternalIPAttachment is missing required fields/annotations:
+      metadata.name, metadata.namespace, and spec.computeInstance must be set,
+      and annotations osac.openshift.io/externalippool-name and
+      osac.openshift.io/externalip-target-namespace must both be present.
+
+- name: Extract ExternalIPAttachment configuration
+  ansible.builtin.set_fact:
+    external_ip_name: >-
+      {{ external_ip_attachment.metadata.annotations['osac.openshift.io/externalip-name']
+         | default(external_ip_attachment.metadata.name) }}
+    attach_vm_namespace: >-
+      {{ external_ip_attachment.metadata.annotations['osac.openshift.io/externalip-target-namespace'] }}
+    attach_pool_name: >-
+      {{ external_ip_attachment.metadata.annotations['osac.openshift.io/externalippool-name'] }}
+
+- name: Fetch ComputeInstance CR
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    namespace: "{{ external_ip_attachment.metadata.namespace }}"
+    label_selectors:
+      - "osac.openshift.io/computeinstance-uuid={{ external_ip_attachment.spec.computeInstance }}"
+  register: attach_ci_lookup
+
+- name: Fail if ComputeInstance not found
+  ansible.builtin.fail:
+    msg: >-
+      ComputeInstance with uuid '{{ external_ip_attachment.spec.computeInstance }}' not found
+      in namespace '{{ external_ip_attachment.metadata.namespace }}'.
+  when: attach_ci_lookup.resources | length == 0
+
+- name: Fail if ComputeInstance lookup is ambiguous
+  ansible.builtin.fail:
+    msg: >-
+      Multiple ComputeInstance resources matched uuid
+      '{{ external_ip_attachment.spec.computeInstance }}' in namespace
+      '{{ external_ip_attachment.metadata.namespace }}'; expected exactly one.
+  when: attach_ci_lookup.resources | length > 1
+
+- name: Extract ComputeInstance name from fetched CR
+  ansible.builtin.set_fact:
+    attach_compute_instance_name: "{{ attach_ci_lookup.resources[0].metadata.name }}"
+
+# Check if the LB Service already exists (idempotency for EDA event redelivery).
+- name: Check if LB Service already exists in VM namespace
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: v1
+    kind: Service
+    name: "osac-eip-{{ external_ip_name }}-ingress"
+    namespace: "{{ attach_vm_namespace }}"
+  register: existing_lb_service_info
+
+- name: Extract IP from existing LB Service (redelivery)
+  ansible.builtin.set_fact:
+    attach_ip_address: "{{ existing_lb_service_info.resources[0].metadata.annotations['metallb.universe.tf/loadBalancerIPs'] }}"
+    attach_already_done: true
+  when:
+    - existing_lb_service_info.resources | length > 0
+    - existing_lb_service_info.resources[0].metadata.annotations['metallb.universe.tf/loadBalancerIPs'] | default('') | length > 0
+
+- name: Set attach_already_done to false when LB Service does not exist
+  ansible.builtin.set_fact:
+    attach_already_done: false
+  when: attach_already_done is not defined
+
+# Read the reserved IP directly from the parking Service status.
+- name: Read reserved IP from parking Service
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: v1
+    kind: Service
+    name: "osac-eip-{{ external_ip_name }}"
+    namespace: metallb-system
+  register: parking_service_info
+  when: not attach_already_done
+
+- name: Fail if parking Service not found or IP not yet assigned
+  ansible.builtin.fail:
+    msg: >-
+      Parking Service 'osac-eip-{{ external_ip_name }}' not found in metallb-system
+      or MetalLB has not yet assigned an IP. Run create_external_ip first.
+  when:
+    - not attach_already_done
+    - >-
+      parking_service_info.resources | length == 0 or
+      parking_service_info.resources[0].status.loadBalancer.ingress | default([]) | length == 0
+
+- name: Extract allocated IP from parking Service status
+  ansible.builtin.set_fact:
+    attach_ip_address: "{{ parking_service_info.resources[0].status.loadBalancer.ingress[0].ip }}"
+  when: not attach_already_done
+
+- name: Display ExternalIPAttachment information
+  ansible.builtin.debug:
+    msg:
+      - "{{ attach_already_done | ternary('ExternalIPAttachment already attached (idempotent redelivery)', 'Creating ExternalIPAttachment') }} '{{ external_ip_name }}'"
+      - "IP address: {{ attach_ip_address }}"
+      - "Pool: {{ attach_pool_name }}"
+      - "VM namespace: {{ attach_vm_namespace }}"
+      - "ComputeInstance: {{ attach_compute_instance_name }} ({{ external_ip_attachment.metadata.namespace }})"
+
+# Delete the parking Service and create the VM-namespace LB Service atomically.
+# The rescue restores the parking Service if LB Service creation fails so the IP
+# is never left unparked without a reservation in metallb-system.
+- name: Attach ExternalIP - delete parking Service and create LB Service
+  when: not attach_already_done
+  block:
+    - name: Delete parking Service from metallb-system
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: absent
+        api_version: v1
+        kind: Service
+        name: "osac-eip-{{ external_ip_name }}"
+        namespace: metallb-system
+        wait: true
+        wait_timeout: 60
+      register: reservation_delete_result
+      retries: 3
+      delay: 5
+      until: reservation_delete_result is successful
+      failed_when:
+        - reservation_delete_result.failed | default(false)
+        - "'NotFound' not in (reservation_delete_result.msg | default(''))"
+
+    - name: Display parking Service deletion result
+      ansible.builtin.debug:
+        msg:
+          - "Parking Service 'osac-eip-{{ external_ip_name }}' deleted"
+          - "Changed: {{ reservation_delete_result.changed | default(false) }}"
+
+    # Create a LoadBalancer Service in the VM namespace.
+    - name: Create LoadBalancer Service in VM namespace
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: present
+        apply: true
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: "osac-eip-{{ external_ip_name }}-ingress"
+            namespace: "{{ attach_vm_namespace }}"
+            labels:
+              osac.openshift.io/externalip: "{{ external_ip_name }}"
+              osac.openshift.io/managed-by: osac-fulfillment
+            annotations:
+              metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
+              metallb.universe.tf/loadBalancerIPs: "{{ attach_ip_address }}"
+          spec:
+            type: LoadBalancer
+            selector:
+              vm.kubevirt.io/name: "{{ attach_compute_instance_name }}"
+            # Initial floating IP support exposes SSH only.
+            # Additional ports can be added as needed for other access patterns.
+            ports:
+              - name: ssh
+                port: 22
+                targetPort: 22
+                protocol: TCP
+      register: lb_service_result
+      retries: 6
+      delay: 10
+      until: lb_service_result is successful
+
+    - name: Display LoadBalancer Service creation result
+      ansible.builtin.debug:
+        msg:
+          - "LoadBalancer Service 'osac-eip-{{ external_ip_name }}-ingress' created in '{{ attach_vm_namespace }}'"
+          - "Changed: {{ lb_service_result.changed | default(false) }}"
+
+  rescue:
+    - name: Restore parking Service in metallb-system after failed LB Service creation
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: present
+        apply: true
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: "osac-eip-{{ external_ip_name }}"
+            namespace: metallb-system
+            labels:
+              osac.openshift.io/externalip: "{{ external_ip_name }}"
+              osac.openshift.io/managed-by: osac-fulfillment
+            annotations:
+              metallb.universe.tf/address-pool: "{{ attach_pool_name }}"
+              metallb.universe.tf/loadBalancerIPs: "{{ attach_ip_address }}"
+          spec:
+            type: LoadBalancer
+            selector: {}
+            ports:
+              - name: placeholder
+                protocol: TCP
+                port: 65535
+                targetPort: 65535
+      when: reservation_delete_result.changed | default(false)
+      register: rescue_parking_result
+      retries: 3
+      delay: 5
+      until: rescue_parking_result is successful
+
+    - name: Fail after attempted rollback of attach operation
+      ansible.builtin.fail:
+        msg: >-
+          Attach of ExternalIP '{{ external_ip_name }}' failed; the parking Service
+          'osac-eip-{{ external_ip_name }}' in metallb-system has been restored
+          if it had been deleted. Check the preceding error for details.
+
+# Annotate the ComputeInstance CR with the assigned external IP.
+- name: Annotate ComputeInstance with external-ip-address
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    name: "{{ attach_compute_instance_name }}"
+    namespace: "{{ external_ip_attachment.metadata.namespace }}"
+    state: present
+    definition:
+      metadata:
+        annotations:
+          osac.openshift.io/external-ip-address: "{{ attach_ip_address }}"
+  register: ci_annotate_result
+
+- name: Display ComputeInstance annotation result
+  ansible.builtin.debug:
+    msg:
+      - "ComputeInstance '{{ attach_compute_instance_name }}' annotated with external-ip-address '{{ attach_ip_address }}'"
+      - "Changed: {{ ci_annotate_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_external_ip.yaml
@@ -1,0 +1,88 @@
+---
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Validate ExternalIP fields and annotations
+  ansible.builtin.assert:
+    that:
+      - external_ip.metadata is defined
+      - external_ip.metadata.name is defined
+      - external_ip.metadata.name | length > 0
+      - external_ip.metadata.annotations is defined
+      - "'osac.openshift.io/externalippool-name' in external_ip.metadata.annotations"
+    fail_msg: >-
+      ExternalIP metadata.name and
+      metadata.annotations['osac.openshift.io/externalippool-name'] are required
+
+- name: Extract ExternalIP configuration
+  ansible.builtin.set_fact:
+    ip_name: "{{ external_ip.metadata.name }}"
+    ip_pool_name: >-
+      {{ external_ip.metadata.annotations['osac.openshift.io/externalippool-name'] }}
+
+- name: Display ExternalIP information
+  ansible.builtin.debug:
+    msg:
+      - "Creating LoadBalancer Service for ExternalIP '{{ ip_name }}'"
+      - "Pool name (IPAddressPool): {{ ip_pool_name }}"
+
+# Empty-selector LB Service reserves an IP from the MetalLB pool without
+# routing traffic. Port 65535 is arbitrary — required by the Service spec
+# but unused. MetalLB writes the assigned IP to status.loadBalancer.ingress.
+- name: Create LoadBalancer Service
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: "osac-eip-{{ ip_name }}"
+        namespace: metallb-system
+        annotations:
+          metallb.universe.tf/address-pool: "{{ ip_pool_name }}"
+        labels:
+          osac.openshift.io/externalip: "{{ ip_name }}"
+          osac.openshift.io/managed-by: osac-fulfillment
+      spec:
+        type: LoadBalancer
+        selector: {}
+        ports:
+          - name: placeholder
+            protocol: TCP
+            port: 65535
+            targetPort: 65535
+  register: lb_service_result
+  retries: 60
+  delay: 10
+  until: lb_service_result is successful
+
+- name: Display LoadBalancer Service creation result
+  ansible.builtin.debug:
+    msg:
+      - "LoadBalancer Service 'osac-eip-{{ ip_name }}' created"
+      - "Changed: {{ lb_service_result.changed | default(false) }}"
+
+- name: Wait for IP assignment
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: v1
+    kind: Service
+    name: "osac-eip-{{ ip_name }}"
+    namespace: metallb-system
+  register: lb_service_info
+  retries: 60
+  delay: 10
+  until: >-
+    lb_service_info.resources | length > 0 and
+    lb_service_info.resources[0].status.loadBalancer.ingress | default([]) | length > 0
+
+- name: Extract assigned IP
+  ansible.builtin.set_fact:
+    assigned_ip: "{{ lb_service_info.resources[0].status.loadBalancer.ingress[0].ip }}"
+
+- name: Display assigned IP
+  ansible.builtin.debug:
+    msg: "ExternalIP '{{ ip_name }}' assigned address: {{ assigned_ip }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_external_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/create_external_ip_pool.yaml
@@ -1,0 +1,80 @@
+---
+# Create MetalLB IPAddressPool and L2Advertisement for ExternalIPPool
+# 1. Creates IPAddressPool with autoAssign: false, avoidBuggyIPs: true, and addresses from CR spec.cidrs
+# 2. Creates L2Advertisement referencing the IPAddressPool by name
+
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Extract ExternalIPPool configuration
+  ansible.builtin.set_fact:
+    pool_name: "{{ external_ip_pool.metadata.name }}"
+    pool_cidrs: "{{ external_ip_pool.spec.cidrs }}"
+
+- name: Display ExternalIPPool information
+  ansible.builtin.debug:
+    msg:
+      - "Creating MetalLB resources for ExternalIPPool '{{ pool_name }}'"
+      - "CIDRs: {{ pool_cidrs }}"
+
+- name: Create IPAddressPool
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: present
+    definition:
+      apiVersion: metallb.io/v1beta1
+      kind: IPAddressPool
+      metadata:
+        name: "{{ pool_name }}"
+        namespace: metallb-system
+        labels:
+          osac.openshift.io/externalippool: "{{ pool_name }}"
+          osac.openshift.io/managed-by: osac-fulfillment
+      spec:
+        autoAssign: false
+        avoidBuggyIPs: true  # skip .0 and .255
+        addresses: "{{ pool_cidrs }}"
+  register: ipaddresspool_result
+
+  # MetalLB webhook may not be ready yet after operator install
+  # Retry once every 10 seconds for 10 minutes
+  retries: 60
+  delay: 10
+  until: ipaddresspool_result is successful
+
+- name: Display IPAddressPool creation result
+  ansible.builtin.debug:
+    msg:
+      - "IPAddressPool '{{ pool_name }}' created successfully"
+      - "Changed: {{ ipaddresspool_result.changed | default(false) }}"
+
+- name: Create L2Advertisement
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: present
+    definition:
+      apiVersion: metallb.io/v1beta1
+      kind: L2Advertisement
+      metadata:
+        name: "{{ pool_name }}-l2adv"
+        namespace: metallb-system
+        labels:
+          osac.openshift.io/externalippool: "{{ pool_name }}"
+          osac.openshift.io/managed-by: osac-fulfillment
+      spec:
+        ipAddressPools:
+          - "{{ pool_name }}"
+  register: l2advertisement_result
+
+  # MetalLB webhook may not be ready yet after operator install
+  retries: 60
+  delay: 10
+  until: l2advertisement_result is successful
+
+- name: Display L2Advertisement creation result
+  ansible.builtin.debug:
+    msg:
+      - "L2Advertisement '{{ pool_name }}-l2adv' created successfully"
+      - "Changed: {{ l2advertisement_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_external_ip.yaml
@@ -1,0 +1,48 @@
+---
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Validate ExternalIP fields
+  ansible.builtin.assert:
+    that:
+      - external_ip.metadata is defined
+      - external_ip.metadata.name is defined
+      - external_ip.metadata.name | length > 0
+    fail_msg: "ExternalIP metadata.name is required"
+
+- name: Extract ExternalIP configuration
+  ansible.builtin.set_fact:
+    ip_name: "{{ external_ip.metadata.name }}"
+
+- name: Display deletion information
+  ansible.builtin.debug:
+    msg:
+      - "Deleting LoadBalancer Service for ExternalIP '{{ ip_name }}'"
+
+- name: Delete LoadBalancer Service
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: absent
+    api_version: v1
+    kind: Service
+    name: "osac-eip-{{ ip_name }}"
+    namespace: metallb-system
+    wait: true
+    wait_timeout: 300
+  register: lb_service_delete_result
+  retries: 3
+  delay: 10
+  until: >-
+    lb_service_delete_result is successful
+    or ('NotFound' in (lb_service_delete_result.msg | default('')))
+  failed_when:
+    - lb_service_delete_result.failed | default(false)
+    - "'NotFound' not in (lb_service_delete_result.msg | default(''))"
+
+- name: Display LoadBalancer Service deletion result
+  ansible.builtin.debug:
+    msg:
+      - "LoadBalancer Service 'osac-eip-{{ ip_name }}' deletion completed"
+      - "Changed: {{ lb_service_delete_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_external_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/delete_external_ip_pool.yaml
@@ -1,0 +1,71 @@
+---
+# Delete MetalLB L2Advertisement and IPAddressPool for ExternalIPPool
+# 1. Deletes L2Advertisement first (must be removed before pool)
+# 2. Deletes IPAddressPool
+# Handles "not found" errors gracefully for both resources
+
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Extract ExternalIPPool configuration
+  ansible.builtin.set_fact:
+    pool_name: "{{ external_ip_pool.metadata.name }}"
+
+- name: Display deletion information
+  ansible.builtin.debug:
+    msg:
+      - "Deleting MetalLB resources for ExternalIPPool '{{ pool_name }}'"
+
+- name: Delete L2Advertisement
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: absent
+    api_version: metallb.io/v1beta1
+    kind: L2Advertisement
+    name: "{{ pool_name }}-l2adv"
+    namespace: metallb-system
+    wait: true
+    wait_timeout: 300
+  register: l2adv_delete_result
+  retries: 3
+  delay: 10
+  until: >-
+    l2adv_delete_result is successful
+    or ('NotFound' in (l2adv_delete_result.msg | default('')))
+  failed_when:
+    - l2adv_delete_result.failed | default(false)
+    - "'NotFound' not in (l2adv_delete_result.msg | default(''))"
+
+- name: Display L2Advertisement deletion result
+  ansible.builtin.debug:
+    msg:
+      - "L2Advertisement '{{ pool_name }}-l2adv' deletion completed"
+      - "Changed: {{ l2adv_delete_result.changed | default(false) }}"
+
+- name: Delete IPAddressPool
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    state: absent
+    api_version: metallb.io/v1beta1
+    kind: IPAddressPool
+    name: "{{ pool_name }}"
+    namespace: metallb-system
+    wait: true
+    wait_timeout: 300
+  register: ipaddresspool_delete_result
+  retries: 3
+  delay: 10
+  until: >-
+    ipaddresspool_delete_result is successful
+    or ('NotFound' in (ipaddresspool_delete_result.msg | default('')))
+  failed_when:
+    - ipaddresspool_delete_result.failed | default(false)
+    - "'NotFound' not in (ipaddresspool_delete_result.msg | default(''))"
+
+- name: Display IPAddressPool deletion result
+  ansible.builtin.debug:
+    msg:
+      - "IPAddressPool '{{ pool_name }}' deletion completed"
+      - "Changed: {{ ipaddresspool_delete_result.changed | default(false) }}"

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/detach_external_ip.yaml
@@ -1,0 +1,273 @@
+---
+- name: Include get remote cluster kubeconfig
+  ansible.builtin.include_role:
+    name: osac.service.common
+    tasks_from: get_remote_cluster_kubeconfig
+
+- name: Validate ExternalIPAttachment fields and annotations
+  ansible.builtin.assert:
+    that:
+      - external_ip_attachment.metadata is defined
+      - external_ip_attachment.metadata.name is defined
+      - external_ip_attachment.metadata.name | length > 0
+      - external_ip_attachment.metadata.namespace is defined
+      - external_ip_attachment.metadata.namespace | length > 0
+      - external_ip_attachment.metadata.annotations is defined
+      - "'osac.openshift.io/externalippool-name' in external_ip_attachment.metadata.annotations"
+      - external_ip_attachment.metadata.annotations['osac.openshift.io/externalippool-name'] | length > 0
+      - "'osac.openshift.io/externalip-target-namespace' in external_ip_attachment.metadata.annotations"
+      - external_ip_attachment.metadata.annotations['osac.openshift.io/externalip-target-namespace'] | length > 0
+    fail_msg: >-
+      ExternalIPAttachment is missing required fields/annotations:
+      metadata.name and metadata.namespace must be set,
+      and annotations osac.openshift.io/externalippool-name and
+      osac.openshift.io/externalip-target-namespace must both be present and non-empty.
+
+- name: Extract ExternalIPAttachment detach configuration
+  ansible.builtin.set_fact:
+    external_ip_name: >-
+      {{ external_ip_attachment.metadata.annotations['osac.openshift.io/externalip-name']
+         | default(external_ip_attachment.metadata.name) }}
+    detach_vm_namespace: >-
+      {{ external_ip_attachment.metadata.annotations['osac.openshift.io/externalip-target-namespace'] }}
+    detach_pool_name: >-
+      {{ external_ip_attachment.metadata.annotations['osac.openshift.io/externalippool-name'] }}
+    detach_compute_instance_uuid: >-
+      {{ ((external_ip_attachment.spec | default({})).computeInstance | default('')) | trim }}
+
+- name: Fetch ComputeInstance CR
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    namespace: "{{ external_ip_attachment.metadata.namespace }}"
+    label_selectors:
+      - "osac.openshift.io/computeinstance-uuid={{ detach_compute_instance_uuid }}"
+  register: detach_ci_lookup
+  when: detach_compute_instance_uuid | length > 0
+
+- name: Fail if ComputeInstance lookup is ambiguous
+  ansible.builtin.fail:
+    msg: >-
+      Multiple ComputeInstance resources matched uuid
+      '{{ detach_compute_instance_uuid }}' in namespace
+      '{{ external_ip_attachment.metadata.namespace }}'; expected exactly one.
+  when:
+    - detach_ci_lookup is not skipped
+    - detach_ci_lookup.resources | default([]) | length > 1
+
+- name: Extract ComputeInstance name from fetched CR
+  ansible.builtin.set_fact:
+    detach_compute_instance_name: "{{ detach_ci_lookup.resources[0].metadata.name }}"
+  when:
+    - detach_ci_lookup is not skipped
+    - detach_ci_lookup.resources | default([]) | length == 1
+
+# Read the IP from the VM namespace LB Service before deleting it.
+- name: Read IP from VM namespace LoadBalancer Service
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: v1
+    kind: Service
+    name: "osac-eip-{{ external_ip_name }}-ingress"
+    namespace: "{{ detach_vm_namespace }}"
+  register: lb_service_info
+
+- name: Set detach_already_done when LB Service is already gone (redelivery)
+  ansible.builtin.set_fact:
+    detach_already_done: true
+  when: >-
+    lb_service_info.resources | length == 0 or
+    lb_service_info.resources[0].status.loadBalancer.ingress | default([]) | length == 0
+
+- name: Set detach_already_done to false when LB Service exists
+  ansible.builtin.set_fact:
+    detach_already_done: false
+  when: detach_already_done is not defined
+
+- name: Display detach already completed (redelivery)
+  ansible.builtin.debug:
+    msg: >-
+      LoadBalancer Service 'osac-eip-{{ external_ip_name }}-ingress' not found in '{{ detach_vm_namespace }}'.
+      Detach already completed (idempotent redelivery).
+  when: detach_already_done
+
+- name: Extract IP address and VM name from VM namespace LB Service
+  ansible.builtin.set_fact:
+    detach_ip_address: "{{ lb_service_info.resources[0].status.loadBalancer.ingress[0].ip }}"
+    detach_vm_name_from_svc: >-
+      {{ (lb_service_info.resources[0].spec.selector | default({}))['vm.kubevirt.io/name'] | default('') }}
+  when: not detach_already_done
+
+- name: Set ComputeInstance name from LB Service selector if not already known
+  ansible.builtin.set_fact:
+    detach_compute_instance_name: "{{ detach_vm_name_from_svc }}"
+  when:
+    - not detach_already_done
+    - detach_compute_instance_name is not defined
+    - detach_vm_name_from_svc | length > 0
+
+- name: Display ExternalIPAttachment detach information
+  ansible.builtin.debug:
+    msg:
+      - "Deleting ExternalIPAttachment '{{ external_ip_name }}'"
+      - "IP address: {{ detach_ip_address }} (read from VM namespace LB Service)"
+      - "Pool: {{ detach_pool_name }}"
+      - "VM namespace: {{ detach_vm_namespace }}"
+      - "ComputeInstance: {{ detach_compute_instance_name | default('not available') }}"
+  when: not detach_already_done
+
+# Delete the LB Service, clear the annotation, and restore the placeholder atomically.
+# The rescue restores the LB Service if placeholder re-creation fails so the IP
+# is never left unparked without a reservation in metallb-system.
+- name: Detach ExternalIP - remove LB Service, clear annotation, restore placeholder
+  when: not detach_already_done
+  block:
+    - name: Delete LoadBalancer Service from VM namespace
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: absent
+        api_version: v1
+        kind: Service
+        name: "osac-eip-{{ external_ip_name }}-ingress"
+        namespace: "{{ detach_vm_namespace }}"
+        wait: true
+        wait_timeout: 60
+      register: lb_service_delete_result
+      retries: 3
+      delay: 5
+      until: lb_service_delete_result is successful
+      failed_when:
+        - lb_service_delete_result.failed | default(false)
+        - "'NotFound' not in (lb_service_delete_result.msg | default(''))"
+
+    - name: Display LB Service deletion result
+      ansible.builtin.debug:
+        msg:
+          - "LoadBalancer Service 'osac-eip-{{ external_ip_name }}-ingress' deleted from '{{ detach_vm_namespace }}'"
+          - "Changed: {{ lb_service_delete_result.changed | default(false) }}"
+
+    - name: Re-create placeholder Service in metallb-system
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: present
+        apply: true
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: "osac-eip-{{ external_ip_name }}"
+            namespace: metallb-system
+            labels:
+              osac.openshift.io/externalip: "{{ external_ip_name }}"
+              osac.openshift.io/managed-by: osac-fulfillment
+            annotations:
+              metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
+              metallb.universe.tf/loadBalancerIPs: "{{ detach_ip_address }}"
+          spec:
+            type: LoadBalancer
+            selector: {}
+            ports:
+              - name: placeholder
+                protocol: TCP
+                port: 65535
+                targetPort: 65535
+      register: placeholder_service_result
+      retries: 60
+      delay: 10
+      until: placeholder_service_result is successful
+
+    - name: Display placeholder Service creation result
+      ansible.builtin.debug:
+        msg:
+          - "Placeholder Service 'osac-eip-{{ external_ip_name }}' re-created in metallb-system"
+          - "IP preserved: {{ detach_ip_address }}"
+          - "Changed: {{ placeholder_service_result.changed | default(false) }}"
+
+  rescue:
+    - name: Restore LoadBalancer Service in VM namespace after failed placeholder re-creation
+      kubernetes.core.k8s:
+        kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+        state: present
+        apply: true
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: "osac-eip-{{ external_ip_name }}-ingress"
+            namespace: "{{ detach_vm_namespace }}"
+            labels:
+              osac.openshift.io/externalip: "{{ external_ip_name }}"
+              osac.openshift.io/managed-by: osac-fulfillment
+            annotations:
+              metallb.universe.tf/address-pool: "{{ detach_pool_name }}"
+              metallb.universe.tf/loadBalancerIPs: "{{ detach_ip_address }}"
+          spec:
+            type: LoadBalancer
+            selector:
+              vm.kubevirt.io/name: "{{ detach_compute_instance_name }}"
+            ports:
+              - name: ssh
+                port: 22
+                targetPort: 22
+                protocol: TCP
+      when:
+        - lb_service_delete_result.changed | default(false)
+        - detach_compute_instance_name is defined
+      register: rescue_lb_result
+      retries: 3
+      delay: 5
+      until: rescue_lb_result is successful
+
+    - name: Fail after attempted rollback of detach operation
+      ansible.builtin.fail:
+        msg: >-
+          Detach of ExternalIP '{{ external_ip_name }}' failed; the LoadBalancer Service
+          'osac-eip-{{ external_ip_name }}-ingress' in '{{ detach_vm_namespace }}' has been restored
+          if it had been deleted. Check the preceding error for details.
+
+# Remove the external-ip-address annotation from the ComputeInstance CR.
+- name: Fetch ComputeInstance to inspect annotations
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    name: "{{ detach_compute_instance_name }}"
+    namespace: "{{ external_ip_attachment.metadata.namespace }}"
+  register: ci_info
+  when: detach_compute_instance_name is defined
+
+- name: Remove external-ip-address annotation from ComputeInstance CR
+  kubernetes.core.k8s_json_patch:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: osac.openshift.io/v1alpha1
+    kind: ComputeInstance
+    name: "{{ detach_compute_instance_name }}"
+    namespace: "{{ external_ip_attachment.metadata.namespace }}"
+    patch:
+      - op: remove
+        path: /metadata/annotations/osac.openshift.io~1external-ip-address
+  register: ci_patch_result
+  when:
+    - detach_compute_instance_name is defined
+    - ci_info is not skipped
+    - ci_info.resources | length > 0
+    - (ci_info.resources[0].metadata.annotations | default({}))
+      ['osac.openshift.io/external-ip-address'] is defined
+
+- name: Display ComputeInstance annotation removal result
+  ansible.builtin.debug:
+    msg:
+      - "ComputeInstance '{{ detach_compute_instance_name }}': external-ip-address annotation removed"
+      - "Changed: {{ ci_patch_result.changed | default(false) }}"
+  when:
+    - detach_compute_instance_name is defined
+    - ci_patch_result is defined
+    - ci_patch_result is not skipped
+
+- name: Display ComputeInstance annotation cleanup skipped
+  ansible.builtin.debug:
+    msg: >-
+      ComputeInstance annotation cleanup skipped
+      (spec.computeInstance was not available during detach)
+  when: detach_compute_instance_name is not defined

--- a/playbook_osac_attach_external_ip.yml
+++ b/playbook_osac_attach_external_ip.yml
@@ -1,0 +1,27 @@
+---
+- name: Attach an ExternalIP to a target resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    external_ip_attachment: "{{ ansible_eda.event.payload }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display ExternalIP attach information
+      ansible.builtin.debug:
+        msg:
+          - "ExternalIP attachment name: {{ ansible_eda.event.payload.metadata.name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected ExternalIP attach role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: attach_external_ip

--- a/playbook_osac_create_external_ip.yml
+++ b/playbook_osac_create_external_ip.yml
@@ -1,0 +1,30 @@
+---
+- name: Create an ExternalIP resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    external_ip: "{{ ansible_eda.event.payload }}"
+    external_ip_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations
+         ['osac.openshift.io/implementation-strategy'] }}
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display ExternalIP information
+      ansible.builtin.debug:
+        msg:
+          - "ExternalIP name: {{ external_ip_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+          - "Template parameters: {{ template_parameters }}"
+
+    - name: Call the selected ExternalIP role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: create_external_ip

--- a/playbook_osac_create_external_ip_pool.yml
+++ b/playbook_osac_create_external_ip_pool.yml
@@ -1,0 +1,28 @@
+---
+- name: Create an ExternalIPPool resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    external_ip_pool: "{{ ansible_eda.event.payload }}"
+    external_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: "{{ ansible_eda.event.payload.spec.implementationStrategy }}"
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display ExternalIPPool information
+      ansible.builtin.debug:
+        msg:
+          - "ExternalIPPool name: {{ external_ip_pool_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+          - "Template parameters: {{ template_parameters }}"
+
+    - name: Call the selected ExternalIPPool role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: create_external_ip_pool

--- a/playbook_osac_delete_external_ip.yml
+++ b/playbook_osac_delete_external_ip.yml
@@ -1,0 +1,29 @@
+---
+- name: Delete an ExternalIP resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    external_ip: "{{ ansible_eda.event.payload }}"
+    external_ip_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations
+         ['osac.openshift.io/implementation-strategy'] }}
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display ExternalIP information
+      ansible.builtin.debug:
+        msg:
+          - "Deleting ExternalIP: {{ external_ip_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected ExternalIP role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: delete_external_ip

--- a/playbook_osac_delete_external_ip_pool.yml
+++ b/playbook_osac_delete_external_ip_pool.yml
@@ -1,0 +1,27 @@
+---
+- name: Delete an ExternalIPPool resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    external_ip_pool: "{{ ansible_eda.event.payload }}"
+    external_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: "{{ ansible_eda.event.payload.spec.implementationStrategy }}"
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display ExternalIPPool information
+      ansible.builtin.debug:
+        msg:
+          - "Deleting ExternalIPPool: {{ external_ip_pool_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected ExternalIPPool role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: delete_external_ip_pool

--- a/playbook_osac_detach_external_ip.yml
+++ b/playbook_osac_detach_external_ip.yml
@@ -1,0 +1,27 @@
+---
+- name: Detach an ExternalIP from a target resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    external_ip_attachment: "{{ ansible_eda.event.payload }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+    template_parameters: {}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display ExternalIP detach information
+      ansible.builtin.debug:
+        msg:
+          - "ExternalIP attachment name: {{ ansible_eda.event.payload.metadata.name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected ExternalIP detach role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: detach_external_ip


### PR DESCRIPTION
Add playbooks and metallb_l2 template role tasks for ExternalIPPool, ExternalIP, and ExternalIPAttachment resources. These mirror the existing PublicIP playbooks with the PublicIP → ExternalIP rename, updated annotations (externalippool-name, externalip-name, externalip-target-namespace), and Service name prefix change (osac-pip- → osac-eip-).

Attachment playbooks follow the existing attach/detach naming convention (attach_external_ip, detach_external_ip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added event-driven automation (EDA) for provisioning, deleting, attaching, and detaching ExternalIPPools using MetalLB L2 services.
  * Introduced automated reservation/assignment flow, including MetalLB pool/IP setup and attachment-based routing for compute instances.
* **Bug Fixes**
  * Improved robustness with stronger input validation, readiness polling, idempotent re-attachment behavior, and coordinated rollback on attach/detach failures.
  * Enhanced deletion handling to tolerate missing resources safely and reliably clean up attachment annotations when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->