### PR TITLE
OSAC-1653: Add agentless_net.steps collection with cluster_infra role

### DIFF
--- a/collections/ansible_collections/agentless_net/steps/CHANGELOG.rst
+++ b/collections/ansible_collections/agentless_net/steps/CHANGELOG.rst
@@ -1,0 +1,19 @@
+================================
+agentless_net.steps Release Notes
+================================
+
+.. contents:: Topics
+
+v1.0.0
+======
+
+Release Summary
+---------------
+Initial release of the agentless_net.steps collection providing
+cluster_infra and external_access step implementations for the
+agentless network backend.
+
+New Roles
+---------
+- ``cluster_infra`` - VLAN allocation, switch configuration, L3 router
+  namespace, and SNAT for CaaS cluster provisioning.

--- a/collections/ansible_collections/agentless_net/steps/galaxy.yml
+++ b/collections/ansible_collections/agentless_net/steps/galaxy.yml
@@ -1,0 +1,23 @@
+namespace: agentless_net
+name: steps
+version: 1.0.0
+readme: README.md
+authors:
+  - OSAC Project
+  - Yoni Bettan
+description: Agentless network backend step implementations for cluster and external access provisioning
+license:
+  - Apache-2.0
+tags:
+  - infrastructure
+  - cloud
+  - baremetal
+  - networking
+repository: https://github.com/osac-project/osac-aap
+issues: https://github.com/osac-project/osac-aap/issues
+build_ignore: []
+dependencies:
+  agentless_net.l2: "*"
+  agentless_net.l3: "*"
+  agentless_net.ipam: "*"
+  osac.service: "*"

--- a/collections/ansible_collections/agentless_net/steps/meta/runtime.yml
+++ b/collections/ansible_collections/agentless_net/steps/meta/runtime.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+requires_ansible: '>=2.15.0'

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/defaults/main.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+# Defaults are defined in group_vars/all/agentless_net.yaml

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/meta/argument_specs.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/meta/argument_specs.yaml
@@ -1,0 +1,43 @@
+---
+argument_specs:
+  create:
+    options:
+      cluster_infra_name:
+        type: str
+        required: true
+      cluster_infra_namespace:
+        type: str
+        required: true
+      cluster_infra_node_requests:
+        type: list
+        elements: dict
+        default: []
+      cluster_working_namespace:
+        type: str
+        required: true
+      cluster_order:
+        type: dict
+        required: true
+      cluster_order_label:
+        type: str
+        required: true
+      agent_resource_class_label:
+        type: str
+        required: true
+      default_agent_namespace:
+        type: str
+        required: true
+  delete:
+    options:
+      cluster_infra_name:
+        type: str
+        required: true
+      cluster_infra_namespace:
+        type: str
+        required: true
+      cluster_order_label:
+        type: str
+        required: true
+      default_agent_namespace:
+        type: str
+        required: true

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/ipam_allocate_vlan.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/ipam_allocate_vlan.yaml
@@ -1,0 +1,9 @@
+---
+- name: Allocate VLAN ID from pool
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Allocate VLAN
+      ansible.builtin.include_role:
+        name: agentless_net.ipam.vlan_id
+        tasks_from: allocate

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/ipam_release_vlan.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/ipam_release_vlan.yaml
@@ -1,0 +1,9 @@
+---
+- name: Release VLAN ID allocation
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Release VLAN
+      ansible.builtin.include_role:
+        name: agentless_net.ipam.vlan_id
+        tasks_from: release

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_create_vlan.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_create_vlan.yaml
@@ -1,0 +1,9 @@
+---
+- name: Create VLAN on switches
+  hosts: switches
+  gather_facts: false
+  tasks:
+    - name: Create VLAN
+      ansible.builtin.include_role:
+        name: agentless_net.l2.vlan
+        tasks_from: create

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_delete_vlan.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_delete_vlan.yaml
@@ -1,0 +1,9 @@
+---
+- name: Delete VLAN from switches
+  hosts: switches
+  gather_facts: false
+  tasks:
+    - name: Delete VLAN
+      ansible.builtin.include_role:
+        name: agentless_net.l2.vlan
+        tasks_from: delete

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_reset_port.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_reset_port.yaml
@@ -1,0 +1,9 @@
+---
+- name: Reset switch port to default
+  hosts: switches
+  gather_facts: false
+  tasks:
+    - name: Reset port
+      ansible.builtin.include_role:
+        name: agentless_net.l2.port
+        tasks_from: reset_port

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_set_access_port.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_set_access_port.yaml
@@ -1,0 +1,9 @@
+---
+- name: Set switch access port to VLAN
+  hosts: switches
+  gather_facts: false
+  tasks:
+    - name: Set access port
+      ansible.builtin.include_role:
+        name: agentless_net.l2.port
+        tasks_from: set_access_port

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_create_router.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_create_router.yaml
@@ -1,0 +1,9 @@
+---
+- name: Create L3 router namespace
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Create router
+      ansible.builtin.include_role:
+        name: agentless_net.l3.router
+        tasks_from: create

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_create_snat.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_create_snat.yaml
@@ -1,0 +1,9 @@
+---
+- name: Configure SNAT for tenant outbound access
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Create SNAT
+      ansible.builtin.include_role:
+        name: agentless_net.l3.snat
+        tasks_from: create

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_delete_router.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_delete_router.yaml
@@ -1,0 +1,9 @@
+---
+- name: Delete L3 router namespace
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Delete router
+      ansible.builtin.include_role:
+        name: agentless_net.l3.router
+        tasks_from: delete

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_delete_snat.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_delete_snat.yaml
@@ -1,0 +1,9 @@
+---
+- name: Remove SNAT rules for tenant
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Delete SNAT
+      ansible.builtin.include_role:
+        name: agentless_net.l3.snat
+        tasks_from: delete

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/create.yaml
@@ -1,0 +1,285 @@
+---
+- name: Show node requests
+  ansible.builtin.debug:
+    var: cluster_infra_node_requests
+
+- name: Build BareMetalPool hostSets
+  ansible.builtin.set_fact:
+    cluster_infra_baremetalpool_host_sets: >-
+      {{ cluster_infra_baremetalpool_host_sets | default([]) + [{
+        'hostType': item.resourceClass,
+        'replicas': item.numberOfNodes | int
+      }] }}
+  loop: "{{ cluster_infra_node_requests }}"
+
+# For now, we create the BareMetalPool in the POD_NAMESPACE, but
+# in the future, we hope to have it created in the cluster_working_namespace.
+# This requires updates to the bare-metal-fulfillment-operator
+
+- name: Step - Create BareMetalPool
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: osac.openshift.io/v1alpha1
+      kind: BareMetalPool
+      metadata:
+        name: "{{ cluster_infra_name }}"
+        namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+        labels: "{{ {cluster_order_label: cluster_infra_name} }}"
+      spec:
+        hostSets: "{{ cluster_infra_baremetalpool_host_sets }}"
+  register: cluster_infra_baremetalpool_response
+
+- name: Set BareMetalPool UID
+  ansible.builtin.set_fact:
+    cluster_infra_baremetalpool_uid: "{{ cluster_infra_baremetalpool_response.result.metadata.uid }}"
+
+# --- agentless_net: allocate VLAN and configure switches ---
+
+- name: Allocate VLAN for cluster  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e ipam_state_file={{ agentless_net_net_node_ipam_state_file }}
+      -e ipam_vlan_pool_start={{ agentless_net_vlan_pool_start }}
+      -e ipam_vlan_pool_end={{ agentless_net_vlan_pool_end }}
+      -e ipam_purpose={{ cluster_infra_name }}
+      {{ role_path }}/playbooks/ipam_allocate_vlan.yaml
+
+- name: Read allocated VLAN from state file  # noqa: no-changed-when
+  ansible.builtin.raw: cat {{ agentless_net_net_node_ipam_state_file }}
+  delegate_to: "{{ groups['net_nodes'][0] }}"
+  register: cluster_infra_ipam_state_raw
+
+- name: Set allocated VLAN fact
+  ansible.builtin.set_fact:
+    cluster_infra_vlan_id: "{{ (cluster_infra_ipam_state_raw.stdout | from_json).vlans[cluster_infra_name] }}"
+
+- name: Display allocated VLAN
+  ansible.builtin.debug:
+    msg: "Allocated VLAN {{ cluster_infra_vlan_id }} for cluster {{ cluster_infra_name }}"
+
+- name: Create VLAN on switches  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e vlan_id={{ cluster_infra_vlan_id }}
+      {{ role_path }}/playbooks/l2_create_vlan.yaml
+
+# --- Wait for bare-metal hosts ---
+
+- name: Calculate total desired nodes
+  ansible.builtin.set_fact:
+    cluster_infra_total_desired_nodes: "{{ cluster_infra_node_requests | map(attribute='numberOfNodes') | map('int') | sum }}"
+
+- name: Wait for BareMetalInstances to be allocated
+  kubernetes.core.k8s_info:
+    api_version: osac.openshift.io/v1alpha1
+    kind: BareMetalInstance
+    namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+  register: cluster_infra_baremetalinstances_result
+  until: >
+    (
+      cluster_infra_baremetalinstances_result.resources |
+      selectattr('metadata.ownerReferences', 'defined') |
+      map(attribute='metadata.ownerReferences') |
+      flatten |
+      selectattr('controller', 'defined') |
+      selectattr('controller', 'equalto', true) |
+      selectattr('uid', 'equalto', cluster_infra_baremetalpool_uid) |
+      list | length
+    ) == (cluster_infra_total_desired_nodes | int)
+  retries: 60
+  delay: 10
+
+- name: Initialize allocated host IDs
+  ansible.builtin.set_fact:
+    cluster_infra_allocated_host_ids: []
+
+- name: Build allocated host IDs from BareMetalInstances
+  ansible.builtin.set_fact:
+    cluster_infra_allocated_host_ids: "{{ cluster_infra_allocated_host_ids + [item.spec.externalHostID] }}"
+  loop: "{{ cluster_infra_baremetalinstances_result.resources }}"
+  when:
+    - item.metadata.ownerReferences is defined
+    - item.metadata.ownerReferences | selectattr('controller', 'defined') | selectattr('controller', 'equalto', true) | selectattr('uid', 'equalto', cluster_infra_baremetalpool_uid) | list | length > 0
+    - item.spec.externalHostID is defined
+    - item.spec.externalHostID != ''
+
+- name: Display allocated host IDs
+  ansible.builtin.debug:
+    msg: "Allocated host IDs: {{ cluster_infra_allocated_host_ids }}"
+
+# --- agentless_net: set access ports for allocated hosts ---
+
+- name: Build host-to-port mapping from switch inventory
+  ansible.builtin.set_fact:
+    cluster_infra_host_port_map: >-
+      {{ cluster_infra_host_port_map | default({}) | combine({
+        item.1.value: {'switch': item.0, 'port': item.1.key}
+      }) }}
+  loop: "{{ groups['switches'] | subelements('access_ports | default({}) | dict2items', skip_missing=True) }}"
+  loop_control:
+    label: "{{ item.0 }}:{{ item.1.key }} -> {{ item.1.value }}"
+
+- name: Set access ports for allocated hosts  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e vlan_id={{ cluster_infra_vlan_id }}
+      -e port_name={{ cluster_infra_host_port_map[item].port }}
+      -l {{ cluster_infra_host_port_map[item].switch }}
+      {{ role_path }}/playbooks/l2_set_access_port.yaml
+  loop: "{{ cluster_infra_allocated_host_ids }}"
+  loop_control:
+    label: "Host {{ item }} -> {{ cluster_infra_host_port_map[item].switch }}:{{ cluster_infra_host_port_map[item].port }}"
+  when: item in cluster_infra_host_port_map
+
+# --- agentless_net: create L3 router namespace and SNAT ---
+
+- name: Compute veth addresses for router namespace
+  ansible.builtin.set_fact:
+    cluster_infra_veth_index: "{{ (cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4 }}"
+
+- name: Set external veth addresses
+  ansible.builtin.set_fact:
+    cluster_infra_external_peer_ip: "10.254.0.{{ cluster_infra_veth_index | int + 1 }}/30"
+    cluster_infra_external_router_ip: "10.254.0.{{ cluster_infra_veth_index | int + 2 }}/30"
+    cluster_infra_external_gateway: "10.254.0.{{ cluster_infra_veth_index | int + 1 }}"
+
+- name: Compute subnet gateway
+  ansible.builtin.set_fact:
+    cluster_infra_subnet_gateway: "{{ agentless_net_subnet_cidr | ansible.utils.ipaddr('next_usable') }}"
+
+- name: Display L3 router configuration
+  ansible.builtin.debug:
+    msg:
+      - "Router: {{ cluster_infra_name }}, VLAN: {{ cluster_infra_vlan_id }}"
+      - "Subnet: {{ agentless_net_subnet_cidr }}, Gateway: {{ cluster_infra_subnet_gateway }}"
+      - "External link: {{ cluster_infra_external_router_ip }} <-> {{ cluster_infra_external_peer_ip }}"
+
+- name: Create L3 router namespace  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e router_name={{ cluster_infra_name }}
+      -e router_vlan_id={{ cluster_infra_vlan_id }}
+      -e router_internal_subnet={{ agentless_net_subnet_cidr }}
+      -e router_internal_gateway={{ cluster_infra_subnet_gateway }}
+      -e router_trunk_interface={{ agentless_net_trunk_interface }}
+      -e router_external_ip={{ cluster_infra_external_router_ip }}
+      -e router_external_peer_ip={{ cluster_infra_external_peer_ip }}
+      -e router_external_gateway={{ cluster_infra_external_gateway }}
+      {{ role_path }}/playbooks/l3_create_router.yaml
+
+- name: Compute veth namespace-side interface name
+  ansible.builtin.set_fact:
+    cluster_infra_snat_veth_ns: "v{{ cluster_infra_name | hash('md5') | truncate(11, True, '') }}i"
+
+- name: Configure SNAT for outbound internet access  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e snat_router_name={{ cluster_infra_name }}
+      -e snat_source_subnet={{ agentless_net_subnet_cidr }}
+      -e snat_veth_interface={{ cluster_infra_snat_veth_ns }}
+      -e snat_external_subnet={{ cluster_infra_external_peer_ip | ansible.utils.ipaddr('network/prefix') }}
+      -e snat_external_interface={{ agentless_net_external_interface }}
+      {{ role_path }}/playbooks/l3_create_snat.yaml
+
+# --- Agent management (same as ESI) ---
+
+# Handle scale down **before** scale up: detach agents not in the
+# BareMetalInstance allocation before attaching new ones.
+
+- name: Wait for the Agents to be removed from the cluster
+  ansible.builtin.include_role:
+    name: osac.service.manage_agents
+    tasks_from: wait_for_agents_to_be_removed
+  vars:
+    manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
+    manage_agents_desired_count: "{{ item.replicas }}"
+    manage_agents_resource_class: "{{ item.hostType }}"
+  loop: "{{ cluster_infra_baremetalpool_host_sets }}"
+
+- name: Detach agents from cluster
+  ansible.builtin.include_role:
+    name: osac.service.manage_agents
+    tasks_from: detach_and_unlabel_all_removed_agents
+  vars:
+    manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
+
+- name: Get all agents in the namespace
+  kubernetes.core.k8s_info:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ default_agent_namespace }}"
+  register: cluster_infra_all_agents_result
+
+- name: Initialize agents to attach list
+  ansible.builtin.set_fact:
+    cluster_infra_agents_to_attach: []
+
+- name: Select agents matching allocated host IDs
+  ansible.builtin.set_fact:
+    cluster_infra_agents_to_attach: "{{ cluster_infra_agents_to_attach + [item] }}"
+  loop: "{{ cluster_infra_all_agents_result.resources }}"
+  when:
+    - item.metadata.annotations is defined
+    - item.metadata.annotations['osac.openshift.io/host_uuid'] is defined
+    - item.metadata.annotations['osac.openshift.io/host_uuid'] in cluster_infra_allocated_host_ids
+  loop_control:
+    label: "Selected agent {{ item.metadata.name }}"
+
+- name: Fail if not all leased hosts resolved to agents
+  ansible.builtin.fail:
+    msg: >-
+      Resolved {{ cluster_infra_agents_to_attach | length }} Agents for
+      {{ cluster_infra_allocated_host_ids | length }} leased hosts.
+  when: (cluster_infra_agents_to_attach | length) != (cluster_infra_allocated_host_ids | length)
+
+- name: Display hosts to attach to cluster network
+  ansible.builtin.debug:
+    msg: "Hosts to attach: {{ cluster_infra_allocated_host_ids }}"
+
+- name: Display agents to label
+  ansible.builtin.debug:
+    msg: "Agents to label: {{ cluster_infra_agents_to_attach | map(attribute='metadata.name') | list }}"
+
+- name: Label selected agents with cluster order
+  kubernetes.core.k8s_json_patch:
+    api_version: agent-install.openshift.io/v1beta1
+    kind: Agent
+    name: "{{ agent.metadata.name }}"
+    namespace: "{{ agent.metadata.namespace }}"
+    patch:
+      - op: add
+        path: /metadata/labels/{{ cluster_order_label | osac.service.json_pointer_escape }}
+        value: "{{ cluster_infra_name }}"
+      - op: add
+        path: /spec/approved
+        value: true
+  loop: "{{ cluster_infra_agents_to_attach }}"
+  loop_control:
+    loop_var: agent
+    label: "Labeling agent {{ agent.metadata.name }}"

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/delete.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/delete.yaml
@@ -1,0 +1,128 @@
+---
+- name: Detach agents from cluster
+  ansible.builtin.include_role:
+    name: osac.service.manage_agents
+    tasks_from: detach_and_unlabel_all_removed_agents
+  vars:
+    manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
+
+# --- Read VLAN ID from IPAM state ---
+
+- name: Read VLAN ID from IPAM state  # noqa: no-changed-when
+  ansible.builtin.raw: cat {{ agentless_net_net_node_ipam_state_file }}
+  delegate_to: "{{ groups['net_nodes'][0] }}"
+  register: cluster_infra_ipam_state_raw
+
+- name: Parse VLAN ID for this cluster
+  ansible.builtin.set_fact:
+    cluster_infra_vlan_id: "{{ (cluster_infra_ipam_state_raw.stdout | from_json).vlans[cluster_infra_name] | default('') }}"
+
+- name: Skip network cleanup if no VLAN allocated
+  ansible.builtin.debug:
+    msg: "No VLAN allocation found for {{ cluster_infra_name }}, skipping network cleanup"
+  when: cluster_infra_vlan_id | string | length == 0
+
+# --- agentless_net: delete SNAT ---
+
+- name: Compute veth namespace-side interface name
+  ansible.builtin.set_fact:
+    cluster_infra_snat_veth_ns: "v{{ cluster_infra_name | hash('md5') | truncate(11, True, '') }}i"
+  when: cluster_infra_vlan_id | string | length > 0
+
+- name: Compute veth addresses for SNAT cleanup
+  ansible.builtin.set_fact:
+    cluster_infra_veth_index: "{{ (cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4 }}"
+  when: cluster_infra_vlan_id | string | length > 0
+
+- name: Set external subnet for SNAT cleanup
+  ansible.builtin.set_fact:
+    cluster_infra_external_peer_ip: "10.254.0.{{ cluster_infra_veth_index | int + 1 }}/30"
+  when: cluster_infra_vlan_id | string | length > 0
+
+- name: Delete SNAT rules  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e snat_router_name={{ cluster_infra_name }}
+      -e snat_source_subnet={{ agentless_net_subnet_cidr }}
+      -e snat_veth_interface={{ cluster_infra_snat_veth_ns }}
+      -e snat_external_subnet={{ cluster_infra_external_peer_ip | ansible.utils.ipaddr('network/prefix') }}
+      -e snat_external_interface={{ agentless_net_external_interface }}
+      {{ role_path }}/playbooks/l3_delete_snat.yaml
+  when: cluster_infra_vlan_id | string | length > 0
+
+# --- agentless_net: delete L3 router namespace ---
+
+- name: Delete L3 router namespace  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e router_name={{ cluster_infra_name }}
+      {{ role_path }}/playbooks/l3_delete_router.yaml
+  when: cluster_infra_vlan_id | string | length > 0
+
+# --- agentless_net: reset access ports ---
+
+- name: Build host-to-port mapping from switch inventory
+  ansible.builtin.set_fact:
+    cluster_infra_host_port_map: >-
+      {{ cluster_infra_host_port_map | default({}) | combine({
+        item.1.value: {'switch': item.0, 'port': item.1.key}
+      }) }}
+  loop: "{{ groups['switches'] | subelements('access_ports | default({}) | dict2items', skip_missing=True) }}"
+  loop_control:
+    label: "{{ item.0 }}:{{ item.1.key }} -> {{ item.1.value }}"
+  when: cluster_infra_vlan_id | string | length > 0
+
+- name: Reset access ports on switches  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e port_name={{ item.value.port }}
+      -l {{ item.value.switch }}
+      {{ role_path }}/playbooks/l2_reset_port.yaml
+  loop: "{{ cluster_infra_host_port_map | default({}) | dict2items }}"
+  loop_control:
+    label: "Reset {{ item.value.switch }}:{{ item.value.port }}"
+  when: cluster_infra_vlan_id | string | length > 0
+
+# --- agentless_net: delete VLAN from switches ---
+
+- name: Delete VLAN from switches  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e vlan_id={{ cluster_infra_vlan_id }}
+      {{ role_path }}/playbooks/l2_delete_vlan.yaml
+  when: cluster_infra_vlan_id | string | length > 0
+
+# --- agentless_net: release VLAN allocation ---
+
+- name: Release VLAN allocation  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e ipam_state_file={{ agentless_net_net_node_ipam_state_file }}
+      -e ipam_purpose={{ cluster_infra_name }}
+      {{ role_path }}/playbooks/ipam_release_vlan.yaml
+  when: cluster_infra_vlan_id | string | length > 0

--- a/group_vars/all/agentless_net.yaml
+++ b/group_vars/all/agentless_net.yaml
@@ -1,0 +1,13 @@
+# =============================================================================
+# Agentless Network Backend (agentless_net.steps)
+# =============================================================================
+agentless_net_inventory_file: "{{ inventory_file | default('') | realpath }}"
+agentless_net_collections_path: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}"
+agentless_net_roles_path: "{{ lookup('env', 'ANSIBLE_ROLES_PATH') }}"
+agentless_net_net_node_ipam_state_file: "{{ lookup('env', 'AGENTLESS_NET_IPAM_STATE_FILE', default='/etc/osac/network_state.json') }}"
+agentless_net_vlan_pool_start: "{{ lookup('env', 'AGENTLESS_NET_VLAN_POOL_START', default='100') | int }}"
+agentless_net_vlan_pool_end: "{{ lookup('env', 'AGENTLESS_NET_VLAN_POOL_END', default='199') | int }}"
+agentless_net_trunk_interface: "{{ lookup('env', 'AGENTLESS_NET_TRUNK_INTERFACE', default='eth1') }}"
+agentless_net_external_interface: "{{ lookup('env', 'AGENTLESS_NET_EXTERNAL_INTERFACE', default='eth0') }}"
+agentless_net_external_gateway: "{{ lookup('env', 'AGENTLESS_NET_EXTERNAL_GATEWAY', default='') }}"
+agentless_net_subnet_cidr: "{{ lookup('env', 'AGENTLESS_NET_SUBNET_CIDR', default='') }}"


### PR DESCRIPTION
Implement the cluster_infra steps role for the agentless_net network backend. This plugs into the existing network_steps_collection mechanism alongside osac.steps (ESI) and netris.steps (Netris).

The role handles VLAN allocation, switch port configuration, L3 router namespace creation, and SNAT setup for CaaS cluster provisioning using the agentless_net L2/L3/IPAM collections.


Assisted-by: Claude Code <noreply@anthropic.com>

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the first release of the `agentless_net.steps` collection.
  * Added cluster infrastructure workflows for provisioning and teardown, including VLAN setup, switch port configuration, router namespace handling, and SNAT.
  * Added collection metadata and supported Ansible version details.

* **Documentation**
  * Added release notes for version `v1.0.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->