### PR TITLE
OSAC-1653, OSAC-1654: Add agentless_net.steps collection for CaaS networking

### DIFF
--- a/collections/ansible_collections/agentless_net/steps/CHANGELOG.rst
+++ b/collections/ansible_collections/agentless_net/steps/CHANGELOG.rst
@@ -1,0 +1,21 @@
+================================
+agentless_net.steps Release Notes
+================================
+
+.. contents:: Topics
+
+v1.0.0
+======
+
+Release Summary
+---------------
+Initial release of the agentless_net.steps collection providing
+cluster_infra and external_access step implementations for the
+agentless network backend.
+
+New Roles
+---------
+- ``cluster_infra`` - VLAN allocation, switch configuration, L3 router
+  namespace, and SNAT for CaaS cluster provisioning.
+- ``external_access`` - Public IP allocation, DNAT for API and ingress
+  endpoints, DNS records, and MetalLB configuration.

--- a/collections/ansible_collections/agentless_net/steps/galaxy.yml
+++ b/collections/ansible_collections/agentless_net/steps/galaxy.yml
@@ -1,0 +1,23 @@
+namespace: agentless_net
+name: steps
+version: 1.0.0
+readme: README.md
+authors:
+  - OSAC Project
+  - Yoni Bettan
+description: Agentless network backend step implementations for cluster and external access provisioning
+license:
+  - Apache-2.0
+tags:
+  - infrastructure
+  - cloud
+  - baremetal
+  - networking
+repository: https://github.com/osac-project/osac-aap
+issues: https://github.com/osac-project/osac-aap/issues
+build_ignore: []
+dependencies:
+  agentless_net.l2: "*"
+  agentless_net.l3: "*"
+  agentless_net.ipam: "*"
+  osac.service: "*"

--- a/collections/ansible_collections/agentless_net/steps/meta/runtime.yml
+++ b/collections/ansible_collections/agentless_net/steps/meta/runtime.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+requires_ansible: '>=2.15.0'

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/defaults/main.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+# Defaults are defined in group_vars/all/agentless_net.yaml
+cluster_infra_state_key: "{{ cluster_infra_namespace }}-{{ cluster_infra_name }}"

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/meta/argument_specs.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/meta/argument_specs.yaml
@@ -1,0 +1,50 @@
+---
+argument_specs:
+  create:
+    options:
+      cluster_infra_name:
+        type: str
+        required: true
+      cluster_infra_namespace:
+        type: str
+        required: true
+      cluster_infra_node_requests:
+        type: list
+        elements: dict
+        default: []
+        options:
+          resourceClass:
+            type: str
+            required: true
+          numberOfNodes:
+            type: int
+            required: true
+      cluster_working_namespace:
+        type: str
+        required: true
+      cluster_order:
+        type: dict
+        required: true
+      cluster_order_label:
+        type: str
+        required: true
+      agent_resource_class_label:
+        type: str
+        required: true
+      default_agent_namespace:
+        type: str
+        required: true
+  delete:
+    options:
+      cluster_infra_name:
+        type: str
+        required: true
+      cluster_infra_namespace:
+        type: str
+        required: true
+      cluster_order_label:
+        type: str
+        required: true
+      default_agent_namespace:
+        type: str
+        required: true

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/ipam_allocate_vlan.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/ipam_allocate_vlan.yaml
@@ -1,0 +1,9 @@
+---
+- name: Allocate VLAN ID from pool
+  hosts: net_nodes[0]
+  gather_facts: false
+  tasks:
+    - name: Allocate VLAN
+      ansible.builtin.include_role:
+        name: agentless_net.ipam.vlan_id
+        tasks_from: allocate

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/ipam_release_vlan.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/ipam_release_vlan.yaml
@@ -1,0 +1,9 @@
+---
+- name: Release VLAN ID allocation
+  hosts: net_nodes[0]
+  gather_facts: false
+  tasks:
+    - name: Release VLAN
+      ansible.builtin.include_role:
+        name: agentless_net.ipam.vlan_id
+        tasks_from: release

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_create_vlan.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_create_vlan.yaml
@@ -1,0 +1,9 @@
+---
+- name: Create VLAN on switches
+  hosts: switches
+  gather_facts: false
+  tasks:
+    - name: Create VLAN
+      ansible.builtin.include_role:
+        name: agentless_net.l2.vlan
+        tasks_from: create

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_delete_vlan.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_delete_vlan.yaml
@@ -1,0 +1,9 @@
+---
+- name: Delete VLAN from switches
+  hosts: switches
+  gather_facts: false
+  tasks:
+    - name: Delete VLAN
+      ansible.builtin.include_role:
+        name: agentless_net.l2.vlan
+        tasks_from: delete

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_reset_port.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_reset_port.yaml
@@ -1,0 +1,9 @@
+---
+- name: Remove VLAN configuration from switch port
+  hosts: switches
+  gather_facts: false
+  tasks:
+    - name: Remove VLAN configuration
+      ansible.builtin.include_role:
+        name: agentless_net.l2.port
+        tasks_from: reset_port

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_set_access_port.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l2_set_access_port.yaml
@@ -1,0 +1,9 @@
+---
+- name: Set switch access port to VLAN
+  hosts: switches
+  gather_facts: false
+  tasks:
+    - name: Set access port
+      ansible.builtin.include_role:
+        name: agentless_net.l2.port
+        tasks_from: set_access_port

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_create_router.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_create_router.yaml
@@ -1,0 +1,9 @@
+---
+- name: Create L3 router namespace
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Create router
+      ansible.builtin.include_role:
+        name: agentless_net.l3.router
+        tasks_from: create

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_create_snat.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_create_snat.yaml
@@ -1,0 +1,9 @@
+---
+- name: Configure SNAT for tenant outbound access
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Create SNAT
+      ansible.builtin.include_role:
+        name: agentless_net.l3.snat
+        tasks_from: create

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_delete_router.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_delete_router.yaml
@@ -1,0 +1,9 @@
+---
+- name: Delete L3 router namespace
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Delete router
+      ansible.builtin.include_role:
+        name: agentless_net.l3.router
+        tasks_from: delete

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_delete_snat.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/playbooks/l3_delete_snat.yaml
@@ -1,0 +1,9 @@
+---
+- name: Remove SNAT rules for tenant
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Delete SNAT
+      ansible.builtin.include_role:
+        name: agentless_net.l3.snat
+        tasks_from: delete

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/create.yaml
@@ -1,0 +1,324 @@
+---
+- name: Show node requests
+  ansible.builtin.debug:
+    var: cluster_infra_node_requests
+
+- name: Build BareMetalPool hostSets
+  ansible.builtin.set_fact:
+    cluster_infra_baremetalpool_host_sets: >-
+      {{ cluster_infra_baremetalpool_host_sets | default([]) + [{
+        'hostType': item.resourceClass,
+        'replicas': item.numberOfNodes | int
+      }] }}
+  loop: "{{ cluster_infra_node_requests }}"
+
+# For now, we create the BareMetalPool in the POD_NAMESPACE, but
+# in the future, we hope to have it created in the cluster_working_namespace.
+# This requires updates to the bare-metal-fulfillment-operator
+
+- name: Step - Create BareMetalPool
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: osac.openshift.io/v1alpha1
+      kind: BareMetalPool
+      metadata:
+        name: "{{ cluster_infra_name }}"
+        namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+        labels: "{{ {cluster_order_label: cluster_infra_name} }}"
+      spec:
+        hostSets: "{{ cluster_infra_baremetalpool_host_sets }}"
+  register: cluster_infra_baremetalpool_response
+
+- name: Set BareMetalPool UID
+  ansible.builtin.set_fact:
+    cluster_infra_baremetalpool_uid: "{{ cluster_infra_baremetalpool_response.result.metadata.uid }}"
+
+# --- agentless_net: allocate VLAN and configure switches ---
+
+- name: Allocate VLAN for cluster  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e ipam_state_file={{ agentless_net_net_node_ipam_state_file }}
+      -e ipam_vlan_pool_start={{ agentless_net_vlan_pool_start }}
+      -e ipam_vlan_pool_end={{ agentless_net_vlan_pool_end }}
+      -e ipam_purpose={{ cluster_infra_state_key }}
+      {{ role_path }}/playbooks/ipam_allocate_vlan.yaml
+
+- name: Read allocated VLAN from state file
+  ansible.builtin.slurp:
+    src: "{{ agentless_net_net_node_ipam_state_file }}"
+  delegate_to: "{{ groups['net_nodes'][0] }}"
+  register: cluster_infra_ipam_state_raw
+
+- name: Set allocated VLAN fact
+  ansible.builtin.set_fact:
+    cluster_infra_vlan_id: "{{ (cluster_infra_ipam_state_raw.content | b64decode | from_json).vlans[cluster_infra_state_key] }}"
+
+- name: Display allocated VLAN
+  ansible.builtin.debug:
+    msg: "Allocated VLAN {{ cluster_infra_vlan_id }} for cluster {{ cluster_infra_name }}"
+
+- name: Create VLAN on switches  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e vlan_id={{ cluster_infra_vlan_id }}
+      {{ role_path }}/playbooks/l2_create_vlan.yaml
+
+# --- Wait for bare-metal hosts ---
+
+- name: Calculate total desired nodes
+  ansible.builtin.set_fact:
+    cluster_infra_total_desired_nodes: "{{ cluster_infra_node_requests | map(attribute='numberOfNodes') | map('int') | sum }}"
+
+- name: Wait for BareMetalInstances to be allocated with host IDs
+  kubernetes.core.k8s_info:
+    api_version: osac.openshift.io/v1alpha1
+    kind: BareMetalInstance
+    namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+  register: cluster_infra_baremetalinstances_result
+  until: >
+    (
+      cluster_infra_baremetalinstances_result.resources |
+      selectattr('metadata.ownerReferences', 'defined') |
+      selectattr('spec.externalHostID', 'defined') |
+      rejectattr('spec.externalHostID', 'equalto', '') |
+      map(attribute='metadata.ownerReferences') |
+      flatten |
+      selectattr('controller', 'defined') |
+      selectattr('controller', 'equalto', true) |
+      selectattr('uid', 'equalto', cluster_infra_baremetalpool_uid) |
+      list | length
+    ) == (cluster_infra_total_desired_nodes | int)
+  retries: 60
+  delay: 10
+
+- name: Initialize allocated host IDs
+  ansible.builtin.set_fact:
+    cluster_infra_allocated_host_ids: []
+
+- name: Build allocated host IDs from BareMetalInstances
+  ansible.builtin.set_fact:
+    cluster_infra_allocated_host_ids: "{{ cluster_infra_allocated_host_ids + [item.spec.externalHostID] }}"
+  loop: "{{ cluster_infra_baremetalinstances_result.resources }}"
+  when:
+    - item.metadata.ownerReferences is defined
+    - item.metadata.ownerReferences | selectattr('controller', 'defined') | selectattr('controller', 'equalto', true) | selectattr('uid', 'equalto', cluster_infra_baremetalpool_uid) | list | length > 0
+    - item.spec.externalHostID is defined
+    - item.spec.externalHostID != ''
+
+- name: Display allocated host IDs
+  ansible.builtin.debug:
+    msg: "Allocated host IDs: {{ cluster_infra_allocated_host_ids }}"
+
+- name: Store allocated host IDs in network state  # noqa: no-changed-when
+  ansible.builtin.raw: |
+    python3 - '{{ agentless_net_net_node_ipam_state_file }}' \
+              '{{ cluster_infra_state_key }}' \
+              '{{ cluster_infra_allocated_host_ids | to_json }}' <<'STATE_PY'
+    import fcntl, json, os, sys
+    state_file, cluster_name, host_ids_json = sys.argv[1:4]
+    host_ids = json.loads(host_ids_json)
+    with open(state_file, 'r+') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        state = json.load(f)
+        state.setdefault('host_allocations', {})[cluster_name] = host_ids
+        f.seek(0)
+        f.write(json.dumps(state, indent=2))
+        f.truncate()
+        f.flush()
+        os.fsync(f.fileno())
+    STATE_PY
+  delegate_to: "{{ groups['net_nodes'][0] }}"
+
+# --- agentless_net: set access ports for allocated hosts ---
+
+- name: Collect access port entries from switch inventory
+  ansible.builtin.set_fact:
+    cluster_infra_switch_port_entries: >-
+      {{ cluster_infra_switch_port_entries | default([]) +
+         (hostvars[item].access_ports | default({}) | dict2items
+          | map('combine', {'switch': item}) | list) }}
+  loop: "{{ groups['switches'] }}"
+
+- name: Build host-to-port mapping
+  ansible.builtin.set_fact:
+    cluster_infra_host_port_map: >-
+      {{ cluster_infra_host_port_map | default({}) | combine({
+        item.value: {'switch': item.switch, 'port': item.key}
+      }) }}
+  loop: "{{ cluster_infra_switch_port_entries }}"
+  loop_control:
+    label: "{{ item.switch }}:{{ item.key }} -> {{ item.value }}"
+
+- name: Verify all allocated hosts have switch-port mappings
+  ansible.builtin.fail:
+    msg: >-
+      Host '{{ item }}' has no switch-port mapping in the inventory.
+      Ensure all hosts are listed in a switch's access_ports.
+  loop: "{{ cluster_infra_allocated_host_ids }}"
+  when: item not in cluster_infra_host_port_map
+
+- name: Set access ports for allocated hosts  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e vlan_id={{ cluster_infra_vlan_id }}
+      -e port_name={{ cluster_infra_host_port_map[item].port }}
+      -l {{ cluster_infra_host_port_map[item].switch }}
+      {{ role_path }}/playbooks/l2_set_access_port.yaml
+  loop: "{{ cluster_infra_allocated_host_ids }}"
+  loop_control:
+    label: "Host {{ item }} -> {{ cluster_infra_host_port_map[item].switch }}:{{ cluster_infra_host_port_map[item].port }}"
+
+# --- agentless_net: create L3 router namespace and SNAT ---
+
+- name: Compute veth addresses for router namespace
+  ansible.builtin.set_fact:
+    cluster_infra_veth_index: "{{ (cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4 }}"
+    cluster_infra_veth_octet3: "{{ ((cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4) // 256 }}"
+    cluster_infra_veth_octet4: "{{ ((cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4) % 256 }}"
+
+- name: Set external veth addresses
+  ansible.builtin.set_fact:
+    cluster_infra_external_peer_ip: "10.254.{{ cluster_infra_veth_octet3 }}.{{ cluster_infra_veth_octet4 | int + 1 }}/30"
+    cluster_infra_external_router_ip: "10.254.{{ cluster_infra_veth_octet3 }}.{{ cluster_infra_veth_octet4 | int + 2 }}/30"
+    cluster_infra_external_gateway: "10.254.{{ cluster_infra_veth_octet3 }}.{{ cluster_infra_veth_octet4 | int + 1 }}"
+
+- name: Compute subnet gateway
+  ansible.builtin.set_fact:
+    cluster_infra_subnet_gateway: "{{ agentless_net_subnet_cidr | ansible.utils.ipaddr('next_usable') }}"
+
+- name: Display L3 router configuration
+  ansible.builtin.debug:
+    msg:
+      - "Router: {{ cluster_infra_name }}, VLAN: {{ cluster_infra_vlan_id }}"
+      - "Subnet: {{ agentless_net_subnet_cidr }}, Gateway: {{ cluster_infra_subnet_gateway }}"
+      - "External link: {{ cluster_infra_external_router_ip }} <-> {{ cluster_infra_external_peer_ip }}"
+
+- name: Create L3 router namespace  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e router_name={{ cluster_infra_name }}
+      -e router_vlan_id={{ cluster_infra_vlan_id }}
+      -e router_internal_subnet={{ agentless_net_subnet_cidr }}
+      -e router_internal_gateway={{ cluster_infra_subnet_gateway }}
+      -e router_trunk_interface={{ agentless_net_trunk_interface }}
+      -e router_external_ip={{ cluster_infra_external_router_ip }}
+      -e router_external_peer_ip={{ cluster_infra_external_peer_ip }}
+      -e router_external_gateway={{ cluster_infra_external_gateway }}
+      {{ role_path }}/playbooks/l3_create_router.yaml
+
+- name: Compute veth namespace-side interface name
+  ansible.builtin.set_fact:
+    cluster_infra_snat_veth_ns: "v{{ cluster_infra_name | hash('md5') | truncate(11, True, '') }}i"
+
+- name: Configure SNAT for outbound internet access  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e snat_router_name={{ cluster_infra_name }}
+      -e snat_source_subnet={{ agentless_net_subnet_cidr }}
+      -e snat_veth_interface={{ cluster_infra_snat_veth_ns }}
+      -e snat_external_subnet={{ cluster_infra_external_peer_ip | ansible.utils.ipaddr('network/prefix') }}
+      -e snat_external_interface={{ agentless_net_external_interface }}
+      {{ role_path }}/playbooks/l3_create_snat.yaml
+
+# --- Agent management (same as ESI) ---
+
+# Handle scale down **before** scale up: detach agents not in the
+# BareMetalInstance allocation before attaching new ones.
+
+- name: Wait for the Agents to be removed from the cluster
+  ansible.builtin.include_role:
+    name: osac.service.manage_agents
+    tasks_from: wait_for_agents_to_be_removed
+  vars:
+    manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
+    manage_agents_desired_count: "{{ item.replicas }}"
+    manage_agents_resource_class: "{{ item.hostType }}"
+  loop: "{{ cluster_infra_baremetalpool_host_sets }}"
+
+- name: Detach agents from cluster
+  ansible.builtin.include_role:
+    name: osac.service.manage_agents
+    tasks_from: detach_and_unlabel_all_removed_agents
+  vars:
+    manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
+
+- name: Get all agents in the namespace
+  kubernetes.core.k8s_info:
+    kind: Agent
+    api_version: agent-install.openshift.io/v1beta1
+    namespace: "{{ default_agent_namespace }}"
+  register: cluster_infra_all_agents_result
+
+- name: Initialize agents to attach list
+  ansible.builtin.set_fact:
+    cluster_infra_agents_to_attach: []
+
+- name: Select agents matching allocated host IDs
+  ansible.builtin.set_fact:
+    cluster_infra_agents_to_attach: "{{ cluster_infra_agents_to_attach + [item] }}"
+  loop: "{{ cluster_infra_all_agents_result.resources }}"
+  when:
+    - item.metadata.annotations is defined
+    - item.metadata.annotations['osac.openshift.io/host_uuid'] is defined
+    - item.metadata.annotations['osac.openshift.io/host_uuid'] in cluster_infra_allocated_host_ids
+  loop_control:
+    label: "Selected agent {{ item.metadata.name }}"
+
+- name: Fail if not all leased hosts resolved to agents
+  ansible.builtin.fail:
+    msg: >-
+      Resolved {{ cluster_infra_agents_to_attach | length }} Agents for
+      {{ cluster_infra_allocated_host_ids | length }} leased hosts.
+  when: (cluster_infra_agents_to_attach | length) != (cluster_infra_allocated_host_ids | length)
+
+- name: Display hosts to attach to cluster network
+  ansible.builtin.debug:
+    msg: "Hosts to attach: {{ cluster_infra_allocated_host_ids }}"
+
+- name: Display agents to label
+  ansible.builtin.debug:
+    msg: "Agents to label: {{ cluster_infra_agents_to_attach | map(attribute='metadata.name') | list }}"
+
+- name: Label selected agents with cluster order
+  kubernetes.core.k8s:
+    api_version: agent-install.openshift.io/v1beta1
+    kind: Agent
+    name: "{{ agent.metadata.name }}"
+    namespace: "{{ agent.metadata.namespace }}"
+    state: present
+    definition:
+      metadata:
+        labels: "{{ {cluster_order_label: cluster_infra_name} }}"
+      spec:
+        approved: true
+  loop: "{{ cluster_infra_agents_to_attach }}"
+  loop_control:
+    loop_var: agent
+    label: "Labeling agent {{ agent.metadata.name }}"

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/delete.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/delete.yaml
@@ -1,0 +1,172 @@
+---
+- name: Detach agents from cluster
+  ansible.builtin.include_role:
+    name: osac.service.manage_agents
+    tasks_from: detach_and_unlabel_all_removed_agents
+  vars:
+    manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
+
+# --- Read VLAN ID from IPAM state ---
+
+- name: Read VLAN ID from IPAM state
+  block:
+    - name: Slurp IPAM state file
+      ansible.builtin.slurp:
+        src: "{{ agentless_net_net_node_ipam_state_file }}"
+      delegate_to: "{{ groups['net_nodes'][0] }}"
+      register: cluster_infra_ipam_state_raw
+
+    - name: Parse VLAN ID and allocated hosts for this cluster
+      ansible.builtin.set_fact:
+        cluster_infra_vlan_id: "{{ (cluster_infra_ipam_state_raw.content | b64decode | from_json).vlans[cluster_infra_state_key] | default('') }}"
+        cluster_infra_allocated_host_ids: "{{ (cluster_infra_ipam_state_raw.content | b64decode | from_json).host_allocations[cluster_infra_state_key] | default([]) }}"
+  rescue:
+    - name: Default to empty VLAN ID and host IDs on missing or corrupt state
+      ansible.builtin.set_fact:
+        cluster_infra_vlan_id: ""
+        cluster_infra_allocated_host_ids: []
+
+- name: Skip network cleanup if no VLAN allocated
+  ansible.builtin.debug:
+    msg: "No VLAN allocation found for {{ cluster_infra_name }}, skipping network cleanup"
+  when: cluster_infra_vlan_id | string | length == 0
+
+# --- agentless_net: delete SNAT ---
+
+- name: Compute veth namespace-side interface name
+  ansible.builtin.set_fact:
+    cluster_infra_snat_veth_ns: "v{{ cluster_infra_name | hash('md5') | truncate(11, True, '') }}i"
+  when: cluster_infra_vlan_id | string | length > 0
+
+- name: Compute veth addresses for SNAT cleanup
+  ansible.builtin.set_fact:
+    cluster_infra_veth_index: "{{ (cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4 }}"
+    cluster_infra_veth_octet3: "{{ ((cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4) // 256 }}"
+    cluster_infra_veth_octet4: "{{ ((cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4) % 256 }}"
+  when: cluster_infra_vlan_id | string | length > 0
+
+- name: Set external subnet for SNAT cleanup
+  ansible.builtin.set_fact:
+    cluster_infra_external_peer_ip: "10.254.{{ cluster_infra_veth_octet3 }}.{{ cluster_infra_veth_octet4 | int + 1 }}/30"
+  when: cluster_infra_vlan_id | string | length > 0
+
+- name: Delete SNAT rules  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e snat_router_name={{ cluster_infra_name }}
+      -e snat_source_subnet={{ agentless_net_subnet_cidr }}
+      -e snat_veth_interface={{ cluster_infra_snat_veth_ns }}
+      -e snat_external_subnet={{ cluster_infra_external_peer_ip | ansible.utils.ipaddr('network/prefix') }}
+      -e snat_external_interface={{ agentless_net_external_interface }}
+      {{ role_path }}/playbooks/l3_delete_snat.yaml
+  when: cluster_infra_vlan_id | string | length > 0
+
+# --- agentless_net: delete L3 router namespace ---
+
+- name: Delete L3 router namespace  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e router_name={{ cluster_infra_name }}
+      {{ role_path }}/playbooks/l3_delete_router.yaml
+  when: cluster_infra_vlan_id | string | length > 0
+
+# --- agentless_net: reset access ports ---
+
+- name: Collect access port entries from switch inventory
+  ansible.builtin.set_fact:
+    cluster_infra_switch_port_entries: >-
+      {{ cluster_infra_switch_port_entries | default([]) +
+         (hostvars[item].access_ports | default({}) | dict2items
+          | map('combine', {'switch': item}) | list) }}
+  loop: "{{ groups['switches'] }}"
+  when: cluster_infra_vlan_id | string | length > 0 and cluster_infra_allocated_host_ids | length > 0
+
+- name: Build host-to-port mapping
+  ansible.builtin.set_fact:
+    cluster_infra_host_port_map: >-
+      {{ cluster_infra_host_port_map | default({}) | combine({
+        item.value: {'switch': item.switch, 'port': item.key}
+      }) }}
+  loop: "{{ cluster_infra_switch_port_entries | default([]) }}"
+  loop_control:
+    label: "{{ item.switch }}:{{ item.key }} -> {{ item.value }}"
+  when: cluster_infra_vlan_id | string | length > 0 and cluster_infra_allocated_host_ids | length > 0
+
+- name: Reset access ports for this cluster's hosts  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e port_name={{ cluster_infra_host_port_map[item].port }}
+      -l {{ cluster_infra_host_port_map[item].switch }}
+      {{ role_path }}/playbooks/l2_reset_port.yaml
+  loop: "{{ cluster_infra_allocated_host_ids }}"
+  loop_control:
+    label: "Reset {{ cluster_infra_host_port_map[item].switch }}:{{ cluster_infra_host_port_map[item].port }} (host {{ item }})"
+  when:
+    - cluster_infra_vlan_id | string | length > 0
+    - cluster_infra_allocated_host_ids | length > 0
+    - item in cluster_infra_host_port_map
+
+# --- agentless_net: delete VLAN from switches ---
+
+- name: Delete VLAN from switches  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e vlan_id={{ cluster_infra_vlan_id }}
+      {{ role_path }}/playbooks/l2_delete_vlan.yaml
+  when: cluster_infra_vlan_id | string | length > 0
+
+# --- agentless_net: release VLAN allocation ---
+
+- name: Release VLAN allocation  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e ipam_state_file={{ agentless_net_net_node_ipam_state_file }}
+      -e ipam_purpose={{ cluster_infra_state_key }}
+      {{ role_path }}/playbooks/ipam_release_vlan.yaml
+  when: cluster_infra_vlan_id | string | length > 0
+
+# --- Clean up host allocation state ---
+
+- name: Remove host allocation from network state  # noqa: no-changed-when
+  ansible.builtin.raw: |
+    python3 - '{{ agentless_net_net_node_ipam_state_file }}' \
+              '{{ cluster_infra_state_key }}' <<'STATE_PY'
+    import fcntl, json, os, sys
+    state_file, cluster_name = sys.argv[1:3]
+    with open(state_file, 'r+') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        state = json.load(f)
+        state.get('host_allocations', {}).pop(cluster_name, None)
+        f.seek(0)
+        f.write(json.dumps(state, indent=2))
+        f.truncate()
+        f.flush()
+        os.fsync(f.fileno())
+    STATE_PY
+  delegate_to: "{{ groups['net_nodes'][0] }}"
+  when: cluster_infra_allocated_host_ids | length > 0

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/defaults/main.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+# Defaults are defined in group_vars/all/agentless_net.yaml
+external_access_state_key: "{{ external_access_namespace }}-{{ external_access_name }}"

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/meta/argument_specs.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/meta/argument_specs.yaml
@@ -1,0 +1,27 @@
+---
+argument_specs:
+  create:
+    options:
+      external_access_name:
+        type: str
+        required: true
+      external_access_namespace:
+        type: str
+        required: true
+      external_access_base_domain:
+        type: str
+        required: true
+      cluster_working_namespace:
+        type: str
+        required: true
+      cluster_order:
+        type: dict
+        required: true
+  delete:
+    options:
+      external_access_name:
+        type: str
+        required: true
+      external_access_base_domain:
+        type: str
+        required: true

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/ipam_allocate_ip.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/ipam_allocate_ip.yaml
@@ -1,0 +1,9 @@
+---
+- name: Allocate public IPs from pool
+  hosts: net_nodes[0]
+  gather_facts: false
+  tasks:
+    - name: Allocate IPs
+      ansible.builtin.include_role:
+        name: agentless_net.ipam.ip
+        tasks_from: allocate

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/ipam_release_ip.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/ipam_release_ip.yaml
@@ -1,0 +1,9 @@
+---
+- name: Release public IP allocation
+  hosts: net_nodes[0]
+  gather_facts: false
+  tasks:
+    - name: Release IPs
+      ansible.builtin.include_role:
+        name: agentless_net.ipam.ip
+        tasks_from: release

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/l3_create_dnat.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/l3_create_dnat.yaml
@@ -1,0 +1,9 @@
+---
+- name: Create DNAT rule in router namespace
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Create DNAT
+      ansible.builtin.include_role:
+        name: agentless_net.l3.dnat
+        tasks_from: create

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/l3_delete_dnat.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/l3_delete_dnat.yaml
@@ -1,0 +1,9 @@
+---
+- name: Delete DNAT rule from router namespace
+  hosts: net_nodes
+  gather_facts: false
+  tasks:
+    - name: Delete DNAT
+      ansible.builtin.include_role:
+        name: agentless_net.l3.dnat
+        tasks_from: delete

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/create.yaml
@@ -1,0 +1,221 @@
+---
+- name: Set DNS names
+  ansible.builtin.set_fact:
+    external_access_api_domain: "api.{{ external_access_name }}.{{ external_access_base_domain }}"
+    external_access_api_int_domain: "api-int.{{ external_access_name }}.{{ external_access_base_domain }}"
+    external_access_ingress_domain: "apps.{{ external_access_name }}.{{ external_access_base_domain }}"
+
+- name: Get kube-apiserver service
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Service
+    namespace: "{{ external_access_namespace }}-{{ external_access_name }}"
+    name: kube-apiserver
+  register: external_access_kube_apiserver_service
+  until: >-
+    (external_access_kube_apiserver_service.resources | length > 0) and
+    (external_access_kube_apiserver_service.resources[0].status.loadBalancer.ingress | default([]) | length > 0)
+  retries: "{{ external_access_resource_wait_retries }}"
+  delay: "{{ external_access_resource_wait_delay }}"
+
+- name: Set API internal IP and port
+  ansible.builtin.set_fact:
+    external_access_api_internal_ip: "{{ external_access_kube_apiserver_service.resources[0].status.loadBalancer.ingress[0].ip }}"
+    external_access_kube_apiserver_port: "{{ external_access_kube_apiserver_service.resources[0].spec.ports[0].port }}"
+
+# --- agentless_net: allocate public IPs ---
+
+- name: Allocate public IP for API  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e ipam_state_file={{ agentless_net_net_node_ipam_state_file }}
+      -e ipam_pool_start={{ agentless_net_public_ip_pool_start }}
+      -e ipam_pool_end={{ agentless_net_public_ip_pool_end }}
+      -e ipam_purpose={{ external_access_state_key }}-api
+      {{ role_path }}/playbooks/ipam_allocate_ip.yaml
+
+- name: Read API public IP from state file
+  ansible.builtin.slurp:
+    src: "{{ agentless_net_net_node_ipam_state_file }}"
+  delegate_to: "{{ groups['net_nodes'][0] }}"
+  register: external_access_api_ipam_raw
+
+- name: Set API public IP
+  ansible.builtin.set_fact:
+    external_access_api_public_ip: "{{ (external_access_api_ipam_raw.content | b64decode | from_json).public_ips[external_access_state_key + '-api'][0] }}"
+
+- name: Allocate public IP for ingress  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e ipam_state_file={{ agentless_net_net_node_ipam_state_file }}
+      -e ipam_pool_start={{ agentless_net_public_ip_pool_start }}
+      -e ipam_pool_end={{ agentless_net_public_ip_pool_end }}
+      -e ipam_purpose={{ external_access_state_key }}-ingress
+      {{ role_path }}/playbooks/ipam_allocate_ip.yaml
+
+- name: Read ingress public IP from state file
+  ansible.builtin.slurp:
+    src: "{{ agentless_net_net_node_ipam_state_file }}"
+  delegate_to: "{{ groups['net_nodes'][0] }}"
+  register: external_access_ingress_ipam_raw
+
+- name: Set ingress public IP
+  ansible.builtin.set_fact:
+    external_access_ingress_public_ip: "{{ (external_access_ingress_ipam_raw.content | b64decode | from_json).public_ips[external_access_state_key + '-ingress'][0] }}"
+
+- name: Display allocated public IPs
+  ansible.builtin.debug:
+    msg:
+      - "API public IP: {{ external_access_api_public_ip }}"
+      - "Ingress public IP: {{ external_access_ingress_public_ip }}"
+
+- name: Store DNAT state for delete resilience  # noqa: no-changed-when
+  ansible.builtin.raw: |
+    python3 - '{{ agentless_net_net_node_ipam_state_file }}' \
+              '{{ external_access_state_key }}' \
+              '{{ external_access_api_internal_ip }}' \
+              '{{ external_access_kube_apiserver_port }}' <<'STATE_PY'
+    import fcntl, json, os, sys
+    state_file, cluster_name, api_ip, api_port = sys.argv[1:5]
+    with open(state_file, 'r+') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        state = json.load(f)
+        state.setdefault('dnat_state', {})[cluster_name] = {
+            'api_internal_ip': api_ip,
+            'api_port': int(api_port)
+        }
+        f.seek(0)
+        f.write(json.dumps(state, indent=2))
+        f.truncate()
+        f.flush()
+        os.fsync(f.fileno())
+    STATE_PY
+  delegate_to: "{{ groups['net_nodes'][0] }}"
+
+# --- agentless_net: create DNAT for API ---
+
+- name: Create DNAT for API endpoint  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e dnat_router_name={{ external_access_name }}
+      -e dnat_public_ip={{ external_access_api_public_ip }}
+      -e dnat_public_port={{ external_access_kube_apiserver_port }}
+      -e dnat_internal_ip={{ external_access_api_internal_ip }}
+      -e dnat_internal_port={{ external_access_kube_apiserver_port }}
+      -e dnat_protocol=tcp
+      {{ role_path }}/playbooks/l3_create_dnat.yaml
+
+# --- DNS records ---
+
+- name: Create DNS records
+  when: >-
+    external_access_base_domain in external_access_supported_base_domains | default([])
+  ansible.builtin.include_role:
+    name: "{{ dns_class }}"
+    tasks_from: create
+  vars:
+    dns_zone: "{{ external_access_base_domain }}"
+    dns_record_name: "{{ item.name }}"
+    dns_record_type: A
+    dns_record_ttl: "{{ external_access_dns_ttl }}"
+    dns_record_value: "{{ item.addr }}"
+    dns_record_overwrite: true
+  loop:
+    - name: "{{ external_access_api_domain }}"
+      addr: "{{ external_access_api_public_ip }}"
+    - name: "{{ external_access_api_int_domain }}"
+      addr: "{{ external_access_api_public_ip }}"
+    - name: "*.{{ external_access_ingress_domain }}"
+      addr: "{{ external_access_ingress_public_ip }}"
+
+- name: Wait for DNS records
+  when: >-
+    external_access_base_domain in external_access_supported_base_domains | default([])
+  ansible.builtin.include_role:
+    name: osac.service.wait_for
+    tasks_from: wait_for_dns
+  vars:
+    wait_for_dns_record: "{{ item }}"
+  loop:
+    - "{{ external_access_api_domain }}"
+    - "{{ external_access_api_int_domain }}"
+    - "default-router.{{ external_access_ingress_domain }}"
+
+# --- Kubeconfig and cluster readiness ---
+
+- name: Get managed cluster admin kubeconfig secret
+  ansible.builtin.include_role:
+    name: osac.service.retrieve_kubeconfig
+  vars:
+    retrieve_kubeconfig_namespace: "{{ cluster_working_namespace }}"
+    retrieve_kubeconfig_cluster_name: "{{ cluster_order.metadata.name }}"
+
+- name: Wait for cluster to become ready
+  ansible.builtin.include_role:
+    name: osac.service.wait_for
+    tasks_from: wait_for_network_cluster_operator
+  vars:
+    wait_for_kubeconfig: "{{ admin_kubeconfig }}"
+
+# --- MetalLB ingress configuration ---
+
+- name: Compute MetalLB ingress IP from subnet
+  ansible.builtin.set_fact:
+    external_access_metallb_ingress_ip: "{{ agentless_net_subnet_cidr | ansible.utils.nthhost(-10) }}"
+
+- name: Configure MetalLB for ingress
+  ansible.builtin.include_role:
+    name: osac.service.metallb_ingress
+    tasks_from: configure_metallb_ingress
+  vars:
+    metallb_ingress_admin_kubeconfig: "{{ admin_kubeconfig }}"
+    metallb_ingress_ip: "{{ external_access_metallb_ingress_ip }}"
+
+# --- agentless_net: create DNAT for ingress ---
+
+- name: Create DNAT for ingress HTTP  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e dnat_router_name={{ external_access_name }}
+      -e dnat_public_ip={{ external_access_ingress_public_ip }}
+      -e dnat_public_port=80
+      -e dnat_internal_ip={{ external_access_metallb_ingress_ip }}
+      -e dnat_internal_port=80
+      -e dnat_protocol=tcp
+      {{ role_path }}/playbooks/l3_create_dnat.yaml
+
+- name: Create DNAT for ingress HTTPS  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e dnat_router_name={{ external_access_name }}
+      -e dnat_public_ip={{ external_access_ingress_public_ip }}
+      -e dnat_public_port=443
+      -e dnat_internal_ip={{ external_access_metallb_ingress_ip }}
+      -e dnat_internal_port=443
+      -e dnat_protocol=tcp
+      {{ role_path }}/playbooks/l3_create_dnat.yaml

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/delete.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/delete.yaml
@@ -1,0 +1,162 @@
+---
+# --- Read public IPs from IPAM state ---
+
+- name: Read IPAM state file
+  block:
+    - name: Slurp IPAM state file
+      ansible.builtin.slurp:
+        src: "{{ agentless_net_net_node_ipam_state_file }}"
+      delegate_to: "{{ groups['net_nodes'][0] }}"
+      register: external_access_ipam_state_raw
+
+    - name: Parse public IPs for this cluster
+      ansible.builtin.set_fact:
+        external_access_api_public_ip: "{{ (external_access_ipam_state_raw.content | b64decode | from_json).public_ips[external_access_state_key + '-api'][0] | default('') }}"
+        external_access_ingress_public_ip: "{{ (external_access_ipam_state_raw.content | b64decode | from_json).public_ips[external_access_state_key + '-ingress'][0] | default('') }}"
+  rescue:
+    - name: Default to empty IPs on missing or corrupt state
+      ansible.builtin.set_fact:
+        external_access_api_public_ip: ""
+        external_access_ingress_public_ip: ""
+
+- name: Skip cleanup if no public IPs allocated
+  ansible.builtin.debug:
+    msg: "No public IP allocations found for {{ external_access_name }}, skipping cleanup"
+  when: external_access_api_public_ip | length == 0 and external_access_ingress_public_ip | length == 0
+
+# --- Read DNAT state for API rule matching ---
+
+- name: Parse API DNAT state
+  when: external_access_api_public_ip | length > 0
+  block:
+    - name: Extract API internal IP and port from state file
+      ansible.builtin.set_fact:
+        external_access_api_internal_ip: "{{ (external_access_ipam_state_raw.content | b64decode | from_json).dnat_state[external_access_state_key].api_internal_ip | default('') }}"
+        external_access_kube_apiserver_port: "{{ (external_access_ipam_state_raw.content | b64decode | from_json).dnat_state[external_access_state_key].api_port | default('') }}"
+  rescue:
+    - name: Default to empty API DNAT state
+      ansible.builtin.set_fact:
+        external_access_api_internal_ip: ""
+        external_access_kube_apiserver_port: ""
+
+- name: Compute MetalLB ingress IP for DNAT delete
+  ansible.builtin.set_fact:
+    external_access_metallb_ingress_ip: "{{ agentless_net_subnet_cidr | ansible.utils.nthhost(-10) }}"
+  when: external_access_ingress_public_ip | length > 0
+
+# --- agentless_net: delete DNAT rules ---
+
+- name: Delete DNAT for API endpoint  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e dnat_router_name={{ external_access_name }}
+      -e dnat_public_ip={{ external_access_api_public_ip }}
+      -e dnat_public_port={{ external_access_kube_apiserver_port }}
+      -e dnat_internal_ip={{ external_access_api_internal_ip }}
+      -e dnat_internal_port={{ external_access_kube_apiserver_port }}
+      -e dnat_protocol=tcp
+      {{ role_path }}/playbooks/l3_delete_dnat.yaml
+  when: external_access_api_public_ip | length > 0 and external_access_api_internal_ip | default('') | length > 0
+
+- name: Delete DNAT for ingress HTTP  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e dnat_router_name={{ external_access_name }}
+      -e dnat_public_ip={{ external_access_ingress_public_ip }}
+      -e dnat_public_port=80
+      -e dnat_internal_ip={{ external_access_metallb_ingress_ip }}
+      -e dnat_internal_port=80
+      -e dnat_protocol=tcp
+      {{ role_path }}/playbooks/l3_delete_dnat.yaml
+  when: external_access_ingress_public_ip | length > 0 and external_access_metallb_ingress_ip is defined
+
+- name: Delete DNAT for ingress HTTPS  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e dnat_router_name={{ external_access_name }}
+      -e dnat_public_ip={{ external_access_ingress_public_ip }}
+      -e dnat_public_port=443
+      -e dnat_internal_ip={{ external_access_metallb_ingress_ip }}
+      -e dnat_internal_port=443
+      -e dnat_protocol=tcp
+      {{ role_path }}/playbooks/l3_delete_dnat.yaml
+  when: external_access_ingress_public_ip | length > 0 and external_access_metallb_ingress_ip is defined
+
+# --- Delete DNS records ---
+
+- name: Delete DNS records
+  when: >-
+    external_access_base_domain in external_access_supported_base_domains | default([])
+  ansible.builtin.include_role:
+    name: "{{ dns_class }}"
+    tasks_from: delete
+  vars:
+    dns_zone: "{{ external_access_base_domain }}"
+    dns_record_name: "{{ item }}"
+    dns_record_type: A
+  loop:
+    - "api.{{ external_access_name }}.{{ external_access_base_domain }}"
+    - "api-int.{{ external_access_name }}.{{ external_access_base_domain }}"
+    - "*.apps.{{ external_access_name }}.{{ external_access_base_domain }}"
+
+# --- agentless_net: release public IPs ---
+
+- name: Release API public IP  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e ipam_state_file={{ agentless_net_net_node_ipam_state_file }}
+      -e ipam_purpose={{ external_access_state_key }}-api
+      {{ role_path }}/playbooks/ipam_release_ip.yaml
+
+- name: Release ingress public IP  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e ipam_state_file={{ agentless_net_net_node_ipam_state_file }}
+      -e ipam_purpose={{ external_access_state_key }}-ingress
+      {{ role_path }}/playbooks/ipam_release_ip.yaml
+
+# --- Clean up DNAT state ---
+
+- name: Remove DNAT state from network state  # noqa: no-changed-when
+  ansible.builtin.raw: |
+    python3 - '{{ agentless_net_net_node_ipam_state_file }}' \
+              '{{ external_access_state_key }}' <<'STATE_PY'
+    import fcntl, json, os, sys
+    state_file, cluster_name = sys.argv[1:3]
+    with open(state_file, 'r+') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        state = json.load(f)
+        state.get('dnat_state', {}).pop(cluster_name, None)
+        f.seek(0)
+        f.write(json.dumps(state, indent=2))
+        f.truncate()
+        f.flush()
+        os.fsync(f.fileno())
+    STATE_PY
+  delegate_to: "{{ groups['net_nodes'][0] }}"
+  when: external_access_api_internal_ip | default('') | length > 0

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -28,4 +28,4 @@ collections:
   - name: ansible_network.network_runner
     type: git
     source: https://github.com/ybettan/network-runner
-    version: 0.3.6
+    version: 0.3.7

--- a/group_vars/all/agentless_net.yaml
+++ b/group_vars/all/agentless_net.yaml
@@ -1,0 +1,21 @@
+# =============================================================================
+# Agentless Network Backend (agentless_net.steps)
+# =============================================================================
+
+# Shared
+agentless_net_inventory_file: "{{ inventory_file }}"
+agentless_net_collections_path: "{{ lookup('env', 'ANSIBLE_COLLECTIONS_PATH') }}"
+agentless_net_roles_path: "{{ lookup('env', 'ANSIBLE_ROLES_PATH') }}"
+agentless_net_net_node_ipam_state_file: "{{ lookup('env', 'AGENTLESS_NET_IPAM_STATE_FILE', default='/etc/osac/network_state.json') }}"
+
+# cluster_infra role
+agentless_net_vlan_pool_start: "{{ lookup('env', 'AGENTLESS_NET_VLAN_POOL_START', default='100') | int }}"
+agentless_net_vlan_pool_end: "{{ lookup('env', 'AGENTLESS_NET_VLAN_POOL_END', default='199') | int }}"
+agentless_net_trunk_interface: "{{ lookup('env', 'AGENTLESS_NET_TRUNK_INTERFACE', default='eth1') }}"
+agentless_net_external_interface: "{{ lookup('env', 'AGENTLESS_NET_EXTERNAL_INTERFACE', default='eth0') }}"
+agentless_net_external_gateway: "{{ lookup('env', 'AGENTLESS_NET_EXTERNAL_GATEWAY', default='') }}"
+agentless_net_subnet_cidr: "{{ lookup('env', 'AGENTLESS_NET_SUBNET_CIDR', default='') }}"
+
+# external_access role
+agentless_net_public_ip_pool_start: "{{ lookup('env', 'AGENTLESS_NET_PUBLIC_IP_POOL_START', default='') }}"
+agentless_net_public_ip_pool_end: "{{ lookup('env', 'AGENTLESS_NET_PUBLIC_IP_POOL_END', default='') }}"

--- a/vendor/ansible_collections/ansible_network/network_runner/FILES.json
+++ b/vendor/ansible_collections/ansible_network/network_runner/FILES.json
@@ -144,7 +144,7 @@
    "name": "roles/switch/providers/cumulus/delete_port.yaml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "87f130043558e5422b89cbf1c1943a07ebe1894b7157f2e4500bcced853e3f9e",
+   "chksum_sha256": "66eaf890170ba8003484a36500071de885ad37fd46cb5e14c0f1c7a0b626d814",
    "format": 1
   },
   {
@@ -221,7 +221,7 @@
    "name": "roles/switch/providers/dellemc.os9.os9/delete_port.yaml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "97f2c40f5fdf3a916195a6d09b76496677b6e93eb13424b19b06b4f83bdf9d62",
+   "chksum_sha256": "5436aecf51f5b30e0c9b69f384bfb6621963a53a6f099b80fa875ea60b528cfe",
    "format": 1
   },
   {
@@ -298,7 +298,7 @@
    "name": "roles/switch/providers/dellos10/delete_port.yaml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "ab330c1b7dc84085ef115c5436e5632584ae7eaec93346841f8813df526ced0e",
+   "chksum_sha256": "8753dc548540f6430c8f76bca5f4510d8fed8d5adcef0c54350923693ca934ae",
    "format": 1
   },
   {
@@ -529,7 +529,7 @@
    "name": "roles/switch/providers/fos/delete_port.yaml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "fd1a23f36abb99b33b69377b6f096d83b2f8ba0a91e6861d4bae772e65c60fd2",
+   "chksum_sha256": "8406582f61843451c5d52666d0196b52517b147ccb095e4fe6a988fb54e80d3a",
    "format": 1
   },
   {
@@ -606,7 +606,7 @@
    "name": "roles/switch/providers/junos/delete_port.yaml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "0f51264a2b836d571e8e5a27b2b56c6048dfe1e4840030c029b6ae88afe4dbee",
+   "chksum_sha256": "22766eab2faa2c87f9c2e78fe1f28bcb85d0b55df6da3cbe70d9d021c1df0004",
    "format": 1
   },
   {
@@ -683,7 +683,7 @@
    "name": "roles/switch/providers/nos/delete_port.yaml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "34101c9229a65d97d879927f6982a3ffaadfa433c7b00f7d7c530c6ab2345177",
+   "chksum_sha256": "7e3b85d065b1ff1df6cc06ba8e59fdb13a93a8cb2f396fc7407b9ec6660e7b4b",
    "format": 1
   },
   {
@@ -760,7 +760,7 @@
    "name": "roles/switch/providers/nxos/delete_port.yaml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "bd21f7e7aea9f63d34edcbdf5053fe114cba038869446390a4fac1d98ecb7775",
+   "chksum_sha256": "3be79b53d3a543a1055cdc0e725a31a70bc9e3b6b5d91000a097bf84e5ab28c2",
    "format": 1
   },
   {
@@ -998,7 +998,7 @@
    "name": "roles/switch/templates/eos/delete_port.j2",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "2bb8a9820b18a12aab56ab29e74909bd53f17f4bab0be6f23164f8e27eea69a1",
+   "chksum_sha256": "38beea0bac84f2b6a4b0a3e7e0e41589ad7fade172892636b0cd0cee720c34d6",
    "format": 1
   },
   {

--- a/vendor/ansible_collections/ansible_network/network_runner/MANIFEST.json
+++ b/vendor/ansible_collections/ansible_network/network_runner/MANIFEST.json
@@ -2,7 +2,7 @@
  "collection_info": {
   "namespace": "ansible_network",
   "name": "network_runner",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "authors": [
    "Ansible Network Team",
    "Yoni Bettan <yonibettan@gmail.com>"
@@ -26,7 +26,7 @@
   "name": "FILES.json",
   "ftype": "file",
   "chksum_type": "sha256",
-  "chksum_sha256": "b31356041d4f53b9acb23312d5b6ae220aa6621f69570542d3156aa57d524b20",
+  "chksum_sha256": "dd8b76baaa7a15883467aea23c85a10a1e1472e4b46c50d9a524a191d9d9202e",
   "format": 1
  },
  "format": 1

--- a/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/cumulus/delete_port.yaml
+++ b/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/cumulus/delete_port.yaml
@@ -1,6 +1,5 @@
 ---
-- name: "cumulus: remove port configuration using nvue"
+- name: "cumulus: remove port VLAN configuration using nvue"
   raw: |
     nv unset interface {{ port_name }} bridge domain
-    nv set interface {{ port_name }} link state down
     nv config apply -y

--- a/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/dellemc.os9.os9/delete_port.yaml
+++ b/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/dellemc.os9.os9/delete_port.yaml
@@ -1,6 +1,8 @@
 ---
-- name: "dellemc.os9: reset interface to default (no switchport and shutdown)"
+- name: "dellemc.os9: remove port VLAN configuration"
   dellemc.os9.os9_config:
     lines:
-      - "default interface {{ port_name }}"
+      - "no switchport"
+    parents:
+      - "interface {{ port_name }}"
   connection: network_cli

--- a/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/dellos10/delete_port.yaml
+++ b/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/dellos10/delete_port.yaml
@@ -1,9 +1,8 @@
 ---
-- name: "dellos10: remove port configuration"
+- name: "dellos10: remove port VLAN configuration"
   dellos10_config:
-    lines: "default interface {{ port_name }}"
-
-- name: "dellos10: administratively disable the port"
-  dellos10_config:
-    lines: "shutdown"
+    lines:
+      - "no switchport mode"
+      - "no switchport access vlan"
+      - "no switchport trunk allowed vlan"
     parents: ["interface {{ port_name }}"]

--- a/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/fos/delete_port.yaml
+++ b/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/fos/delete_port.yaml
@@ -6,6 +6,5 @@
       - no switchport trunk allowed vlan
       - no switchport trunk native vlan
       - no switchport access vlan
-      - shutdown
     parents: interface {{ port_name }}
   connection: network_cli

--- a/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/junos/delete_port.yaml
+++ b/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/junos/delete_port.yaml
@@ -1,9 +1,9 @@
 ---
-- name: "junos: delete port"
+- name: "junos: remove port VLAN configuration"
   junos_command:
     commands:
       - config
-      - "delete interfaces {{ port_name }}"
+      - "delete interfaces {{ port_name }} unit 0 family ethernet-switching"
       - commit
   register: result
   retries: "{{ _retries }}"

--- a/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/nos/delete_port.yaml
+++ b/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/nos/delete_port.yaml
@@ -1,9 +1,8 @@
 ---
-- name: "nos: reset interface to default (no switchport and shutdown)"
+- name: "nos: remove port VLAN configuration"
   community.network.nos_config:
     lines:
       - "no switchport"
-      - "shutdown"
     parents:
       - "interface {{ port_name }}"
   connection: network_cli

--- a/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/nxos/delete_port.yaml
+++ b/vendor/ansible_collections/ansible_network/network_runner/roles/switch/providers/nxos/delete_port.yaml
@@ -1,11 +1,9 @@
 ---
-- name: "nxos: remove port configuration"
+- name: "nxos: remove port VLAN configuration"
   nxos_config:
-    lines: "default interface {{ port_name }}"
-  connection: network_cli
-
-- name: "nxos: administratively disable the port"
-  nxos_config:
-    lines: "shutdown"
+    lines:
+      - "no switchport mode"
+      - "no switchport access vlan"
+      - "no switchport trunk allowed vlan"
     parents: ["interface {{ port_name }}"]
   connection: network_cli

--- a/vendor/ansible_collections/ansible_network/network_runner/roles/switch/templates/eos/delete_port.j2
+++ b/vendor/ansible_collections/ansible_network/network_runner/roles/switch/templates/eos/delete_port.j2
@@ -1,3 +1,2 @@
 interface {{ port_name }}
 {% include "clean_config.j2" %}
-shutdown

--- a/vendor/ansible_collections/nvidia/bare_metal/FILES.json
+++ b/vendor/ansible_collections/nvidia/bare_metal/FILES.json
@@ -22,20 +22,6 @@
    "format": 1
   },
   {
-   "name": "Makefile",
-   "ftype": "file",
-   "chksum_type": "sha256",
-   "chksum_sha256": "8c2bf2daf6dd9fcf1d9c3bec7f2225ec145e16264a645d91ee8d35b1fc6223fd",
-   "format": 1
-  },
-  {
-   "name": "README.md",
-   "ftype": "file",
-   "chksum_type": "sha256",
-   "chksum_sha256": "b8e2ba476e1e0ed87fad74f9b69f93c3d165625015cebb117ba5cb61ae01d7ee",
-   "format": 1
-  },
-  {
    "name": "meta",
    "ftype": "dir",
    "chksum_type": null,
@@ -71,20 +57,6 @@
    "format": 1
   },
   {
-   "name": "plugins/inventory",
-   "ftype": "dir",
-   "chksum_type": null,
-   "chksum_sha256": null,
-   "format": 1
-  },
-  {
-   "name": "plugins/inventory/bmm.py",
-   "ftype": "file",
-   "chksum_type": "sha256",
-   "chksum_sha256": "6a0f368d99e4b0cd5d9e0dee1d62096e3b3c10562d67fee01849156aedd96f78",
-   "format": 1
-  },
-  {
    "name": "plugins/module_utils",
    "ftype": "dir",
    "chksum_type": null,
@@ -96,6 +68,13 @@
    "ftype": "file",
    "chksum_type": "sha256",
    "chksum_sha256": "cc7e2d01c739a620d7101f2f4554c2fa3d883b4801510beeb8ddbc62a071b575",
+   "format": 1
+  },
+  {
+   "name": "plugins/module_utils/client.py",
+   "ftype": "file",
+   "chksum_type": "sha256",
+   "chksum_sha256": "918f2d56bc10ff7664dbb2f58c3d342eb9a8a375743acb5eaf97cd914b6de35a",
    "format": 1
   },
   {
@@ -113,13 +92,6 @@
    "format": 1
   },
   {
-   "name": "plugins/module_utils/client.py",
-   "ftype": "file",
-   "chksum_type": "sha256",
-   "chksum_sha256": "918f2d56bc10ff7664dbb2f58c3d342eb9a8a375743acb5eaf97cd914b6de35a",
-   "format": 1
-  },
-  {
    "name": "plugins/modules",
    "ftype": "dir",
    "chksum_type": null,
@@ -130,14 +102,14 @@
    "name": "plugins/modules/allocation.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "72a6f37d731732d3d1785eb928f6ee7a72adee81e3f10db19af9f4f922faf66e",
+   "chksum_sha256": "2aff40825730a11b4a18bd0d81fe06c2a8d48c33e4d3139eb4313c9e683979f5",
    "format": 1
   },
   {
    "name": "plugins/modules/allocation_constraint.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "ac7330a3c8f03595c7d199bfb71b0e24157c2b7897a8cbd8a028325f6b6f335f",
+   "chksum_sha256": "6c2b7cf963250ccd7f5dbf246dba7930918524ac31be943dc80023c03fa64d73",
    "format": 1
   },
   {
@@ -151,112 +123,112 @@
    "name": "plugins/modules/allocation_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "db825d45aeb719e8767380a96c878df3a5104fa1ef0e36e5db8d0100476d86de",
+   "chksum_sha256": "7374221ccbd9a18fb7be202251b2bbae359f7fc37757cdf27e01b304916d0358",
    "format": 1
   },
   {
    "name": "plugins/modules/audit_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "92dbdad465a0c07adcd02516462422e9208a40745e5f689b870dfbcaf3d98d8b",
+   "chksum_sha256": "a3614bc2d8d5346503de1bf97572d19b1d6c1ffe847cef9ed899fd97e7ac2ad9",
    "format": 1
   },
   {
    "name": "plugins/modules/dpu_extension_service.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "16cd0ff99fbc6d4a10f9fb5e22bc004c8e6dcac198d82fe07f55851726f36065",
+   "chksum_sha256": "01c3c33005a9b1e9ffa21430c26ad8387a8f93167e26fef9f28f31f2ccd6e146",
    "format": 1
   },
   {
    "name": "plugins/modules/dpu_extension_service_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "20f1fb46a83575bebd35489a100401ff26eda80c1dc538b5e79c1d79ae82fcb3",
+   "chksum_sha256": "376ec389e89737c90cd20eb6015b0a8e2d4780fa568084f72fa4734a3dfcfa60",
    "format": 1
   },
   {
    "name": "plugins/modules/expected_machine.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "3eafcf821f86aba97d417433307639ecac859f06ec23d29c2304d3439b9465c2",
+   "chksum_sha256": "07d0e80e22cb000171035aaa797b23ba838b5ee5a91d5fb50772ccf84d78cbcc",
    "format": 1
   },
   {
    "name": "plugins/modules/expected_machine_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "1231ce1f1be9af49d616586c45013b16631830cafafaaba4438e0034dcbc64ff",
+   "chksum_sha256": "3332d232e90225f7a0e7add428869cf989d56bcc90c56548f445693206332a81",
    "format": 1
   },
   {
    "name": "plugins/modules/expected_power_shelf.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "978d6d4ff8723ff1a8be709f1d3093d78229c66a527d838a501580f29f139b7a",
+   "chksum_sha256": "7bf9d32c48fa1a359dedc123ec9b4bb79c06e902472af74085b047954dcf985c",
    "format": 1
   },
   {
    "name": "plugins/modules/expected_power_shelf_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "8a3a36c408046dde6bf05c20a23a070cf46baec0840e911c2eda45b683d94921",
+   "chksum_sha256": "350b5e9879e19fe8f7cef0facfc116759190c6adda7d0c6c361b0504953beb3c",
    "format": 1
   },
   {
    "name": "plugins/modules/expected_switch.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "e4915b6907a96c976184c221411b17ab9fa4ac76b1586295757318443a380d78",
+   "chksum_sha256": "a9688292de2a9654c2d7dde1d7b843b5d7ac4169f10ae5942e7db366058ace4a",
    "format": 1
   },
   {
    "name": "plugins/modules/expected_switch_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "43a8154882319220f60912523de9a6ba70dd0f33668cb10159fac7ce5a564569",
+   "chksum_sha256": "83253ef2f14c61700d8a725f93502dc3e2c1ce38bd0638d6dcdd1c46fcb51d50",
    "format": 1
   },
   {
    "name": "plugins/modules/infiniband_partition.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "dc7757990f51c7a806e71ef1c90cbc0414d26ab7ff6657a53532fcc26a7877c6",
+   "chksum_sha256": "2c937bc005c52c3b98ece566a51c1628bb8b1f8564c6593be8bf7378a55b3834",
    "format": 1
   },
   {
    "name": "plugins/modules/infiniband_partition_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "edd46de139bf3c7d7300e3e7508edac0e05eebc319365515308f36851c4cc13b",
+   "chksum_sha256": "f6d6f94f4f533e5e25baa59b42f064ece68770e834e46cd698831ba04218a204",
    "format": 1
   },
   {
    "name": "plugins/modules/infrastructure_provider_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "1ba339d37dab59aec664478ce5efb985f613a2cf862c712303c4a20393cb99a6",
+   "chksum_sha256": "b8fc124a76b84e8fd4b99b850b167d897908e9ab26b6d1131543f8acbe2a0cf4",
    "format": 1
   },
   {
    "name": "plugins/modules/instance.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "ae05245c5735692a72d343e3fdcc50983de555fe328551a5080cf1caf9193291",
+   "chksum_sha256": "eb0705f4b4afaa08f2e2b2f18b48770c5279f244da2deb1315746c6afb4302e6",
    "format": 1
   },
   {
    "name": "plugins/modules/instance_batch.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "cd1aa6ae37395ffa254b4b6abe7c213b175cbb9e0055745b433981bfc9ea6714",
+   "chksum_sha256": "0f43c91f15a14adcb360e989ce16367b494f42a62ce71fe734f87b075c892ff9",
    "format": 1
   },
   {
    "name": "plugins/modules/instance_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "0d6862c1d8f20473dcb4fc182ac84a9adc411f0733ac293abe8b619fce55f175",
+   "chksum_sha256": "8984f3bfc32151d1d8b34a0b9751b59104226b2778f7b7fc498aed723e2f5e18",
    "format": 1
   },
   {
@@ -270,98 +242,98 @@
    "name": "plugins/modules/instance_type.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "57acd956d5aa547311bc71c479b8826004e3c48c358f77bc5d9657860188ea04",
+   "chksum_sha256": "75ca8eb698882778d834b38bab8f05bf093feab81299247f192d684e7d353d30",
    "format": 1
   },
   {
    "name": "plugins/modules/instance_type_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "8f2ace38054247abb73f5bac87943ce3129d0a3d4a9272bb58a9d92bd5b928c0",
+   "chksum_sha256": "141bfe54525008d5ae8937e888d411b184605aadb49fe6c0ed7cafdea89ce8e3",
    "format": 1
   },
   {
    "name": "plugins/modules/ip_block.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "d58788db90f22a3c0c710df133d78b99543437a32dd4960175f0b6428391b685",
+   "chksum_sha256": "3244830641f79aeaa656f433daa3b0d39beb0cab33a6bf93307981b95f57bda3",
    "format": 1
   },
   {
    "name": "plugins/modules/ip_block_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "476f4d9186b85a6382795f8e853622093051200701f2360d56559008558c7c23",
+   "chksum_sha256": "7af83ba0302c6cf13197f23f7b665976a9c41cde882901424731f1dd8a7fa017",
    "format": 1
   },
   {
    "name": "plugins/modules/machine.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "dbad0de5f8682c25407b196162b1cca58eb3c0aad77b42f6f65c1bf8bb2d6ec6",
+   "chksum_sha256": "72149ec64c42fd3f762b719001bf771f10fe26cf13bf7beb08593ff0060ac6f0",
    "format": 1
   },
   {
    "name": "plugins/modules/machine_capability_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "dfed7980b5e22962a7c67d6e46cee767e5723b4c060c2e93180d2dcfb3d13a66",
+   "chksum_sha256": "af5ed9f39b61463f55e5a0ab5dbfb67bced7d660da6e721e2f5b90e0f3652bb1",
    "format": 1
   },
   {
    "name": "plugins/modules/machine_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "6659d1c2b5f1fba8750134a85d2b6c9d26b5673dc43d5e3342fae79977926a54",
+   "chksum_sha256": "0aa0678a56926da6d8286af25da78210691432a72cb5d416e718d32f830ff9cc",
    "format": 1
   },
   {
    "name": "plugins/modules/metadata_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "8f62c165827207ec4bfec6aa2186664c3621e60627e0704aa8b397cc3d5452af",
+   "chksum_sha256": "48926ed95953a60bff4269c51439d13baa488216494c8d78e5fb877a83f73c4f",
    "format": 1
   },
   {
    "name": "plugins/modules/network_security_group.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "5524729e0b85e8c7b4500fc58a36b0b032dce00322406055f391cdb795ea6f8f",
+   "chksum_sha256": "6f69b1d8613a44ba6c49aeac71f5d25a273b18e19914eb4f15e09cef36e5c8b7",
    "format": 1
   },
   {
    "name": "plugins/modules/network_security_group_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "72a83f466cd68a62a8529506fdc96a2b91a0c86fd619518143f4824e37d78902",
+   "chksum_sha256": "3af84d8b760e1fd4f4516b74085ac3525ece28c6f4be062d208c72a4134ace8a",
    "format": 1
   },
   {
    "name": "plugins/modules/nvlink_logical_partition.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "e9d07a094672f5b33ca7e8e7a53f8ce62e0973b80599efd09b94c39d1e4b8550",
+   "chksum_sha256": "2ef552d46e56cba02e3bbc36699efdf086d671b46ada629ba0f620017e90a3f1",
    "format": 1
   },
   {
    "name": "plugins/modules/nvlink_logical_partition_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "6e13b0966970a0a1f69aaff55fdd0f34f41f3ef8069a62c6f7cd80fa71f32e2d",
+   "chksum_sha256": "8abc04b3b4f8e57f735eb57e7f1f03d7d07ebd55f1c9c8ca61898d49a3fda143",
    "format": 1
   },
   {
    "name": "plugins/modules/operating_system.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "9b21afcd5b16dc214fc80975b8e15db4fe37dd4f825cd955378eabfe797852df",
+   "chksum_sha256": "73f5be32061cfc2923c3971b2902c58a5ba19abb53e0d47740bb6f1274920469",
    "format": 1
   },
   {
    "name": "plugins/modules/operating_system_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "4ec7d67f0bab273a6862e244bbf9e6e0399c8fd4f4f97adf62bf45ccf1bb3a5f",
+   "chksum_sha256": "f8b7128e6c48e7b3509a6284825e6ec17544bff4454760bc2e027cbd5f3b0b91",
    "format": 1
   },
   {
@@ -375,21 +347,21 @@
    "name": "plugins/modules/rack_firmware.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "7ac085e36c0eab4e9b00a41e05d79f16cddd851a3a2d65a585ab9930e011a780",
+   "chksum_sha256": "c9fcce267ba40da3c962a6e2b1296183309302f16aa88d62a028c80ba3e5a164",
    "format": 1
   },
   {
    "name": "plugins/modules/rack_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "6cf42f51644a013cec5398718b733df64ef493e95bff5cfb70daa8f43abe91f9",
+   "chksum_sha256": "89a84feee75433e4dbf596bc6e8072fcb2dd1460effb406a6ec202566ee31171",
    "format": 1
   },
   {
    "name": "plugins/modules/rack_power.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "3079d5becf27488f381b50d6974114bb1b6e4b5f64e633aadf01956911ccfd25",
+   "chksum_sha256": "b5cfb941bbcd420788e73e88e3383b74c3d8eb4d4b70123bc47f33d8114cf984",
    "format": 1
   },
   {
@@ -403,77 +375,77 @@
    "name": "plugins/modules/rack_validation.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "3bc9264c097b69da107976ca2bfbdfb81585f350ef967627f0e81899f705790e",
+   "chksum_sha256": "02540c39806aa0f722fad6dea9815ff2d6fbd1a8776fbe62ad9e205f11ce9754",
    "format": 1
   },
   {
    "name": "plugins/modules/service_account_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "77793e510f958ef56913f1ce589dec837eb311fe9a6e6bf327138c9fad11f3ab",
+   "chksum_sha256": "c5f80c7e19bdf47cfa9660f3d3549c40e824d630f6bdaf92ce7183ab9cd217e2",
    "format": 1
   },
   {
    "name": "plugins/modules/site.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "9e4e78f56e941a882b936ec172c9b9dcb56b3c025f6865e08b12365092a9ea39",
+   "chksum_sha256": "ea30c534eb1795a6ae8f0c74e99421e97f71ba6cafbdb9dbcea02f9d2a06614e",
    "format": 1
   },
   {
    "name": "plugins/modules/site_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "a90a4d02c5a6ce56d3a3b6ef0bc19f6711fe8ac43c55b0456170bee24e690076",
+   "chksum_sha256": "5f8953eeee16935eb30b9f620f7963cdb55345dd4075c33a94874f50e51cc16c",
    "format": 1
   },
   {
    "name": "plugins/modules/sku_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "e7953349b42d2cb095753e561f9b709120a3f51904ea369c66add14e1ba42c81",
+   "chksum_sha256": "a36426f1397b6725802475291c3e5e38243a5e2f3f49e3969c90efd268dd2eb6",
    "format": 1
   },
   {
    "name": "plugins/modules/ssh_key.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "91efa545cf1b19288b8d2b54e9c6d333f2ba8b607457e58573a49e48689207b6",
+   "chksum_sha256": "72378ec39aa9e95bde3abf5e7ed76f65dc43c8d6465c3ab5773fbf7854fc97fd",
    "format": 1
   },
   {
    "name": "plugins/modules/ssh_key_group.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "3ed6c679645f10e676527ca27b1f7ceeadb1cac52deb6de652aeb3a70a29f57a",
+   "chksum_sha256": "64de2bb9ec07e82ac3b7619f9cb143024e8947005b1bd4998579a0310e49a99f",
    "format": 1
   },
   {
    "name": "plugins/modules/ssh_key_group_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "6e37b5d62750a0d53a83c424ebba6dd6ea270577c0c996abb8a6b4b6fb0d9014",
+   "chksum_sha256": "ac57cde332af6fb0c4a20fa1c6814e48aca3d4added9393cbd9eb4e63a2480a1",
    "format": 1
   },
   {
    "name": "plugins/modules/ssh_key_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "212a79c1cbf4377dd47cdea7f895e239dae37c102319f152e375c979af72e3dc",
+   "chksum_sha256": "649dcd84db4e5439f57d78ae90560106b3a1b29fdb793bffb9973046fa45519e",
    "format": 1
   },
   {
    "name": "plugins/modules/subnet.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "2f76a5decbab7f3e0d411be1e3d67e7dd78bd2a09852b63750f89775df4c6900",
+   "chksum_sha256": "fd3ccd57cebf79011e3b58ebe3e705126e04d695d8cdac5c760ee425d6f5f8c1",
    "format": 1
   },
   {
    "name": "plugins/modules/subnet_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "66364a56e47c814cfcac6459b07505ca2fcc7c3d7515ccd4864974da1b737454",
+   "chksum_sha256": "754bcdbecc35503a383c29c58b384a1ce9ca654e9de182744d744d8b21a7c90b",
    "format": 1
   },
   {
@@ -487,91 +459,105 @@
    "name": "plugins/modules/tenant_account_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "08905c4a5b5bc3ca5672696bcaceb08caf56f2b313520616a249e96ce8ee2c17",
+   "chksum_sha256": "3f7a88946bc7c28f61832a1e94ea58d008e9d76c9f95bd133292c550204543a4",
    "format": 1
   },
   {
    "name": "plugins/modules/tenant_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "4f6bfed2be0e0b32bcc9ce1698827d2a060f13344e2a389c8b8e184434c78930",
+   "chksum_sha256": "8e624083dabb8a34de31c47632aac6a245580d7d4899587682f8eb551ccfc287",
    "format": 1
   },
   {
    "name": "plugins/modules/tray_firmware.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "57550e43fb4a00401c45f3c832418b7881c04121ec190db3fda90d2993950146",
+   "chksum_sha256": "cb91542e4b59a892f77c48420776d74dba948e2d3eb7cde7307fb8527c7e3d38",
    "format": 1
   },
   {
    "name": "plugins/modules/tray_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "178bea68cf9480e376fef6b74ca53c7e575f7784ecf99e02b428608625b45638",
+   "chksum_sha256": "4b2bfa9b0ea64d2b4d8de358bdfebfbf1d0a7f4d86634849c9012828cfd7ba97",
    "format": 1
   },
   {
    "name": "plugins/modules/tray_power.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "833989f5a783a77a35265aaa4e29be5dac18964c3ab4eb2a4c85d10d86a0da81",
+   "chksum_sha256": "4c12f4e725a93d85bd8125b70dc9688844903f1f7ec9b5d2123c8fa6d35e2120",
    "format": 1
   },
   {
    "name": "plugins/modules/tray_validation.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "5fbcf41ad745b387afd2317df6b942278d787fb74991f240296a32e84b578fd1",
+   "chksum_sha256": "6198aeee40fd3dce00bca01b9c23f4beb984c72e847042ab2fec849968a5fa04",
    "format": 1
   },
   {
    "name": "plugins/modules/user_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "54b8eb1d91397e7db54a98669f1ef8e4a72fb1e9924596b5fb3a5fd2eaf662c3",
+   "chksum_sha256": "4b8f259d2e27fccd6cb90efaab140ac40d52019cdf7b7b69e4f509ba126820ed",
    "format": 1
   },
   {
    "name": "plugins/modules/vpc.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "dc53486eb11aad0bc269f7621d3284ac058baa4995eae8ee4e6e9292792a8d2a",
+   "chksum_sha256": "66c6273b246add79157939c5afb98bdf8df57107ad97a7a235b3411f37100eb7",
    "format": 1
   },
   {
    "name": "plugins/modules/vpc_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "46c70bb12650c5ad5011f0562f4c2b6ebd92dba75163e0d07c8fbc75ac02754c",
+   "chksum_sha256": "830d59495e10309d7711369e26bc9968bd651bc0e8cd76cc66cfe56c9278b0e8",
    "format": 1
   },
   {
    "name": "plugins/modules/vpc_peering.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "fc2d6b2c671aa5583ebe304d5186fb4b2c33bc2083799c2ffdeb41d9a36d79ac",
+   "chksum_sha256": "4b729a25e7fe3c4f9547d7f68fe4bcbbb0327dc4ef3d7eada94fbe4e7ba4ec0c",
    "format": 1
   },
   {
    "name": "plugins/modules/vpc_peering_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "10c4a4a387cdadf337f61f6a3e288391247496eaa1d0a55068615c869b068ae6",
+   "chksum_sha256": "13163ed5b50ee2ee838ac9a11a91955988a053f3ccec648c4e32b86968934e5f",
    "format": 1
   },
   {
    "name": "plugins/modules/vpc_prefix.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "007616761a6aace9b45ff5147e23b4c742d796dc805f46b827219d9a64305639",
+   "chksum_sha256": "61fd3007d1d9d74834f88129a8051b9a7b14942a5692f10885cb89bb26ae9a77",
    "format": 1
   },
   {
    "name": "plugins/modules/vpc_prefix_info.py",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "564244584aabfa7470ffe4a57179b9ec8ac23b1a886962e8dd5e3ab0cefd144a",
+   "chksum_sha256": "ddbc29d6e7ecbbcf639ad0faa435c04daeb160651a4de6880ed6f71001c1946f",
+   "format": 1
+  },
+  {
+   "name": "plugins/inventory",
+   "ftype": "dir",
+   "chksum_type": null,
+   "chksum_sha256": null,
+   "format": 1
+  },
+  {
+   "name": "plugins/inventory/bmm.py",
+   "ftype": "file",
+   "chksum_type": "sha256",
+   "chksum_sha256": "6a0f368d99e4b0cd5d9e0dee1d62096e3b3c10562d67fee01849156aedd96f78",
    "format": 1
   },
   {
@@ -579,13 +565,6 @@
    "ftype": "dir",
    "chksum_type": null,
    "chksum_sha256": null,
-   "format": 1
-  },
-  {
-   "name": "scripts/generate.py",
-   "ftype": "file",
-   "chksum_type": "sha256",
-   "chksum_sha256": "3e8386d4d2688f0f374d5196e299aaf032ac95a3a9f65018e46a212dc2b574c8",
    "format": 1
   },
   {
@@ -603,6 +582,13 @@
    "format": 1
   },
   {
+   "name": "scripts/generate.py",
+   "ftype": "file",
+   "chksum_type": "sha256",
+   "chksum_sha256": "3e8386d4d2688f0f374d5196e299aaf032ac95a3a9f65018e46a212dc2b574c8",
+   "format": 1
+  },
+  {
    "name": "tests",
    "ftype": "dir",
    "chksum_type": null,
@@ -614,13 +600,6 @@
    "ftype": "file",
    "chksum_type": "sha256",
    "chksum_sha256": "cc7e2d01c739a620d7101f2f4554c2fa3d883b4801510beeb8ddbc62a071b575",
-   "format": 1
-  },
-  {
-   "name": "tests/conftest.py",
-   "ftype": "file",
-   "chksum_type": "sha256",
-   "chksum_sha256": "48c59aa41ef3ed28e1099230b24f1cb22ceabed4a4ee63683f459fbf3edfb294",
    "format": 1
   },
   {
@@ -638,17 +617,17 @@
    "format": 1
   },
   {
-   "name": "tests/unit/test_client.py",
-   "ftype": "file",
-   "chksum_type": "sha256",
-   "chksum_sha256": "7ff12aee50f579cbe1b3c804fe7b7c20771b87bbbbfb86b66ed80ce42a229ab7",
-   "format": 1
-  },
-  {
    "name": "tests/unit/test_common.py",
    "ftype": "file",
    "chksum_type": "sha256",
    "chksum_sha256": "df08e759199044aa2a5ca1a27c4510c94ff56183ea04c780b4f3823abbd142a5",
+   "format": 1
+  },
+  {
+   "name": "tests/unit/test_client.py",
+   "ftype": "file",
+   "chksum_type": "sha256",
+   "chksum_sha256": "7ff12aee50f579cbe1b3c804fe7b7c20771b87bbbbfb86b66ed80ce42a229ab7",
    "format": 1
   },
   {
@@ -663,6 +642,27 @@
    "ftype": "file",
    "chksum_type": "sha256",
    "chksum_sha256": "81125ba0f66b4ea6b2d8775bce917daf2d8ee50339788a4e456a82af70448527",
+   "format": 1
+  },
+  {
+   "name": "tests/conftest.py",
+   "ftype": "file",
+   "chksum_type": "sha256",
+   "chksum_sha256": "48c59aa41ef3ed28e1099230b24f1cb22ceabed4a4ee63683f459fbf3edfb294",
+   "format": 1
+  },
+  {
+   "name": "Makefile",
+   "ftype": "file",
+   "chksum_type": "sha256",
+   "chksum_sha256": "8c2bf2daf6dd9fcf1d9c3bec7f2225ec145e16264a645d91ee8d35b1fc6223fd",
+   "format": 1
+  },
+  {
+   "name": "README.md",
+   "ftype": "file",
+   "chksum_type": "sha256",
+   "chksum_sha256": "b8e2ba476e1e0ed87fad74f9b69f93c3d165625015cebb117ba5cb61ae01d7ee",
    "format": 1
   }
  ],

--- a/vendor/ansible_collections/nvidia/bare_metal/MANIFEST.json
+++ b/vendor/ansible_collections/nvidia/bare_metal/MANIFEST.json
@@ -2,7 +2,7 @@
  "collection_info": {
   "namespace": "nvidia",
   "name": "bare_metal",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "authors": [
    "NVIDIA Bare Metal Manager Dev Team"
   ],
@@ -27,7 +27,7 @@
   "name": "FILES.json",
   "ftype": "file",
   "chksum_type": "sha256",
-  "chksum_sha256": "60b060d69a6e0655b2aa2317797c69fbe80436a8d29764d92da79b49627fa2d2",
+  "chksum_sha256": "67665f57704218b1158aad131294f091554bf868696da854ee87b51f65a07dcf",
   "format": 1
  },
  "format": 1

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/allocation.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/allocation.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.allocation
 short_description: Manage Allocation resources
 description:
-- Allocation operations
+- Allocations are the mechanism by which Provider can delegate Network and Compute resources to Tenant.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -43,6 +43,7 @@ options:
         type: str
         description:
         - resource_type parameter.
+        required: true
         choices:
         - InstanceType
         - IPBlock
@@ -58,7 +59,7 @@ options:
   description:
     type: str
     description:
-    - description parameter.
+    - Detailed description for the Allocation
   id:
     type: str
     description:
@@ -66,11 +67,11 @@ options:
   name:
     type: str
     description:
-    - name parameter.
+    - Concise and descriptive name for the Allocation
   site_id:
     type: str
     description:
-    - site_id parameter.
+    - ID of the Site where resources should be allocated
   state:
     type: str
     description:
@@ -81,7 +82,7 @@ options:
   tenant_id:
     type: str
     description:
-    - tenant_id parameter.
+    - ID of the Tenant that should receive the Allocation
   wait:
     type: bool
     description:
@@ -128,7 +129,7 @@ ARGUMENT_SPEC = dict(
 allocation_constraints=dict(type='list', elements='dict', options=dict(
     constraint_type=dict(type='str', required=True, choices=['Reserved', 'OnDemand', 'Preemptible']),
     constraint_value=dict(type='int', required=True),
-    resource_type=dict(type='str', choices=['InstanceType', 'IPBlock']),
+    resource_type=dict(type='str', required=True, choices=['InstanceType', 'IPBlock']),
     resource_type_id=dict(type='str', required=True),
 )),
 allocation_id=dict(type='str'),

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/allocation_constraint.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/allocation_constraint.py
@@ -30,7 +30,7 @@ options:
   constraint_type:
     type: str
     description:
-    - constraint_type parameter.
+    - Type of the Allocation Constraint. Please note that OnDemand and Preemptible are not supported by current implementation.
     choices:
     - Reserved
     - OnDemand
@@ -38,7 +38,8 @@ options:
   constraint_value:
     type: int
     description:
-    - constraint_value parameter.
+    - Value of the Allocation Constraint. For InstanceType, this value represents number of Machines allocated for Tenant.
+      For IPBlock, this value represents the prefix Length of the IP Block.
   id:
     type: str
     description:
@@ -46,14 +47,15 @@ options:
   resource_type:
     type: str
     description:
-    - resource_type parameter.
+    - Type of the Resource that the Allocation Constraint applies to
     choices:
     - InstanceType
     - IPBlock
   resource_type_id:
     type: str
     description:
-    - resource_type_id parameter.
+    - ID of the Resource Type that the Allocation Constraint applies to. For InstanceType, this is the ID of the Instance
+      Type. For IPBlock, this is the ID of the IP Block.
   state:
     type: str
     description:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/allocation_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/allocation_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.allocation_info
 short_description: Retrieve Allocation information
 description:
-- Allocation operations
+- Allocations are the mechanism by which Provider can delegate Network and Compute resources to Tenant.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -42,7 +42,7 @@ options:
   infrastructure_provider_id:
     type: str
     description:
-    - Filter Allocations by Infrastructure Provider ID
+    - Filter Allocations by Infrastructure Provider ID.
   query:
     type: str
     description:
@@ -71,7 +71,7 @@ options:
   tenant_id:
     type: str
     description:
-    - Filter Allocations by Tenant ID.  Can be specified multiple times to filter on more than one Tenant ID.
+    - Filter Allocations by Tenant ID.
 '''
 
 EXAMPLES = r'''

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/audit_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/audit_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.audit_info
 short_description: Retrieve Audit information
 description:
-- Audit operations
+- Audit is a record of actions taken by users on the API.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/dpu_extension_service.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/dpu_extension_service.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.dpu_extension_service
 short_description: Manage DPU Extension Service resources
 description:
-- DPU Extension Service allows users to run custom services in the DPUs of their Instances
+- DPU Extension Service allows users to run custom services in the DPUs of their Instances. Currently K8s pods are the only
+  supported service type.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/dpu_extension_service_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/dpu_extension_service_info.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.dpu_extension_service_info
 short_description: Retrieve DPU Extension Service information
 description:
-- DPU Extension Service allows users to run custom services in the DPUs of their Instances
+- DPU Extension Service allows users to run custom services in the DPUs of their Instances. Currently K8s pods are the only
+  supported service type.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_machine.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_machine.py
@@ -13,8 +13,10 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.expected_machine
 short_description: Manage Expected Machine resources
 description:
-- Expected Machine operations allow Infrastructure Providers to pre-register machines that are expected to be discovered at
-  a site.
+- 'Expected Machine identifies a Machine that is expected to be discovered at a Site. Infrastructure Providers can pre-register
+  Expected Machines using BMC credentials
+
+  and serial numbers to help with Machine discovery and ingestion.'
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -24,18 +26,18 @@ options:
     type: str
     description:
     - MAC address of the Expected Machine's BMC (Baseboard Management Controller)
-  bmc_password:
-    type: str
-    description:
-    - Password for accessing the Expected Machine's BMC
-  bmc_username:
-    type: str
-    description:
-    - Username for accessing the Expected Machine's BMC
   chassis_serial_number:
     type: str
     description:
     - Serial number of the Expected Machine's chassis
+  default_bmc_password:
+    type: str
+    description:
+    - Password for accessing the Expected Machine's BMC
+  default_bmc_username:
+    type: str
+    description:
+    - Username for accessing the Expected Machine's BMC
   description:
     type: str
     description:
@@ -148,9 +150,9 @@ from ansible_collections.nvidia.bare_metal.plugins.module_utils.resource import 
 
 ARGUMENT_SPEC = dict(
 bmc_mac_address=dict(type='str'),
-bmc_password=dict(type='str'),
-bmc_username=dict(type='str'),
 chassis_serial_number=dict(type='str'),
+default_bmc_password=dict(type='str'),
+default_bmc_username=dict(type='str'),
 description=dict(type='str'),
 expected_machine_id=dict(type='str'),
 fallback_dpu_serial_numbers=dict(type='list', elements='str'),
@@ -176,8 +178,8 @@ RESOURCE_CONFIG = {
     'resource_item_path': '/v2/org/{org}/carbide/expected-machine/{expectedMachineId}',
     'id_param': 'expectedMachineId',
     'name_field': 'name',
-    'create_schema_fields': ['site_id', 'bmc_mac_address', 'bmc_username', 'bmc_password', 'chassis_serial_number', 'fallback_dpu_serial_numbers', 'sku_id', 'rack_id', 'name', 'manufacturer', 'model', 'description', 'firmware_version', 'slot_id', 'tray_idx', 'host_id', 'labels'],
-    'update_schema_fields': ['id', 'bmc_mac_address', 'bmc_username', 'bmc_password', 'chassis_serial_number', 'fallback_dpu_serial_numbers', 'sku_id', 'rack_id', 'name', 'manufacturer', 'model', 'description', 'firmware_version', 'slot_id', 'tray_idx', 'host_id', 'labels'],
+    'create_schema_fields': ['site_id', 'bmc_mac_address', 'default_bmc_username', 'default_bmc_password', 'chassis_serial_number', 'fallback_dpu_serial_numbers', 'sku_id', 'rack_id', 'name', 'manufacturer', 'model', 'description', 'firmware_version', 'slot_id', 'tray_idx', 'host_id', 'labels'],
+    'update_schema_fields': ['id', 'bmc_mac_address', 'default_bmc_username', 'default_bmc_password', 'chassis_serial_number', 'fallback_dpu_serial_numbers', 'sku_id', 'rack_id', 'name', 'manufacturer', 'model', 'description', 'firmware_version', 'slot_id', 'tray_idx', 'host_id', 'labels'],
     'scope_fields': ['site_id'],
     'ready_statuses': ['Ready'],
     'error_statuses': ['Error'],

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_machine_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_machine_info.py
@@ -13,8 +13,10 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.expected_machine_info
 short_description: Retrieve Expected Machine information
 description:
-- Expected Machine operations allow Infrastructure Providers to pre-register machines that are expected to be discovered at
-  a site.
+- 'Expected Machine identifies a Machine that is expected to be discovered at a Site. Infrastructure Providers can pre-register
+  Expected Machines using BMC credentials
+
+  and serial numbers to help with Machine discovery and ingestion.'
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_power_shelf.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_power_shelf.py
@@ -13,8 +13,10 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.expected_power_shelf
 short_description: Manage Expected Power Shelf resources
 description:
-- Expected Power Shelf operations allow Infrastructure Providers to pre-register power shelves that are expected to be discovered
-  at a site.
+- 'Expected Power Shelf identifies a Power Shelf that is expected to be discovered at a Site. Infrastructure Providers can
+  pre-register Expected Power Shelves using BMC
+
+  credentials and serial numbers to help with Power Shelf discovery and ingestion.'
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_power_shelf_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_power_shelf_info.py
@@ -13,8 +13,10 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.expected_power_shelf_info
 short_description: Retrieve Expected Power Shelf information
 description:
-- Expected Power Shelf operations allow Infrastructure Providers to pre-register power shelves that are expected to be discovered
-  at a site.
+- 'Expected Power Shelf identifies a Power Shelf that is expected to be discovered at a Site. Infrastructure Providers can
+  pre-register Expected Power Shelves using BMC
+
+  credentials and serial numbers to help with Power Shelf discovery and ingestion.'
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_switch.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_switch.py
@@ -13,8 +13,10 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.expected_switch
 short_description: Manage Expected Switch resources
 description:
-- Expected Switch operations allow Infrastructure Providers to pre-register network switches that are expected to be discovered
-  at a site.
+- 'Expected Switch identifies a Switch that is expected to be discovered at a Site. Infrastructure Providers can pre-register
+  Expected Switches using BMC, NvOS credentials
+
+  and serial numbers to help with Switch discovery and ingestion.'
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_switch_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/expected_switch_info.py
@@ -13,8 +13,10 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.expected_switch_info
 short_description: Retrieve Expected Switch information
 description:
-- Expected Switch operations allow Infrastructure Providers to pre-register network switches that are expected to be discovered
-  at a site.
+- 'Expected Switch identifies a Switch that is expected to be discovered at a Site. Infrastructure Providers can pre-register
+  Expected Switches using BMC, NvOS credentials
+
+  and serial numbers to help with Switch discovery and ingestion.'
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/infiniband_partition.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/infiniband_partition.py
@@ -13,7 +13,11 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.infiniband_partition
 short_description: Manage InfiniBand Partition resources
 description:
-- Partitions provide networking support for high-performance computing that features very high throughput and very low latency.
+- 'InfiniBand (IB) is a high-performance, low-latency networking standard designed for interconnecting servers and storage
+  in HPC (High-Performance Computing) and AI systems,
+
+  utilizing RDMA (Remote Direct Memory Access) to reduce CPU overhead. InfiniBand Partitions are used to group Machines into
+  logical partitions for network isolation and load distribution.'
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -31,6 +35,10 @@ options:
     type: str
     description:
     - 'ID path parameter: infini_band_partition_id.'
+  labels:
+    type: dict
+    description:
+    - String key value pairs describing Partition labels. Up to 10 key value pairs can be specified
   name:
     type: str
     description:
@@ -92,6 +100,7 @@ ARGUMENT_SPEC = dict(
 description=dict(type='str'),
 id=dict(type='str'),
 infini_band_partition_id=dict(type='str'),
+labels=dict(type='dict'),
 name=dict(type='str'),
 site_id=dict(type='str'),
 state=dict(type='str', choices=['present', 'absent']),
@@ -104,8 +113,8 @@ RESOURCE_CONFIG = {
     'resource_item_path': '/v2/org/{org}/carbide/infiniband-partition/{infiniBandPartitionId}',
     'id_param': 'infiniBandPartitionId',
     'name_field': 'name',
-    'create_schema_fields': ['name', 'description', 'site_id'],
-    'update_schema_fields': ['name', 'description'],
+    'create_schema_fields': ['name', 'description', 'site_id', 'labels'],
+    'update_schema_fields': ['name', 'description', 'labels'],
     'scope_fields': ['site_id'],
     'ready_statuses': ['Ready'],
     'error_statuses': ['Error'],

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/infiniband_partition_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/infiniband_partition_info.py
@@ -13,7 +13,11 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.infiniband_partition_info
 short_description: Retrieve InfiniBand Partition information
 description:
-- Partitions provide networking support for high-performance computing that features very high throughput and very low latency.
+- 'InfiniBand (IB) is a high-performance, low-latency networking standard designed for interconnecting servers and storage
+  in HPC (High-Performance Computing) and AI systems,
+
+  utilizing RDMA (Remote Direct Memory Access) to reduce CPU overhead. InfiniBand Partitions are used to group Machines into
+  logical partitions for network isolation and load distribution.'
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/infrastructure_provider_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/infrastructure_provider_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.infrastructure_provider_info
 short_description: Retrieve Infrastructure Provider information
 description:
-- Infrastructure Provider issues a unique identifier for a Provider and contains information about their Org
+- Infrastructure Provider is the anchor entity for an organization that owns and manages Site resources.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/instance.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/instance.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.instance
 short_description: Manage Instance resources
 description:
-- Instance is a Machine provisioned with an Operating System for a Tenant and attached to one or more Subnets
+- Instance is a Machine provisioned with an Operating System by a Tenant and attached to one or more VPC Prefixes or Subnets.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -22,8 +22,8 @@ options:
   allow_unhealthy_machine:
     type: bool
     description:
-    - Must be set to true creating a targeted Instance with a Machine that is in Error status. Requires Targeted Instance
-      Creation capability enabled for Tenant
+    - Set to true in order to target Machines are in maintenance or have health alerts preventing regular provision flow.
+      Requires Targeted Instance Creation capability enabled for Tenant
   always_boot_with_custom_ipxe:
     type: bool
     description:
@@ -204,6 +204,13 @@ options:
     description:
     - When specified along with triggerReboot, the Instance will boot using the custom iPXE specified by OS. If Instance has
       alwaysBootWithCustomIpxe flag set then this value will be ignored.
+  secondary_vpc_ids:
+    type: list
+    description:
+    - IDs of additional VPCs the Instance should attach to through non-primary interfaces. This field may only be specified
+      when every entry in `interfaces` uses `vpcPrefixId`. IDs must be unique, must be valid UUIDs, and must not include the
+      primary `vpcId`.
+    elements: str
   ssh_key_group_ids:
     type: list
     description:
@@ -321,6 +328,7 @@ nv_link_interfaces=dict(type='list', elements='dict', options=dict(
 operating_system_id=dict(type='str'),
 phone_home_enabled=dict(type='bool'),
 reboot_with_custom_ipxe=dict(type='bool'),
+secondary_vpc_ids=dict(type='list', elements='str'),
 ssh_key_group_ids=dict(type='list', elements='str'),
 state=dict(type='str', choices=['present', 'absent']),
 tenant_id=dict(type='str'),
@@ -336,8 +344,8 @@ RESOURCE_CONFIG = {
     'resource_item_path': '/v2/org/{org}/carbide/instance/{instanceId}',
     'id_param': 'instanceId',
     'name_field': 'name',
-    'create_schema_fields': ['name', 'description', 'tenant_id', 'instance_type_id', 'machine_id', 'vpc_id', 'user_data', 'operating_system_id', 'network_security_group_id', 'ipxe_script', 'always_boot_with_custom_ipxe', 'phone_home_enabled', 'labels', 'interfaces', 'infiniband_interfaces', 'dpu_extension_service_deployments', 'nv_link_interfaces', 'ssh_key_group_ids', 'allow_unhealthy_machine'],
-    'update_schema_fields': ['name', 'description', 'trigger_reboot', 'reboot_with_custom_ipxe', 'apply_updates_on_reboot', 'operating_system_id', 'ipxe_script', 'ssh_key_group_ids', 'network_security_group_id', 'user_data', 'always_boot_with_custom_ipxe', 'phone_home_enabled', 'labels', 'interfaces', 'infiniband_interfaces', 'nv_link_interfaces', 'dpu_extension_service_deployments'],
+    'create_schema_fields': ['name', 'description', 'tenant_id', 'instance_type_id', 'machine_id', 'vpc_id', 'secondary_vpc_ids', 'user_data', 'operating_system_id', 'network_security_group_id', 'ipxe_script', 'always_boot_with_custom_ipxe', 'phone_home_enabled', 'labels', 'interfaces', 'infiniband_interfaces', 'dpu_extension_service_deployments', 'nv_link_interfaces', 'ssh_key_group_ids', 'allow_unhealthy_machine'],
+    'update_schema_fields': ['name', 'description', 'trigger_reboot', 'reboot_with_custom_ipxe', 'apply_updates_on_reboot', 'operating_system_id', 'ipxe_script', 'ssh_key_group_ids', 'network_security_group_id', 'user_data', 'always_boot_with_custom_ipxe', 'phone_home_enabled', 'labels', 'secondary_vpc_ids', 'interfaces', 'infiniband_interfaces', 'nv_link_interfaces', 'dpu_extension_service_deployments'],
     'scope_fields': [],
     'ready_statuses': ['Ready'],
     'error_statuses': ['Error'],

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/instance_batch.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/instance_batch.py
@@ -161,6 +161,13 @@ options:
     type: bool
     description:
     - When set to true, the Instances will be enabled with the Phone Home service.
+  secondary_vpc_ids:
+    type: list
+    description:
+    - IDs of additional VPCs the Instances should attach to through non-primary interfaces. This field may only be specified
+      when every entry in `interfaces` uses `vpcPrefixId`. IDs must be unique, must be valid UUIDs, and must not include the
+      primary `vpcId`.
+    elements: str
   ssh_key_group_ids:
     type: list
     description:
@@ -246,6 +253,7 @@ nv_link_interfaces=dict(type='list', elements='dict', options=dict(
 )),
 operating_system_id=dict(type='str'),
 phone_home_enabled=dict(type='bool'),
+secondary_vpc_ids=dict(type='list', elements='str'),
 ssh_key_group_ids=dict(type='list', elements='str'),
 tenant_id=dict(type='str', required=True),
 topology_optimized=dict(type='bool'),
@@ -255,7 +263,7 @@ vpc_id=dict(type='str', required=True),
 
 RESOURCE_CONFIG = {
     'resource_path': '/v2/org/{org}/carbide/instance/batch',
-    'create_schema_fields': ['name_prefix', 'count', 'description', 'tenant_id', 'instance_type_id', 'vpc_id', 'user_data', 'operating_system_id', 'network_security_group_id', 'ipxe_script', 'always_boot_with_custom_ipxe', 'phone_home_enabled', 'labels', 'interfaces', 'infiniband_interfaces', 'dpu_extension_service_deployments', 'nv_link_interfaces', 'ssh_key_group_ids', 'topology_optimized'],
+    'create_schema_fields': ['name_prefix', 'count', 'description', 'tenant_id', 'instance_type_id', 'vpc_id', 'secondary_vpc_ids', 'user_data', 'operating_system_id', 'network_security_group_id', 'ipxe_script', 'always_boot_with_custom_ipxe', 'phone_home_enabled', 'labels', 'interfaces', 'infiniband_interfaces', 'dpu_extension_service_deployments', 'nv_link_interfaces', 'ssh_key_group_ids', 'topology_optimized'],
 }
 
 

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/instance_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/instance_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.instance_info
 short_description: Retrieve Instance information
 description:
-- Instance is a Machine provisioned with an Operating System for a Tenant and attached to one or more Subnets
+- Instance is a Machine provisioned with an Operating System by a Tenant and attached to one or more VPC Prefixes or Subnets.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/instance_type.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/instance_type.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.instance_type
 short_description: Manage Instance Type resources
 description:
-- Instance Types allow grouping two or more Machines into a pool which can be specified when creating an Instance.
+- Instance Types allow grouping Machines into a pool defined by their capabilities. Providers can then allocate a portion
+  of the Instance Type pool to a Tenant.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/instance_type_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/instance_type_info.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.instance_type_info
 short_description: Retrieve Instance Type information
 description:
-- Instance Types allow grouping two or more Machines into a pool which can be specified when creating an Instance.
+- Instance Types allow grouping Machines into a pool defined by their capabilities. Providers can then allocate a portion
+  of the Instance Type pool to a Tenant.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -39,7 +40,7 @@ options:
   infrastructure_provider_id:
     type: str
     description:
-    - Filter Instance Types by Infrastructure Provider ID
+    - Filter Instance Types by Infrastructure Provider ID.
   instance_type_id:
     type: str
     description:
@@ -60,7 +61,7 @@ options:
   tenant_id:
     type: str
     description:
-    - Filter Instance Types by Tenant ID
+    - Filter Instance Types by Tenant ID.
 '''
 
 EXAMPLES = r'''

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ip_block.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ip_block.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.ip_block
 short_description: Manage IP Block resources
 description:
-- IP Block is a set of IP addresses defined by a prefix and prefix length.
+- IP Block is a contiguous block of IP addresses defined by a prefix and prefix length.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ip_block_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ip_block_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.ip_block_info
 short_description: Retrieve IP Block information
 description:
-- IP Block is a set of IP addresses defined by a prefix and prefix length.
+- IP Block is a contiguous block of IP addresses defined by a prefix and prefix length.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/machine.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/machine.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.machine
 short_description: Manage Machine resources
 description:
-- Machine operations
+- Machine is a physical server that contains CPUs, GPUs, memory, storage, and networking hardware. Machines are the physical
+  building blocks of a Site.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/machine_capability_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/machine_capability_info.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.machine_capability_info
 short_description: Retrieve Machine Capability information
 description:
-- Machine Capability operations
+- Machine Capability defines the hardware capabilities of a Machine. Machine Capabilities can be used to group Machines into
+  Instance Types.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/machine_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/machine_info.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.machine_info
 short_description: Retrieve Machine information
 description:
-- Machine operations
+- Machine is a physical server that contains CPUs, GPUs, memory, storage, and networking hardware. Machines are the physical
+  building blocks of a Site.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/metadata_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/metadata_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.metadata_info
 short_description: Retrieve Metadata information
 description:
-- Metadata describes various system level attributes of the API server
+- Metadata describes various system level attributes of the API service.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/network_security_group.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/network_security_group.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.network_security_group
 short_description: Manage Network Security Group resources
 description:
-- Network Security Group operations
+- Network Security Group is a security policy that controls the traffic flowing between Instances.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/network_security_group_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/network_security_group_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.network_security_group_info
 short_description: Retrieve Network Security Group information
 description:
-- Network Security Group operations
+- Network Security Group is a security policy that controls the traffic flowing between Instances.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/nvlink_logical_partition.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/nvlink_logical_partition.py
@@ -13,8 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.nvlink_logical_partition
 short_description: Manage NVLink Logical Partition resources
 description:
-- NVLink Logical Partitions provide networking support for high-performance computing that features very high throughput and
-  very low latency for GPU to GPU communication.
+- NVLink Logical Partitions are used to group GPUs into logical partitions for shared memory and low-latency direct communication
+  between GPUs.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/nvlink_logical_partition_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/nvlink_logical_partition_info.py
@@ -13,8 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.nvlink_logical_partition_info
 short_description: Retrieve NVLink Logical Partition information
 description:
-- NVLink Logical Partitions provide networking support for high-performance computing that features very high throughput and
-  very low latency for GPU to GPU communication.
+- NVLink Logical Partitions are used to group GPUs into logical partitions for shared memory and low-latency direct communication
+  between GPUs.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/operating_system.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/operating_system.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.operating_system
 short_description: Manage Operating System resources
 description:
-- Operating System operations
+- Operating Systems in NICo are typically iPXE scripts that are used to boot Machines.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -59,7 +59,7 @@ options:
   infrastructure_provider_id:
     type: str
     description:
-    - Specified if a Provider owns the Operating System
+    - 'Deprecated: Infrastructure Provider is now inferred from org membership.'
   ipxe_script:
     type: str
     description:
@@ -107,7 +107,7 @@ options:
   tenant_id:
     type: str
     description:
-    - Specified if a Tenant owns the Operating System
+    - 'Deprecated: Tenant is now inferred from org membership.'
   user_data:
     type: str
     description:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/operating_system_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/operating_system_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.operating_system_info
 short_description: Retrieve Operating System information
 description:
-- Operating System operations
+- Operating Systems in NICo are typically iPXE scripts that are used to boot Machines.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/rack_firmware.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/rack_firmware.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.rack_firmware
 short_description: Manage Rack resources
 description:
-- Rack operations
+- Rack is a physical enclosure that contains a number of Machines. Racks are the physical building blocks of a Site.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/rack_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/rack_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.rack_info
 short_description: Retrieve Rack information
 description:
-- Rack operations
+- Rack is a physical enclosure that contains a number of Machines. Racks are the physical building blocks of a Site.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/rack_power.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/rack_power.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.rack_power
 short_description: Manage Rack resources
 description:
-- Rack operations
+- Rack is a physical enclosure that contains a number of Machines. Racks are the physical building blocks of a Site.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/rack_validation.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/rack_validation.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.rack_validation
 short_description: Manage Rack resources
 description:
-- Rack operations
+- Rack is a physical enclosure that contains a number of Machines. Racks are the physical building blocks of a Site.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/service_account_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/service_account_info.py
@@ -13,7 +13,10 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.service_account_info
 short_description: Retrieve Service Account information
 description:
-- When API service is configured in Service Account mode, API users can act as both Provider and Tenant
+- 'When API service is configured in Service Account mode, API users can act as both Provider and Tenant. For service accounts,
+  the Tenant entity is initialized as a
+
+  privileged Tenant with `targetedInstanceCreation` capability enabled.'
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/site.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/site.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.site
 short_description: Manage Site resources
 description:
-- Site operations
+- Site is a datacenter that contains physical hardware and networking resources. All resources created by Provider or Tenant
+  are directly or indirectly anchored to the Site object.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -31,7 +32,7 @@ options:
   description:
     type: str
     description:
-    - description parameter.
+    - Description for the Site
   id:
     type: str
     description:
@@ -39,11 +40,13 @@ options:
   is_serial_console_enabled:
     type: bool
     description:
-    - Enable/disable Serial Console. Can only be updated by Provider
+    - Enable/disable Serial Console. Can only be updated by Provider. Modifying this attribute has no actual effect on SOL.
+      It will be removed in a future API version.
   is_serial_console_ssh_keys_enabled:
     type: bool
     description:
-    - Enable/disable Serial Console access using SSH Keys. Can only be updated by Tenant
+    - Enable/disable Serial Console access using SSH Keys. Previously updateable only by Tenants, modifying this value is
+      no longer supported, update SSH Key Groups to remove Site instead.
   location:
     type: dict
     description:
@@ -64,7 +67,7 @@ options:
   name:
     type: str
     description:
-    - name parameter.
+    - Name for the Site
   renew_registration_token:
     type: bool
     description:
@@ -76,11 +79,13 @@ options:
   serial_console_idle_timeout:
     type: int
     description:
-    - Maximum idle time in seconds before Serial Console is disconnected. Can only be updated by Provider
+    - Maximum idle time in seconds before Serial Console is disconnected. Can only be updated by Provider. Modifying this
+      attribute has no actual effect on SOL. It will be removed in a future API version.
   serial_console_max_session_length:
     type: int
     description:
-    - Maximum length of Serial Console session in seconds. Can only be updated by Provider
+    - Maximum length of Serial Console session in seconds. Can only be updated by Provider. Modifying this attribute has no
+      actual effect on SOL. It will be removed in a future API version.
   site_id:
     type: str
     description:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/site_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/site_info.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.site_info
 short_description: Retrieve Site information
 description:
-- Site operations
+- Site is a datacenter that contains physical hardware and networking resources. All resources created by Provider or Tenant
+  are directly or indirectly anchored to the Site object.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/sku_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/sku_info.py
@@ -13,8 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.sku_info
 short_description: Retrieve SKU information
 description:
-- SKU (Stock Keeping Unit) operations allow Infrastructure Providers to retrieve hardware configurations discovered at their
-  sites.
+- SKU (Stock Keeping Unit) defines one or more hardware configurations or Machine Bill of Materials (BOM).
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ssh_key.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ssh_key.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.ssh_key
 short_description: Manage SSH Key resources
 description:
-- SSH Key allows access to Serial Console
+- SSH Key is a public key that can be used to access the Serial Console of an Instance.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ssh_key_group.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ssh_key_group.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.ssh_key_group
 short_description: Manage SSH Key Group resources
 description:
-- SSH Key Groups allow binding several SSH Keys together so they can be applied to Sites or other entities as a unit
+- SSH Key Groups allow grouping several SSH Keys together so they can be synced to Sites and used to access the Serial Console
+  of Instances.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ssh_key_group_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ssh_key_group_info.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.ssh_key_group_info
 short_description: Retrieve SSH Key Group information
 description:
-- SSH Key Groups allow binding several SSH Keys together so they can be applied to Sites or other entities as a unit
+- SSH Key Groups allow grouping several SSH Keys together so they can be synced to Sites and used to access the Serial Console
+  of Instances.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ssh_key_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/ssh_key_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.ssh_key_info
 short_description: Retrieve SSH Key information
 description:
-- SSH Key allows access to Serial Console
+- SSH Key is a public key that can be used to access the Serial Console of an Instance.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/subnet.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/subnet.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.subnet
 short_description: Manage Subnet resources
 description:
-- Subnets are networking constructs that connect a set of bare metal machines.
+- Subnet is a network prefix belonging to an IP Block allocated to a Tenant. Tenant can use Subnets to enable network connectivity
+  between their Instances.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/subnet_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/subnet_info.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.subnet_info
 short_description: Retrieve Subnet information
 description:
-- Subnets are networking constructs that connect a set of bare metal machines.
+- Subnet is a network prefix belonging to an IP Block allocated to a Tenant. Tenant can use Subnets to enable network connectivity
+  between their Instances.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tenant_account_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tenant_account_info.py
@@ -32,6 +32,10 @@ options:
     type: str
     description:
     - Filter TenantAccounts by Infrastructure Provider ID
+  query:
+    type: str
+    description:
+    - Search string to filter Tenant Accounts by account number, tenant org, or tenant org display name
   tenant_id:
     type: str
     description:
@@ -76,6 +80,7 @@ ARGUMENT_SPEC = dict(
 account_id=dict(type='str'),
 id=dict(type='str'),
 infrastructure_provider_id=dict(type='str'),
+query=dict(type='str'),
 tenant_id=dict(type='str'),
 )
 
@@ -83,7 +88,7 @@ RESOURCE_CONFIG = {
     'resource_path': '/v2/org/{org}/carbide/tenant/account',
     'resource_item_path': '/v2/org/{org}/carbide/tenant/account/{accountId}',
     'id_param': 'accountId',
-    'filter_fields': ['infrastructure_provider_id', 'tenant_id'],
+    'filter_fields': ['infrastructure_provider_id', 'tenant_id', 'query'],
 }
 
 

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tenant_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tenant_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.tenant_info
 short_description: Retrieve Tenant information
 description:
-- Tenant issues a unique identifier for a Tenant and contains information about their Org
+- Tenant is the anchor entity for an organization that consumes Network and Compute resources on a Site.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tray_firmware.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tray_firmware.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.tray_firmware
 short_description: Manage Tray resources
 description:
-- Tray operations
+- Tray represents a component within a Rack.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tray_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tray_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.tray_info
 short_description: Retrieve Tray information
 description:
-- Tray operations
+- Tray represents a component within a Rack.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tray_power.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tray_power.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.tray_power
 short_description: Manage Tray resources
 description:
-- Tray operations
+- Tray represents a component within a Rack.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tray_validation.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/tray_validation.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.tray_validation
 short_description: Manage Tray resources
 description:
-- Tray operations
+- Tray represents a component within a Rack.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/user_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/user_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.user_info
 short_description: Retrieve User information
 description:
-- User operations
+- User is a logical entity that identifies individuals operating on behalf of an organization.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.vpc
 short_description: Manage VPC resources
 description:
-- VPC operations
+- VPC defines the networking isolation boundary for Tenant's Instances.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -51,6 +51,12 @@ options:
     type: str
     description:
     - ID of the default NVLink Logical Partition that GPUs for all Instances in the VPC will attach to
+  routing_profile:
+    type: str
+    description:
+    - Specify routing profile for the VPC. Only supported when `networkVirtualizationType` is set to `FNN`, or when `networkVirtualizationType`
+      is omitted and Site has Native Networking enabled. Requires Tenant to have elevated privilege. Current accepted values
+      are `privileged-internal`, `internal`, and `external`.
   site_id:
     type: str
     description:
@@ -120,6 +126,7 @@ name=dict(type='str'),
 network_security_group_id=dict(type='str'),
 network_virtualization_type=dict(type='str', choices=['ETHERNET_VIRTUALIZER', 'FNN']),
 nv_link_logical_partition_id=dict(type='str'),
+routing_profile=dict(type='str'),
 site_id=dict(type='str'),
 state=dict(type='str', choices=['present', 'absent']),
 vni=dict(type='int'),
@@ -133,7 +140,7 @@ RESOURCE_CONFIG = {
     'resource_item_path': '/v2/org/{org}/carbide/vpc/{vpcId}',
     'id_param': 'vpcId',
     'name_field': 'name',
-    'create_schema_fields': ['id', 'name', 'description', 'site_id', 'network_virtualization_type', 'network_security_group_id', 'vni', 'nv_link_logical_partition_id', 'labels'],
+    'create_schema_fields': ['id', 'name', 'description', 'site_id', 'network_virtualization_type', 'routing_profile', 'network_security_group_id', 'vni', 'nv_link_logical_partition_id', 'labels'],
     'update_schema_fields': ['name', 'description', 'network_security_group_id', 'nv_link_logical_partition_id', 'labels'],
     'scope_fields': ['site_id'],
     'ready_statuses': ['Ready'],

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.vpc_info
 short_description: Retrieve VPC information
 description:
-- VPC operations
+- VPC defines the networking isolation boundary for Tenant's Instances.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -26,7 +26,13 @@ options:
   network_security_group_id:
     type: str
     description:
-    - Filter VPCs by NetworkSecurityGroup ID
+    - Filter VPCs by Network Security Group ID. Can be specified multiple times to filter on more than one Network Security
+      Group.
+  nv_link_logical_partition_id:
+    type: str
+    description:
+    - Filter VPCs by NVLink Logical Partition ID. Can be specified multiple times to filter on more than one NVLink Logical
+      Partition.
   query:
     type: str
     description:
@@ -34,11 +40,11 @@ options:
   site_id:
     type: str
     description:
-    - Filter VPCs by Site ID
+    - Filter VPCs by Site ID. Can be specified multiple times to filter on more than one Site.
   status:
     type: str
     description:
-    - Filter VPCs by Status
+    - Filter VPCs by Status. Can be specified multiple times to filter on more than one Status.
   vpc_id:
     type: str
     description:
@@ -82,6 +88,7 @@ from ansible_collections.nvidia.bare_metal.plugins.module_utils.resource import 
 ARGUMENT_SPEC = dict(
 id=dict(type='str'),
 network_security_group_id=dict(type='str'),
+nv_link_logical_partition_id=dict(type='str'),
 query=dict(type='str'),
 site_id=dict(type='str'),
 status=dict(type='str'),
@@ -92,7 +99,7 @@ RESOURCE_CONFIG = {
     'resource_path': '/v2/org/{org}/carbide/vpc',
     'resource_item_path': '/v2/org/{org}/carbide/vpc/{vpcId}',
     'id_param': 'vpcId',
-    'filter_fields': ['site_id', 'status', 'query', 'network_security_group_id'],
+    'filter_fields': ['site_id', 'status', 'network_security_group_id', 'nv_link_logical_partition_id', 'query'],
 }
 
 

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc_peering.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc_peering.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.vpc_peering
 short_description: Manage VPC Peering resources
 description:
-- VPC Peerings are network connections between two VPCs on the same site.
+- VPC Peering allows Instances in one VPC to communicate with Instances in another VPC on the same Site.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc_peering_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc_peering_info.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.vpc_peering_info
 short_description: Retrieve VPC Peering information
 description:
-- VPC Peerings are network connections between two VPCs on the same site.
+- VPC Peering allows Instances in one VPC to communicate with Instances in another VPC on the same Site.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc_prefix.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc_prefix.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.vpc_prefix
 short_description: Manage VPC Prefix resources
 description:
-- VPC Prefixes are networking constructs that connect a set of bare metal machines.
+- VPC Prefix is a network prefix belonging to an IP Block allocated to a Tenant. Tenant can use VPC Prefixes to enable network
+  connectivity between their Instances.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:
@@ -26,7 +27,7 @@ options:
   ip_block_id:
     type: str
     description:
-    - ip_block_id parameter.
+    - ID of the IP Block to allocate the VPC Prefix from
   name:
     type: str
     description:

--- a/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc_prefix_info.py
+++ b/vendor/ansible_collections/nvidia/bare_metal/plugins/modules/vpc_prefix_info.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: nvidia.bare_metal.vpc_prefix_info
 short_description: Retrieve VPC Prefix information
 description:
-- VPC Prefixes are networking constructs that connect a set of bare metal machines.
+- VPC Prefix is a network prefix belonging to an IP Block allocated to a Tenant. Tenant can use VPC Prefixes to enable network
+  connectivity between their Instances.
 version_added: 1.0.0
 author: NVIDIA Bare Metal Manager Dev Team
 extends_documentation_fragment:


### PR DESCRIPTION
## Summary

Add the `agentless_net.steps` collection — a pluggable network backend for CaaS cluster provisioning using VLAN-based L2 switching and Linux namespace L3 routing. This plugs into the existing `network_steps_collection` mechanism
alongside `osac.steps` (ESI) and `netris.steps` (Netris).

### cluster_infra role ([OSAC-1653](https://redhat.atlassian.net/browse/OSAC-1653))
- VLAN allocation from pool via `agentless_net.ipam.vlan_id`
- VLAN creation on physical switches via `agentless_net.l2.vlan`
- Access port configuration for allocated hosts via `agentless_net.l2.port`
- L3 router namespace with SNAT for outbound internet access via `agentless_net.l3.router` and `agentless_net.l3.snat`
- BareMetalPool provisioning and Agent management (reused from ESI)

### external_access role ([OSAC-1654](https://redhat.atlassian.net/browse/OSAC-1654))
- Public IP allocation for API and ingress via `agentless_net.ipam.ip`
- DNAT rules for API (port 6443) and ingress (ports 80, 443) via `agentless_net.l3.dnat`
- DNS record creation (api.*, api-int.*, *.apps)
- MetalLB ingress configuration

Also adds `group_vars/all/agentless_net.yaml` for backend configuration (env-overridable, same pattern as Netris).

## Test plan

- [x] `ansible-lint` passes at production profile
- [x] All playbook wrappers tested against containerlab (create, idempotency, delete)
- [ ] Full E2E with OSAC deployment (tracked in [OSAC-1655](https://redhat.atlassian.net/browse/OSAC-1655))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the `agentless_net.steps` Ansible collection (v1.0.0).
  * Added `cluster_infra` workflows to provision and remove cluster networking, including VLAN/IPAM allocation, switch port configuration, router/SNAT setup, and agent labeling/approval.
  * Added `external_access` workflows to provision and remove public API/ingress connectivity, including public IP allocation, DNAT, DNS records, and MetalLB ingress.
* **Documentation**
  * Added collection changelog, Galaxy metadata, runtime requirements, and shared configuration defaults.
* **Bug Fixes**
  * Improved teardown to safely skip cleanup when required allocations aren’t present.
* **Chores**
  * Bumped the `ansible_network.network_runner` collection version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->