### PR TITLE
OSAC-1698: Revert VM network spec to pod: {} with bridge interface

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_build_spec.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_build_spec.yaml
@@ -38,9 +38,7 @@
               spinlocks: 8191
       networks:
         - name: default
-          multus:
-            networkName: "{{ compute_instance_target_namespace }}/{{ vm_cudn_nad_name }}"
-            default: true
+          pod: {}
       volumes: "{{ root_disk_volume }}"
   when: guest_os_family != 'windows'
 
@@ -93,9 +91,7 @@
               spinlocks: 8192
       networks:
         - name: default
-          multus:
-            networkName: "{{ compute_instance_target_namespace }}/{{ vm_cudn_nad_name }}"
-            default: true
+          pod: {}
       volumes: "{{ root_disk_volume }}"
   when: guest_os_family == 'windows'
 


### PR DESCRIPTION
Replace multus default:true NAD reference with pod: {} in the VM spec. The explicit Multus reference causes failures on clusters with the OVN-K enable-preconfigured-udn-addresses feature gate enabled, because OVN-K expects the default-network annotation to point to openshift-ovn-kubernetes, not a user namespace. With pod: {} the CUDN is still the primary network via the namespace label k8s.ovn.org/primary-user-defined-network, and the playbook validation still prevents VMs without a subnet reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default network attachment configuration in VM templates to properly resolve network interfaces for both Linux and Windows guest operating systems using pod-scoped network configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->