### PR TITLE
Fix L3 router idempotency: handle VLAN sub-interface in namespace

### DIFF
--- a/collections/ansible_collections/agentless_net/l3/roles/router/tasks/create.yaml
+++ b/collections/ansible_collections/agentless_net/l3/roles/router/tasks/create.yaml
@@ -34,9 +34,15 @@
   when: router_ns_exists.rc != 0
   changed_when: true
 
-- name: Check if VLAN sub-interface exists
+- name: Check if VLAN sub-interface exists on host
   ansible.builtin.raw: ip link show {{ router_trunk_interface }}.{{ router_vlan_id }} 2>/dev/null
-  register: router_vlan_if_exists
+  register: router_vlan_if_on_host
+  changed_when: false
+  failed_when: false
+
+- name: Check if VLAN sub-interface exists in namespace
+  ansible.builtin.raw: ip netns exec {{ router_name }} ip link show {{ router_trunk_interface }}.{{ router_vlan_id }} 2>/dev/null
+  register: router_vlan_if_in_ns
   changed_when: false
   failed_when: false
 
@@ -45,18 +51,18 @@
     ip link add link {{ router_trunk_interface }}
     name {{ router_trunk_interface }}.{{ router_vlan_id }}
     type vlan id {{ router_vlan_id }}
-  when: router_vlan_if_exists.rc != 0
+  when: router_vlan_if_on_host.rc != 0 and router_vlan_if_in_ns.rc != 0
   changed_when: true
 
 - name: Ensure VLAN sub-interface is up
   ansible.builtin.raw: ip link set {{ router_trunk_interface }}.{{ router_vlan_id }} up
+  when: router_vlan_if_in_ns.rc != 0
   changed_when: false
 
 - name: Move VLAN sub-interface into namespace
   ansible.builtin.raw: ip link set {{ router_trunk_interface }}.{{ router_vlan_id }} netns {{ router_name }}
-  register: router_move_if_result
-  changed_when: router_move_if_result.rc == 0
-  failed_when: router_move_if_result.rc != 0 and 'File exists' not in (router_move_if_result.stderr | default(''))
+  when: router_vlan_if_in_ns.rc != 0
+  changed_when: true
 
 - name: Configure internal interface inside namespace
   ansible.builtin.raw: |


### PR DESCRIPTION
On first run, the VLAN sub-interface (e.g. eth1.100) is created on the host, brought up, then moved into the router namespace. On subsequent runs (e.g. operator reconciliation), the interface is inside the namespace but the tasks assumed it was on the host, causing failures:

- "VLAN device already exists" when trying to create it
- "Cannot find device" when trying to bring it up
- "File exists" when trying to move it

Fix by splitting the check into host vs namespace lookups and skipping the host-side tasks (create, up, move) when the interface is already in the namespace.

Assisted-by: Claude Code <noreply@anthropic.com>

---

/assign @danmanor 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router VLAN sub-interface creation by checking for the interface both on the host and inside the target network namespace.
  * Made interface setup more reliable by only creating, bringing up, and moving the sub-interface when it is actually missing in the relevant location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->