### PR TITLE
Add support for different OCP versions

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_small/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/defaults/main.yaml
@@ -1,0 +1,2 @@
+ocp_release_version: "4.22.0"
+ocp_release_image: "quay.io/openshift-release-dev/ocp-release:{{ ocp_release_version }}-multi"

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/meta/osac.yaml
@@ -1,0 +1,18 @@
+# Define the display name and description of the template
+title: Simple OpenShift Cluster
+description: >
+  This template will build a minimally configured OpenShift cluster.
+  Defaults to OCP 4.22 but the version can be overridden via the
+  ocp_release_version variable or by setting release_image on the ClusterOrder.
+
+# This sets the nodeRequest field in the ClusterOrder manifest. There must be at
+# least one entry in this list.
+default_node_request:
+- resourceClass: fc430
+  numberOfNodes: 2
+
+# This declares that for a cluster built from this template, only the resource
+# classes listed here may be used when requesting additional nodes. If this
+# list is empty or unspecified, a ClusterOrder may request nodes from any
+# available resource class.
+allowed_resource_classes: []

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/delete.yaml
@@ -1,0 +1,61 @@
+- name: Set delete step defaults
+  ansible.builtin.set_fact:
+    delete_step_pre_delete_hook_default:
+      name: osac.templates.ocp_small
+      tasks_from: noop.yaml
+    delete_step_hosted_cluster_default:
+      name: osac.service.hosted_cluster
+      tasks_from: main.yaml
+    delete_step_external_access_default:
+      name: osac.service.external_access
+      tasks_from: main.yaml
+    delete_step_cluster_infra_default:
+      name: osac.service.cluster_infra
+      tasks_from: main.yaml
+    delete_step_post_delete_hook_default:
+      name: osac.templates.ocp_small
+      tasks_from: noop.yaml
+
+- name: Step - Pre-delete hook
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_pre_delete_hook_override | default(delete_step_pre_delete_hook_default)).name }}"
+    tasks_from: "{{ (delete_step_pre_delete_hook_override | default(delete_step_pre_delete_hook_default)).tasks_from }}"
+
+- name: Step - Destroy hosted cluster
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_hosted_cluster_override | default(delete_step_hosted_cluster_default)).name }}"
+    tasks_from: "{{ (delete_step_hosted_cluster_override | default(delete_step_hosted_cluster_default)).tasks_from }}"
+  vars:
+    hosted_cluster_state: absent
+    hosted_cluster_name: "{{ cluster_order.metadata.name }}"
+    hosted_cluster_namespace: "{{ cluster_working_namespace }}"
+    hosted_cluster_settings:
+      ocp_release_image: "{{ ocp_release_image }}"
+      pull_secret: "{{ cluster_settings_pull_secret }}"
+      ssh_public_key: "{{ cluster_settings_ssh_public_key }}"
+    hosted_cluster_node_count: >-
+      {{ cluster_order.spec.nodeRequests | map(attribute="numberOfNodes") | sum }}
+
+- name: Step - Remove port forwarding
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_external_access_override | default(delete_step_external_access_default)).name }}"
+    tasks_from: "{{ (delete_step_external_access_override | default(delete_step_external_access_default)).tasks_from }}"
+  vars:
+    external_access_state: absent
+    external_access_name: "{{ cluster_order.metadata.name }}"
+    external_access_namespace: "{{ cluster_working_namespace }}"
+
+- name: Step - Destroy cluster infrastructure
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_cluster_infra_override | default(delete_step_cluster_infra_default)).name }}"
+    tasks_from: "{{ (delete_step_cluster_infra_override | default(delete_step_cluster_infra_default)).tasks_from }}"
+  vars:
+    cluster_infra_state: absent
+    cluster_infra_name: "{{ cluster_order.metadata.name }}"
+    cluster_infra_namespace: "{{ cluster_working_namespace }}"
+    cluster_infra_node_requests: []
+
+- name: Step - Post-delete hook
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_post_delete_hook_override | default(delete_step_post_delete_hook_default)).name }}"
+    tasks_from: "{{ (delete_step_post_delete_hook_override | default(delete_step_post_delete_hook_default)).tasks_from }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/install.yaml
@@ -1,0 +1,93 @@
+- name: Set install step defaults
+  ansible.builtin.set_fact:
+    install_step_pre_install_hook_default:
+      name: osac.templates.ocp_small
+      tasks_from: noop.yaml
+    install_step_hosted_cluster_default:
+      name: osac.service.hosted_cluster
+      tasks_from: main.yaml
+    install_step_cluster_infra_default:
+      name: osac.service.cluster_infra
+      tasks_from: main.yaml
+    install_step_external_access_default:
+      name: osac.service.external_access
+      tasks_from: main.yaml
+    install_step_retrieve_kubeconfig_default:
+      name: osac.service.retrieve_kubeconfig
+      tasks_from: main.yaml
+    install_step_wait_for_nodes_default:
+      name: osac.service.wait_for
+      tasks_from: wait_for_nodes.yaml
+    install_step_wait_for_cluster_operators_default:
+      name: osac.service.wait_for
+      tasks_from: wait_for_cluster_operators.yaml
+    install_step_post_install_hook_default:
+      name: osac.templates.ocp_small
+      tasks_from: noop.yaml
+
+- name: Step - Pre-install hook
+  ansible.builtin.include_role:
+    name: "{{ (install_step_pre_install_hook_override | default(install_step_pre_install_hook_default)).name }}"
+    tasks_from: "{{ (install_step_pre_install_hook_override | default(install_step_pre_install_hook_default)).tasks_from }}"
+
+- name: Step - Create hosted cluster
+  ansible.builtin.include_role:
+    name: "{{ (install_step_hosted_cluster_override | default(install_step_hosted_cluster_default)).name }}"
+    tasks_from: "{{ (install_step_hosted_cluster_override | default(install_step_hosted_cluster_default)).tasks_from }}"
+  vars:
+    hosted_cluster_name: "{{ cluster_order.metadata.name }}"
+    hosted_cluster_namespace: "{{ cluster_working_namespace }}"
+    hosted_cluster_settings:
+      ocp_release_image: "{{ ocp_release_image }}"
+      pull_secret: "{{ cluster_settings_pull_secret }}"
+      ssh_public_key: "{{ cluster_settings_ssh_public_key }}"
+    hosted_cluster_node_requests: "{{ cluster_order.spec.nodeRequests | unique(attribute='resourceClass') }}"
+    hosted_cluster_state: present
+
+- name: Step - Create cluster infrastructure
+  ansible.builtin.include_role:
+    name: "{{ (install_step_cluster_infra_override | default(install_step_cluster_infra_default)).name }}"
+    tasks_from: "{{ (install_step_cluster_infra_override | default(install_step_cluster_infra_default)).tasks_from }}"
+  vars:
+    cluster_infra_state: present
+    cluster_infra_name: "{{ cluster_order.metadata.name }}"
+    cluster_infra_namespace: "{{ cluster_working_namespace }}"
+    cluster_infra_node_requests: "{{ cluster_order.spec.nodeRequests | unique(attribute='resourceClass') }}"
+
+- name: Step - Configure port forwarding
+  ansible.builtin.include_role:
+    name: "{{ (install_step_external_access_override | default(install_step_external_access_default)).name }}"
+    tasks_from: "{{ (install_step_external_access_override | default(install_step_external_access_default)).tasks_from }}"
+  vars:
+    external_access_name: "{{ cluster_order.metadata.name }}"
+    external_access_state: present
+    external_access_namespace: "{{ cluster_working_namespace }}"
+    external_access_ingress_internal_network: "network-{{ cluster_order.metadata.name }}"
+
+- name: Step - Retrieve kubeconfig
+  ansible.builtin.include_role:
+    name: "{{ (install_step_retrieve_kubeconfig_override | default(install_step_retrieve_kubeconfig_default)).name }}"
+    tasks_from: "{{ (install_step_retrieve_kubeconfig_override | default(install_step_retrieve_kubeconfig_default)).tasks_from }}"
+  vars:
+    retrieve_kubeconfig_cluster_name: "{{ cluster_order.metadata.name }}"
+    retrieve_kubeconfig_namespace: "{{ cluster_working_namespace }}"
+
+- name: Step - Wait for nodes to be ready
+  ansible.builtin.include_role:
+    name: "{{ (install_step_wait_for_nodes_override | default(install_step_wait_for_nodes_default)).name }}"
+    tasks_from: "{{ (install_step_wait_for_nodes_override | default(install_step_wait_for_nodes_default)).tasks_from }}"
+  vars:
+    wait_for_kubeconfig: "{{ admin_kubeconfig }}"
+    wait_for_nodes_expected_count: "{{ cluster_order.spec.nodeRequests | map(attribute='numberOfNodes') | map('int') | sum }}"
+
+- name: Step - Wait for cluster operators
+  ansible.builtin.include_role:
+    name: "{{ (install_step_wait_for_cluster_operators_override | default(install_step_wait_for_cluster_operators_default)).name }}"
+    tasks_from: "{{ (install_step_wait_for_cluster_operators_override | default(install_step_wait_for_cluster_operators_default)).tasks_from }}"
+  vars:
+    wait_for_kubeconfig: "{{ admin_kubeconfig }}"
+
+- name: Step - Post-install hook
+  ansible.builtin.include_role:
+    name: "{{ (install_step_post_install_hook_override | default(install_step_post_install_hook_default)).name }}"
+    tasks_from: "{{ (install_step_post_install_hook_override | default(install_step_post_install_hook_default)).tasks_from }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/noop.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/noop.yaml
@@ -1,0 +1,3 @@
+---
+# No-op task file for default hooks
+# This file makes the template self-contained without external collection dependencies

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/post_install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/post_install.yaml
@@ -1,0 +1,69 @@
+---
+- name: Ensure openshift-operators namespace exists
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-operators
+
+- name: Create cert-manager subscription
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: cert-manager
+        namespace: openshift-operators
+      spec:
+        channel: stable
+        installPlanApproval: Automatic
+        name: cert-manager
+        source: community-operators
+        sourceNamespace: openshift-marketplace
+
+- name: Create production issuer
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-production-http01
+      spec:
+        acme:
+          privateKeySecretRef:
+            name: letsencrypt-production-http01
+          server: 'https://acme-v02.api.letsencrypt.org/directory'
+          solvers:
+            - http01:
+                ingress:
+                  class: openshift-default
+  register: production_issuer_result
+  until: production_issuer_result is succeeded
+  retries: 30
+  delay: 30
+
+- name: Create staging issuer
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-staging-http01
+      spec:
+        acme:
+          privateKeySecretRef:
+            name: letsencrypt-staging-http01
+          server: 'https://acme-staging-v02.api.letsencrypt.org/directory'
+          solvers:
+            - http01:
+                ingress:
+                  class: openshift-default
+  register: staging_issuer_result
+  until: staging_issuer_result is succeeded
+  retries: 30
+  delay: 30


### PR DESCRIPTION
The OCP version was hardcoded to 4.17.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OCP 4.22.0 is now the default release version
  * Added cluster template definitions for Simple OpenShift Cluster configurations
  * Enabled cluster installation and deletion workflow orchestration
  * Added post-installation automation for certificate management and Let's Encrypt integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->