### PR TITLE
OSAC-1704: Add USB tablet input device to VM spec for VNC cursor accuracy

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_build_spec.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_build_spec.yaml
@@ -26,6 +26,11 @@
           interfaces:
             - name: default
               bridge: {}
+          # USB tablet provides absolute cursor positioning for VNC
+          inputs:
+            - name: tablet
+              type: tablet
+              bus: usb
         features:
           smm:
             enabled: true
@@ -79,6 +84,11 @@
           interfaces:
             - name: default
               bridge: {}
+          # USB tablet provides absolute cursor positioning for VNC
+          inputs:
+            - name: tablet
+              type: tablet
+              bus: usb
           tpm: {}
           rng: {}
         features:


### PR DESCRIPTION
 Without an absolute-coordinate input device, VNC falls back to relative mouse deltas via the PS/2 mouse, causing persistent cursor drift. The USB tablet registers an absolute input handler that VNC maps to directly.

 Ref:
- https://linux-kvm.org/page/USB / "USB tablet (called usb-tablet): Provides an absolute pointer device which often helps with getting a consistent mouse cursor position in VNC."
- https://github.com/kubevirt/kubevirt/issues/3474
- https://www.qemu.org/docs/master/system/invocation.html / `-vnc` flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added USB tablet input device support to both Linux and Windows VM templates, enabling absolute cursor positioning for improved VNC session experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->