### PR TITLE
OSAC-1693: Add importAgentsEnabled to config-as-code secret template

### DIFF
--- a/charts/aap/templates/config-as-code-secret.yaml
+++ b/charts/aap/templates/config-as-code-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.configAsCode.eeImage }}
+{{- if or .Values.configAsCode.eeImage .Values.configAsCode.importAgentsEnabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,7 +7,16 @@ metadata:
   labels:
     {{- include "osac-aap.labels" . | nindent 4 }}
 stringData:
-  AAP_EE_IMAGE: {{ .Values.configAsCode.eeImage | quote }}
-  AAP_PROJECT_GIT_URI: {{ .Values.configAsCode.projectGitUri | quote }}
-  AAP_PROJECT_GIT_BRANCH: {{ .Values.configAsCode.projectGitBranch | quote }}
+  {{- if .Values.configAsCode.importAgentsEnabled }}
+  OSAC_IMPORT_AGENTS_ENABLED: "true"
+  {{- end }}
+  {{- with .Values.configAsCode.eeImage }}
+  AAP_EE_IMAGE: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.configAsCode.projectGitUri }}
+  AAP_PROJECT_GIT_URI: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.configAsCode.projectGitBranch }}
+  AAP_PROJECT_GIT_BRANCH: {{ . | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/aap/templates/import-agents-inventory.yaml
+++ b/charts/aap/templates/import-agents-inventory.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.configAsCode.importAgentsEnabled .Values.importAgents.servers }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: import-agents-inventory
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-aap.labels" . | nindent 4 }}
+data:
+  servers.yml: |
+    servers:
+    {{- .Values.importAgents.servers | toYaml | nindent 4 }}
+{{- end }}

--- a/charts/aap/values.yaml
+++ b/charts/aap/values.yaml
@@ -26,6 +26,10 @@ configAsCode:
   eeImage: ""
   projectGitUri: ""
   projectGitBranch: ""
+  importAgentsEnabled: false
+
+importAgents:
+  servers: []
 
 serviceAccounts:
   osacSa: "osac-sa"


### PR DESCRIPTION
Broaden the config-as-code-secret gate to also fire when importAgentsEnabled is true, and conditionally include OSAC_IMPORT_AGENTS_ENABLED in the secret. This allows the osac-installer parent chart to control import agent enablement via Helm value passthrough (aap.configAsCode.importAgentsEnabled) without needing a separate template that conflicts with this one.