### PR TITLE
OSAC-1707: inject SSH keys via config-drive metaData instead of merging into userData

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/create.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/create.yaml
@@ -63,70 +63,22 @@
   when: not (already_provisioned | bool)
   block:
     - name: Build userData content
-      when: ssh_key | length > 0 or user_data_secret_ref | length > 0
+      when: user_data_secret_ref | length > 0
       block:
-        - name: Read userDataSecret from BareMetalInstance namespace
-          when: user_data_secret_ref | length > 0
-          block:
-            - name: Fetch userDataSecret
-              kubernetes.core.k8s_info:
-                api_version: v1
-                kind: Secret
-                namespace: "{{ bare_metal_instance.metadata.namespace }}"
-                name: "{{ user_data_secret_ref }}"
-              register: user_data_secret_result
+        - name: Fetch userDataSecret
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Secret
+            namespace: "{{ bare_metal_instance.metadata.namespace }}"
+            name: "{{ user_data_secret_ref }}"
+          register: user_data_secret_result
 
-            - name: Fail if userDataSecret not found
-              ansible.builtin.fail:
-                msg: >-
-                  Secret '{{ user_data_secret_ref }}' not found in namespace
-                  '{{ bare_metal_instance.metadata.namespace }}'
-              when: user_data_secret_result.resources | length == 0
-
-            - name: Extract user data content from Secret
-              ansible.builtin.set_fact:
-                existing_user_data: "{{ user_data_secret_result.resources[0].data.userdata | b64decode }}"
-
-        - name: Generate cloud-init with SSH key only
-          when:
-            - ssh_key | length > 0
-            - user_data_secret_ref | length == 0
-          ansible.builtin.set_fact:
-            final_user_data: |
-              #cloud-config
-              ssh_authorized_keys:
-                - {{ ssh_key }}
-
-        - name: Use existing user data as-is (no SSH key to merge)
-          when:
-            - ssh_key | length == 0
-            - user_data_secret_ref | length > 0
-          ansible.builtin.set_fact:
-            final_user_data: "{{ existing_user_data }}"
-
-        - name: Merge SSH key into existing cloud-init user data
-          when:
-            - ssh_key | length > 0
-            - user_data_secret_ref | length > 0
-          block:
-            - name: Fail if user data is not cloud-config format
-              ansible.builtin.fail:
-                msg: >-
-                  Cannot inject SSH key into user data that is not cloud-config format.
-                  User data must start with '#cloud-config' to support SSH key injection.
-                  Either remove the ssh_key parameter or provide user data in cloud-config
-                  format with ssh_authorized_keys included.
-              when: not (existing_user_data | trim is match('^#cloud-config'))
-
-            - name: Parse existing cloud-init and merge SSH key
-              ansible.builtin.set_fact:
-                final_user_data: >-
-                  #cloud-config
-                  {{ (existing_user_data | regex_replace('^#cloud-config\s*\n?', '') | from_yaml | default({}))
-                     | combine({'ssh_authorized_keys':
-                         ((existing_user_data | regex_replace('^#cloud-config\s*\n?', '') | from_yaml | default({})).ssh_authorized_keys | default([]))
-                         + [ssh_key]})
-                     | to_nice_yaml }}
+        - name: Fail if userDataSecret not found
+          ansible.builtin.fail:
+            msg: >-
+              Secret '{{ user_data_secret_ref }}' not found in namespace
+              '{{ bare_metal_instance.metadata.namespace }}'
+          when: user_data_secret_result.resources | length == 0
 
         - name: Create userData Secret in BMH namespace
           kubernetes.core.k8s:
@@ -137,8 +89,21 @@
               metadata:
                 name: "{{ bmh_name }}-user-data"
                 namespace: "{{ bmh_namespace }}"
-              stringData:
-                userData: "{{ final_user_data }}"
+              data:
+                userData: "{{ user_data_secret_result.resources[0].data.userdata }}"
+
+    - name: Create metaData Secret with SSH public key
+      when: ssh_key | length > 0
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ bmh_name }}-meta-data"
+            namespace: "{{ bmh_namespace }}"
+          stringData:
+            metaData: "{{ {'public_keys': {'osac': ssh_key}} | to_nice_yaml }}"
 
     - name: Create networkData Secret
       when: template_params.networkData | default('') | length > 0
@@ -177,13 +142,26 @@
              }, recursive=True) }}
 
     - name: Add userData to BMH patch
-      when: final_user_data is defined
+      when: user_data_secret_ref | length > 0
       ansible.builtin.set_fact:
         bmh_patch: >-
           {{ bmh_patch | combine({
                'spec': bmh_patch.spec | combine({
                  'userData': {
                    'name': bmh_name ~ '-user-data',
+                   'namespace': bmh_namespace
+                 }
+               })
+             }, recursive=True) }}
+
+    - name: Add metaData to BMH patch
+      when: ssh_key | length > 0
+      ansible.builtin.set_fact:
+        bmh_patch: >-
+          {{ bmh_patch | combine({
+               'spec': bmh_patch.spec | combine({
+                 'metaData': {
+                   'name': bmh_name ~ '-meta-data',
                    'namespace': bmh_namespace
                  }
                })

--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/tasks/delete.yaml
@@ -44,7 +44,7 @@
         - name: Remove image and networkData from BMH
           when: bmh_has_image | bool
           block:
-            - name: Patch BareMetalHost to remove image, networkData, and userData
+            - name: Patch BareMetalHost to remove image, networkData, userData, and metaData
               kubernetes.core.k8s:
                 api_version: metal3.io/v1alpha1
                 kind: BareMetalHost
@@ -56,6 +56,7 @@
                     image: null
                     networkData: null
                     userData: null
+                    metaData: null
 
             - name: Wait for BMH to reach available or ready state
               kubernetes.core.k8s_info:
@@ -82,6 +83,14 @@
             kind: Secret
             namespace: "{{ bmh_namespace }}"
             name: "{{ bmh_name }}-user-data"
+            state: absent
+
+        - name: Delete metaData Secret
+          kubernetes.core.k8s:
+            api_version: v1
+            kind: Secret
+            namespace: "{{ bmh_namespace }}"
+            name: "{{ bmh_name }}-meta-data"
             state: absent
 
     - name: Metal3 deprovisioning completed


### PR DESCRIPTION
## Problem

The `bm_host_metal3_provisioning` role merged SSH keys into user-provided cloud-init userData by parsing and rewriting the YAML. This was fragile in two ways:

1. The `>-` folding scalar collapsed the `#cloud-config` header onto the YAML body, causing cloud-init to silently ignore the entire file
2. The merge required userData to be `#cloud-config` format — Ignition, shell scripts, or other formats would fail

## Root Cause

YAML `>-` scalar folds newlines into spaces. The `#cloud-config` header must be on its own line for cloud-init to recognize the format.

## Fix

Replace the userData YAML merge with Metal3's config-drive metaData mechanism:

- SSH keys are now passed via `public_keys` in a metaData Secret, which Metal3/Ironic writes to `meta_data.json` on the config-drive
- User-provided userData is copied through as-is without parsing or format validation
- BMH `spec.metaData` references the new Secret alongside existing `spec.userData`
- Deprovision clears `spec.metaData` and deletes the metaData Secret

The `public_keys` field in `meta_data.json` is the OpenStack config-drive standard for SSH key injection, supported by cloud-init, Afterburn (FCOS/RHCOS), and cloudbase-init by default.

## Testing

Full e2e validation on ostest cluster:
- Provisioned a BMI with SSH key + cloud-init userData via the public API
- Verified userData Secret contains unmodified cloud-init content (no SSH key merged)
- Verified metaData Secret contains `public_keys` map with the SSH key
- Verified BMH `spec.metaData` and `spec.userData` both reference their Secrets
- SSH'd into the provisioned host using the injected key — confirmed connectivity
- Verified cloud-init packages (`vim`, `curl`) and `runcmd` executed correctly
- Deprovisioned and verified BMH returned to `available`, both Secrets deleted

## Confidence

HIGH — validated end-to-end on live Metal3/Ironic infrastructure with Fedora 44 Cloud image.

## Risk Assessment

LOW — the `public_keys` mechanism is the OpenStack standard (stable since 2012) and is supported by all major cloud image init systems. The only risk is custom images that strip cloud-init/Afterburn entirely, but such images wouldn't support SSH key injection via userData either.

Fixes https://redhat.atlassian.net/browse/OSAC-1707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata support for Metal3 bare metal host provisioning with dedicated SSH key management

* **Refactor**
  * User data provisioning now copies configuration from referenced data sources instead of inline generation
  * Cleanup process extended to remove associated metadata when deprovisioning hosts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->