### PR TITLE
OSAC-1325: switches VAST storage paths to tenant-UID-hash convention

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_quotas.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_quotas.yaml
@@ -6,19 +6,20 @@
 # Requires in scope:
 #   _vast_vms_conn      — VAST VMS connection dict
 #   _vast_tenant_id     — VAST tenant ID
-#   _provider_tiers     — tier list from dispatcher
-#   tenant_name         — play-level var
+#   _provider_tiers         — tier list from dispatcher
+#   _vast_tenant_uid_hash   — first 8 hex chars of SHA256(tenant_uid)
+#   tenant_name             — play-level var
 
 - name: Create VAST quota per tier (when quota specified)
   when: _provider_tiers | selectattr('quota', 'defined') | list | length > 0
   vastdata.vms.quotas:
     vms: "{{ _vast_vms_conn }}"
-    name: "quota-{{ tenant_name }}-{{ item.name }}"
-    path: "/osac/{{ tenant_name }}/{{ item.name }}"
+    name: "quota-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}-{{ item.name }}"
+    path: "/osac-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}/{{ item.name }}"
     tenant_id: "{{ _vast_tenant_id }}"
     hard_limit: "{{ item.quota }}"
     state: present
   loop: "{{ _provider_tiers | selectattr('quota', 'defined') | list }}"
   loop_control:
-    label: "quota-{{ tenant_name }}-{{ item.name }}"
+    label: "quota-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}-{{ item.name }}"
   no_log: true

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_views.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_views.yaml
@@ -7,13 +7,14 @@
 #   _vast_tenant_id         — VAST tenant ID
 #   _vast_view_policy_ids   — dict mapping protocol → policy ID
 #   _provider_tiers         — tier list from dispatcher
+#   _vast_tenant_uid_hash   — first 8 hex chars of SHA256(tenant_uid)
 #   tenant_name             — play-level var
 
 - name: Create VAST view per tier
   vastdata.vms.views:
     vms: "{{ _vast_vms_conn }}"
-    name: "view-{{ tenant_name }}-{{ item.name }}"
-    path: "/osac/{{ tenant_name }}/{{ item.name }}"
+    name: "view-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}-{{ item.name }}"
+    path: "/osac-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}/{{ item.name }}"
     create_dir: true
     policy_id: "{{ _vast_view_policy_ids[item.protocol] }}"
     tenant_id: "{{ _vast_tenant_id }}"
@@ -22,12 +23,12 @@
     state: present
   loop: "{{ _provider_tiers }}"
   loop_control:
-    label: "view-{{ tenant_name }}-{{ item.name }}"
+    label: "view-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}-{{ item.name }}"
   no_log: true
 
 - name: Log VAST view creation results
   ansible.builtin.debug:
-    msg: "VAST view 'view-{{ tenant_name }}-{{ item.name }}' ensured at path '/osac/{{ tenant_name }}/{{ item.name }}'"
+    msg: "VAST view 'view-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}-{{ item.name }}' ensured at path '/osac-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}/{{ item.name }}'"
   loop: "{{ _provider_tiers }}"
   loop_control:
-    label: "view-{{ tenant_name }}-{{ item.name }}"
+    label: "view-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}-{{ item.name }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -228,7 +228,7 @@
           provisioner: "{{ vast_storage_csi_provisioner_map[item.protocol] }}"
           parameters: >-
             {{ _vast_sc_base_params
-               | combine({'root_export': '/osac/' ~ tenant_name ~ '/' ~ item.name})
+               | combine({'root_export': '/osac-' ~ tenant_name ~ '-' ~ _vast_tenant_uid_hash ~ '/' ~ item.name})
                | combine({'view_policy': _vast_nfs_view_policy})
                | combine(({'qos_policy': item.qos_policy} if item.qos_policy is defined else {})) }}
           reclaimPolicy: Delete
@@ -254,7 +254,7 @@
           provisioner: "{{ vast_storage_csi_provisioner_map[item.protocol] }}"
           parameters: >-
             {{ _vast_sc_base_params
-               | combine({'subsystem': 'view-' ~ tenant_name ~ '-' ~ item.name,
+               | combine({'subsystem': 'view-' ~ tenant_name ~ '-' ~ _vast_tenant_uid_hash ~ '-' ~ item.name,
                           'tenant_name': tenant_name})
                | combine({'csi.storage.k8s.io/node-stage-secret-name': _vast_csi_secret_ref.name})
                | combine({'csi.storage.k8s.io/node-stage-secret-namespace': _vast_csi_secret_ref.namespace})
@@ -310,6 +310,8 @@
         vast_username: ""
         vast_password: ""
         _vast_tenant_id: ""
+        _vast_tenant_uid: ""
+        _vast_tenant_uid_hash: ""
         _vast_tenant_csi_username: ""
         _vast_tenant_csi_password: ""
         _vast_tenant_endpoint: ""

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -310,7 +310,6 @@
         vast_username: ""
         vast_password: ""
         _vast_tenant_id: ""
-        _vast_tenant_uid: ""
         _vast_tenant_uid_hash: ""
         _vast_tenant_csi_username: ""
         _vast_tenant_csi_password: ""

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
@@ -13,7 +13,6 @@
 #
 # Requires:
 #   tenant_name                              — play-level var
-#   tenant_uid                               — play-level var (K8s Tenant CR metadata.uid)
 #   vast_storage_tenant_config_secret_prefix — from defaults
 #   vast_storage_config_namespace            — from defaults
 #
@@ -70,13 +69,9 @@
     _vast_view_policy_names_raw: "{{ _vast_tenant_config_secret.resources[0].data.view_policy_names | default('') | b64decode | default('', true) }}"
   no_log: true
 
-- name: Read tenant UID hash from hub Secret with play-level fallback
+- name: Read tenant UID hash from hub Secret
   ansible.builtin.set_fact:
-    _vast_tenant_uid_hash: >-
-      {{ (_vast_tenant_config_secret.resources[0].data.tenant_uid_hash | b64decode)
-         if (_vast_tenant_config_secret.resources[0].data.tenant_uid_hash is defined
-             and (_vast_tenant_config_secret.resources[0].data.tenant_uid_hash | b64decode | length) > 0)
-         else (tenant_uid | hash('sha256'))[:8] }}
+    _vast_tenant_uid_hash: "{{ _vast_tenant_config_secret.resources[0].data.tenant_uid_hash | b64decode }}"
 
 - name: Parse per-protocol view policy names when available
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
@@ -7,16 +7,20 @@
 # CALLER CONTRACT: After using this file, callers MUST clear these facts in their always block:
 #   _vast_tenant_csi_username, _vast_tenant_csi_password, _vast_tenant_vip_pool,
 #   _vast_tenant_endpoint, _vast_view_policy_name, _vast_view_policy_names,
-#   _vast_view_policy_names_raw, _vast_tenant_block_encryption_passphrase
+#   _vast_view_policy_names_raw, _vast_tenant_block_encryption_passphrase,
+#   _vast_tenant_uid, _vast_tenant_uid_hash
 # Failure to clear leaves credentials in play-scoped facts for the remainder of the play.
 #
 # Requires:
 #   tenant_name                              — play-level var
+#   tenant_uid                               — play-level var (K8s Tenant CR metadata.uid)
 #   vast_storage_tenant_config_secret_prefix — from defaults
 #   vast_storage_config_namespace            — from defaults
 #
 # Sets output facts (caller clears in always block):
 #   _vast_tenant_id
+#   _vast_tenant_uid
+#   _vast_tenant_uid_hash
 #   _vast_tenant_csi_username
 #   _vast_tenant_csi_password
 #   _vast_tenant_vip_pool
@@ -66,6 +70,18 @@
     _vast_tenant_block_encryption_passphrase: "{{ _vast_tenant_config_secret.resources[0].data.block_encryption_passphrase | default('') | b64decode | default('', true) }}"
     _vast_view_policy_names_raw: "{{ _vast_tenant_config_secret.resources[0].data.view_policy_names | default('') | b64decode | default('', true) }}"
   no_log: true
+
+- name: Extract tenant_uid from hub Secret with play-level fallback
+  ansible.builtin.set_fact:
+    _vast_tenant_uid: >-
+      {{ (_vast_tenant_config_secret.resources[0].data.tenant_uid | b64decode)
+         if (_vast_tenant_config_secret.resources[0].data.tenant_uid is defined
+             and (_vast_tenant_config_secret.resources[0].data.tenant_uid | b64decode | length) > 0)
+         else tenant_uid }}
+
+- name: Compute tenant UID hash for storage paths
+  ansible.builtin.set_fact:
+    _vast_tenant_uid_hash: "{{ (_vast_tenant_uid | hash('sha256'))[:8] }}"
 
 - name: Parse per-protocol view policy names when available
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
@@ -8,7 +8,7 @@
 #   _vast_tenant_csi_username, _vast_tenant_csi_password, _vast_tenant_vip_pool,
 #   _vast_tenant_endpoint, _vast_view_policy_name, _vast_view_policy_names,
 #   _vast_view_policy_names_raw, _vast_tenant_block_encryption_passphrase,
-#   _vast_tenant_uid, _vast_tenant_uid_hash
+#   _vast_tenant_uid_hash
 # Failure to clear leaves credentials in play-scoped facts for the remainder of the play.
 #
 # Requires:
@@ -19,7 +19,6 @@
 #
 # Sets output facts (caller clears in always block):
 #   _vast_tenant_id
-#   _vast_tenant_uid
 #   _vast_tenant_uid_hash
 #   _vast_tenant_csi_username
 #   _vast_tenant_csi_password
@@ -71,17 +70,13 @@
     _vast_view_policy_names_raw: "{{ _vast_tenant_config_secret.resources[0].data.view_policy_names | default('') | b64decode | default('', true) }}"
   no_log: true
 
-- name: Extract tenant_uid from hub Secret with play-level fallback
+- name: Read tenant UID hash from hub Secret with play-level fallback
   ansible.builtin.set_fact:
-    _vast_tenant_uid: >-
-      {{ (_vast_tenant_config_secret.resources[0].data.tenant_uid | b64decode)
-         if (_vast_tenant_config_secret.resources[0].data.tenant_uid is defined
-             and (_vast_tenant_config_secret.resources[0].data.tenant_uid | b64decode | length) > 0)
-         else tenant_uid }}
-
-- name: Compute tenant UID hash for storage paths
-  ansible.builtin.set_fact:
-    _vast_tenant_uid_hash: "{{ (_vast_tenant_uid | hash('sha256'))[:8] }}"
+    _vast_tenant_uid_hash: >-
+      {{ (_vast_tenant_config_secret.resources[0].data.tenant_uid_hash | b64decode)
+         if (_vast_tenant_config_secret.resources[0].data.tenant_uid_hash is defined
+             and (_vast_tenant_config_secret.resources[0].data.tenant_uid_hash | b64decode | length) > 0)
+         else (tenant_uid | hash('sha256'))[:8] }}
 
 - name: Parse per-protocol view policy names when available
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -176,7 +176,6 @@
                   osac.openshift.io/tenant: "{{ tenant_name }}"
               type: Opaque
               stringData:
-                tenant_uid: "{{ tenant_uid }}"
                 tenant_uid_hash: "{{ (tenant_uid | hash('sha256'))[:8] }}"
                 vast_tenant_id: "{{ _vast_tenant_result.tenants.id | string }}"
                 vast_local_provider_id: "{{ _vast_local_provider_id | string }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -176,6 +176,7 @@
                   osac.openshift.io/tenant: "{{ tenant_name }}"
               type: Opaque
               stringData:
+                tenant_uid: "{{ tenant_uid }}"
                 vast_tenant_id: "{{ _vast_tenant_result.tenants.id | string }}"
                 vast_local_provider_id: "{{ _vast_local_provider_id | string }}"
                 vip_pool_name: "{{ vast_storage_vip_pool_name }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -177,6 +177,7 @@
               type: Opaque
               stringData:
                 tenant_uid: "{{ tenant_uid }}"
+                tenant_uid_hash: "{{ (tenant_uid | hash('sha256'))[:8] }}"
                 vast_tenant_id: "{{ _vast_tenant_result.tenants.id | string }}"
                 vast_local_provider_id: "{{ _vast_local_provider_id | string }}"
                 vip_pool_name: "{{ vast_storage_vip_pool_name }}"

--- a/playbook_osac_create_tenant_cluster_storage.yml
+++ b/playbook_osac_create_tenant_cluster_storage.yml
@@ -6,6 +6,7 @@
   vars:
     tenant_name: "{{ ansible_eda.event.payload.metadata.name }}"
     tenant_namespace: "{{ ansible_eda.event.payload.metadata.namespace }}"
+    tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
     _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
     _storage_snapshots: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
@@ -16,13 +17,15 @@
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:
-        msg: "tenant must be provided via ansible_eda.event.payload with metadata.name and metadata.namespace set"
+        msg: "tenant must be provided via ansible_eda.event.payload with metadata.name, metadata.namespace, and metadata.uid set"
       when: >-
         ansible_eda is not defined or
         ansible_eda.event.payload.metadata.name is not defined or
         ansible_eda.event.payload.metadata.name | length == 0 or
         ansible_eda.event.payload.metadata.namespace is not defined or
-        ansible_eda.event.payload.metadata.namespace | length == 0
+        ansible_eda.event.payload.metadata.namespace | length == 0 or
+        ansible_eda.event.payload.metadata.uid is not defined or
+        ansible_eda.event.payload.metadata.uid | length == 0
 
     - name: Validate STORAGE_TIERS env var is configured
       ansible.builtin.fail:

--- a/playbook_osac_create_tenant_storage_backend.yml
+++ b/playbook_osac_create_tenant_storage_backend.yml
@@ -6,6 +6,7 @@
   vars:
     tenant_name: "{{ ansible_eda.event.payload.metadata.name }}"
     tenant_namespace: "{{ ansible_eda.event.payload.metadata.namespace }}"
+    tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
     _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
@@ -15,13 +16,15 @@
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:
-        msg: "tenant must be provided via ansible_eda.event.payload with metadata.name and metadata.namespace set"
+        msg: "tenant must be provided via ansible_eda.event.payload with metadata.name, metadata.namespace, and metadata.uid set"
       when: >-
         ansible_eda is not defined or
         ansible_eda.event.payload.metadata.name is not defined or
         ansible_eda.event.payload.metadata.name | length == 0 or
         ansible_eda.event.payload.metadata.namespace is not defined or
-        ansible_eda.event.payload.metadata.namespace | length == 0
+        ansible_eda.event.payload.metadata.namespace | length == 0 or
+        ansible_eda.event.payload.metadata.uid is not defined or
+        ansible_eda.event.payload.metadata.uid | length == 0
 
     - name: Validate STORAGE_TIERS env var is configured
       ansible.builtin.fail:

--- a/tests/integration/fixtures/storage/storageclass-vast-test.yaml
+++ b/tests/integration/fixtures/storage/storageclass-vast-test.yaml
@@ -11,7 +11,7 @@ metadata:
 provisioner: csi.vastdata.com
 parameters:
   vip_pool_name: vippool-test-tenant
-  root_export: /osac/test-tenant/default
+  root_export: /osac-test-tenant-abcd1234/default
   csi.storage.k8s.io/provisioner-secret-name: vast-csi-test-tenant
   csi.storage.k8s.io/provisioner-secret-namespace: test-tenant-ns
   csi.storage.k8s.io/controller-publish-secret-name: vast-csi-test-tenant

--- a/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -67,6 +67,7 @@
               osac.openshift.io/tenant: "test-ensuresc"
           type: Opaque
           stringData:
+            tenant_uid: "test-uid-12345"
             vast_tenant_id: "999"
             vast_local_provider_id: "1"
             vip_pool_name: "osac-test-pool"
@@ -95,6 +96,7 @@
   vars:
     tenant_name: "test-ensuresc"
     tenant_namespace: "osac-system"
+    tenant_uid: "test-uid-12345"
     storage_provider_tiers:
       - name: default
         protocol: nfs
@@ -149,7 +151,7 @@
       ansible.builtin.assert:
         that:
           - _sc_result.resources[0].parameters.vip_pool_name == "osac-test-pool"
-          - _sc_result.resources[0].parameters.root_export == "/osac/test-ensuresc/default"
+          - _sc_result.resources[0].parameters.root_export == "/osac-test-ensuresc-d0f7f176/default"
           - "_sc_result.resources[0].parameters['csi.storage.k8s.io/provisioner-secret-name'] == 'vast-csi-test-ensuresc'"
           - "_sc_result.resources[0].parameters['csi.storage.k8s.io/provisioner-secret-namespace'] == 'osac-system'"
           - _sc_result.resources[0].parameters.view_policy == "osac-test-ensuresc-nfs"
@@ -222,7 +224,7 @@
       ansible.builtin.assert:
         that:
           - _block_sc_result.resources[0].parameters.vip_pool_name == "osac-test-pool"
-          - _block_sc_result.resources[0].parameters.subsystem == "view-test-ensuresc-block-tier"
+          - _block_sc_result.resources[0].parameters.subsystem == "view-test-ensuresc-d0f7f176-block-tier"
           - "_block_sc_result.resources[0].parameters['csi.storage.k8s.io/provisioner-secret-name'] == 'vast-csi-test-ensuresc'"
           - "_block_sc_result.resources[0].parameters['csi.storage.k8s.io/provisioner-secret-namespace'] == 'osac-system'"
           - _block_sc_result.resources[0].parameters.storagePath is not defined

--- a/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -68,6 +68,7 @@
           type: Opaque
           stringData:
             tenant_uid: "test-uid-12345"
+            tenant_uid_hash: "d0f7f176"
             vast_tenant_id: "999"
             vast_local_provider_id: "1"
             vip_pool_name: "osac-test-pool"

--- a/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -67,7 +67,6 @@
               osac.openshift.io/tenant: "test-ensuresc"
           type: Opaque
           stringData:
-            tenant_uid: "test-uid-12345"
             tenant_uid_hash: "d0f7f176"
             vast_tenant_id: "999"
             vast_local_provider_id: "1"

--- a/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
@@ -63,6 +63,7 @@
   vars:
     tenant_name: "test-onboard"
     tenant_namespace: "osac-system"
+    tenant_uid: "test-uid-12345"
     storage_provider_tiers:
       - name: default
         protocol: nfs
@@ -131,7 +132,7 @@
       ansible.builtin.assert:
         that:
           - _sc_result.resources[0].parameters.vip_pool_name == "osac-test-pool"
-          - _sc_result.resources[0].parameters.root_export == "/osac/test-onboard/default"
+          - _sc_result.resources[0].parameters.root_export == "/osac-test-onboard-d0f7f176/default"
           - "_sc_result.resources[0].parameters['csi.storage.k8s.io/provisioner-secret-name'] == 'vast-csi-test-onboard'"
           - "_sc_result.resources[0].parameters['csi.storage.k8s.io/provisioner-secret-namespace'] == 'osac-system'"
         fail_msg: "StorageClass parameters incorrect: {{ _sc_result.resources[0].parameters }}"

--- a/tests/integration/targets/storage_provider_setup/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_setup/tasks/main.yml
@@ -20,6 +20,7 @@
   vars:
     tenant_name: "test-setup"
     tenant_namespace: "osac-system"
+    tenant_uid: "test-uid-setup"
     storage_provider_tiers:
       - name: default
         protocol: nfs
@@ -101,6 +102,7 @@
           vip_pool_name: "{{ _hub_secret.resources[0].data.vip_pool_name | b64decode }}"
           vast_endpoint: "{{ _hub_secret.resources[0].data.vast_endpoint | b64decode }}"
           storage_provider_type: "{{ _hub_secret.resources[0].data.storage_provider_type | b64decode }}"
+          tenant_uid_hash: "{{ _hub_secret.resources[0].data.tenant_uid_hash | b64decode }}"
 
     - name: Assert hub Secret has tenant manager name
       ansible.builtin.assert:
@@ -145,6 +147,13 @@
           - _secret_data.storage_provider_type == "vast"
         fail_msg: "Expected storage_provider_type 'vast', got '{{ _secret_data.storage_provider_type }}'"
         success_msg: "storage_provider_type correct"
+
+    - name: Assert hub Secret has tenant UID hash
+      ansible.builtin.assert:
+        that:
+          - _secret_data.tenant_uid_hash == "6ee13f1b"
+        fail_msg: "Expected tenant_uid_hash '6ee13f1b', got '{{ _secret_data.tenant_uid_hash }}'"
+        success_msg: "tenant_uid_hash correct"
 
     - name: Assert hub Secret labels
       ansible.builtin.assert:

--- a/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
@@ -50,6 +50,7 @@
   vars:
     tenant_name: "test-rollback"
     tenant_namespace: "osac-system"
+    tenant_uid: "test-uid-rollback"
     storage_provider_tiers:
       - name: default
         protocol: nfs


### PR DESCRIPTION
## Summary
- Switches VAST storage paths from `/osac/{tenant_name}/{tier}` to `/osac-{tenant_name}-{uid_hash}/{tier}` where `uid_hash` is the first 8 hex chars of SHA256(Tenant CR `metadata.uid`)
- Threads `tenant_uid` from playbook entry points through the hub Secret to all path-consuming task files, with a fallback for existing tenants whose hub Secret predates this change
- Updates VAST view and quota names to `{type}-{tenant_name}-{uid_hash}-{tier}` for uniqueness across same-named tenants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant storage setup now uses a tenant UID hash to generate more unique names and paths for quotas, views, exports, and block identifiers.
  * Tenant configuration now stores and reuses the tenant UID hash during provisioning.

* **Bug Fixes**
  * Added validation to ensure tenant metadata includes a UID before creating storage resources.
  * Updated storage paths in tests and provisioning flows to match the new tenant-specific naming scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->