### PR TITLE
OSAC-1550: read sshPublicKey from template parameters

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/create.yaml
@@ -20,9 +20,9 @@
     bmh_namespace: "{{ bare_metal_instance.spec.externalHostID.split('/')[0] }}"
     bmh_name: "{{ bare_metal_instance.spec.externalHostID.split('/')[1] }}"
 
-- name: Extract SSH key and userDataSecret from template parameters
+- name: Extract SSH public key and userDataSecret from template parameters
   ansible.builtin.set_fact:
-    ssh_key: "{{ template_params.sshKey | default('') }}"
+    ssh_key: "{{ template_params.sshPublicKey | default(template_params.sshKey | default('')) }}"
     user_data_secret_ref: "{{ template_params.userDataSecret | default('') }}"
 
 - name: Get BareMetalHost

--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/create.yaml
@@ -22,7 +22,7 @@
 
 - name: Extract SSH public key and userDataSecret from template parameters
   ansible.builtin.set_fact:
-    ssh_key: "{{ template_params.sshPublicKey | default(template_params.sshKey | default('')) }}"
+    ssh_key: "{{ template_params.sshPublicKey | default('') }}"
     user_data_secret_ref: "{{ template_params.userDataSecret | default('') }}"
 
 - name: Get BareMetalHost


### PR DESCRIPTION
## Summary

- Update `bm_host_metal3_provisioning` role to read `template_params.sshPublicKey` instead of `template_params.sshKey`

Required by the fulfillment-service parameter key rename in https://github.com/osac-project/fulfillment-service/pull/744. Both PRs should merge together.

## Test plan

- [ ] Verify with fulfillment-service PR #744 that SSH keys are passed correctly through the template parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed SSH public key parameter recognition during bare metal host provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->