### PR TITLE
OSAC-1805: Fix VM networking for primary UDN namespaces 

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_build_spec.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_build_spec.yaml
@@ -25,7 +25,8 @@
                 bus: virtio
           interfaces:
             - name: default
-              bridge: {}
+              binding:
+                name: l2bridge
           # USB tablet provides absolute cursor positioning for VNC
           inputs:
             - name: tablet
@@ -43,9 +44,7 @@
               spinlocks: 8191
       networks:
         - name: default
-          multus:
-            networkName: "{{ compute_instance_target_namespace }}/{{ vm_cudn_nad_name }}"
-            default: true
+          pod: {}
       volumes: "{{ root_disk_volume }}"
   when: guest_os_family != 'windows'
 
@@ -83,7 +82,8 @@
                 bus: virtio
           interfaces:
             - name: default
-              bridge: {}
+              binding:
+                name: l2bridge
           # USB tablet provides absolute cursor positioning for VNC
           inputs:
             - name: tablet
@@ -103,9 +103,7 @@
               spinlocks: 8192
       networks:
         - name: default
-          multus:
-            networkName: "{{ compute_instance_target_namespace }}/{{ vm_cudn_nad_name }}"
-            default: true
+          pod: {}
       volumes: "{{ root_disk_volume }}"
   when: guest_os_family == 'windows'
 

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_validate.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_validate.yaml
@@ -86,9 +86,9 @@
   ansible.builtin.set_fact:
     default_vm_labels: "{{ default_vm_labels | combine(vm_sg_labels) }}"
 
-- name: Extract primary subnet reference for CUDN NAD
+- name: Extract primary subnet reference
   ansible.builtin.set_fact:
-    vm_cudn_nad_name: >-
+    vm_subnet_ref: >-
       {{
         (
           compute_instance.spec.networkAttachments
@@ -102,8 +102,8 @@
 - name: Require networkAttachments with subnetRef
   ansible.builtin.assert:
     that:
-      - vm_cudn_nad_name | length > 0
+      - vm_subnet_ref | length > 0
     fail_msg: >-
       ComputeInstance must have spec.networkAttachments[0].subnetRef set.
-      This is required to determine the CUDN NetworkAttachmentDefinition
-      for VM networking. Ensure the ComputeInstance references a Subnet.
+      This identifies the subnet namespace where the VM will be created.
+      Ensure the ComputeInstance references a Subnet.

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/test.yml
@@ -32,8 +32,8 @@
 #   Test 9 (Windows sysprep with valid password accepted):
 #     ansible-playbook ... -e test_windows_sysprep_valid=true
 #
-#   Test 10 (CUDN NAD name extracted from networkAttachments):
-#     ansible-playbook ... -e test_create_cudn_nad_extracted=true
+#   Test 10 (Subnet reference extracted from networkAttachments):
+#     ansible-playbook ... -e test_create_subnet_ref_extracted=true
 #
 #   Test 11 (Missing networkAttachments rejected):
 #     ansible-playbook ... -e test_create_missing_subnet_fails=true
@@ -513,10 +513,10 @@
             fail_msg: "Expected vm_hostname='test-win-with-i' (truncated), got {{ vm_hostname | default('undefined') }}"
 
 # ──────────────────────────────────────────────────────────────
-# Test 10: CUDN NAD name extracted from networkAttachments
-# Expected: vm_cudn_nad_name == subnetRef from fixture
+# Test 10: Subnet reference extracted from networkAttachments
+# Expected: vm_subnet_ref == subnetRef from fixture
 # ──────────────────────────────────────────────────────────────
-- name: "Test ocp_virt_vm -- CUDN NAD name extracted from networkAttachments"
+- name: "Test ocp_virt_vm -- subnet reference extracted from networkAttachments"
   hosts: localhost
 
   collections:
@@ -526,7 +526,7 @@
     compute_instance_label: "osac.openshift.io/computeinstance"
 
   tasks:
-    - when: test_create_cudn_nad_extracted | default(false) | bool
+    - when: test_create_subnet_ref_extracted | default(false) | bool
       block:
         - name: Read ComputeInstance fixture with networkAttachments
           ansible.builtin.set_fact:
@@ -536,17 +536,17 @@
           ansible.builtin.set_fact:
             compute_instance_name: "{{ compute_instance.metadata.name }}"
 
-        - name: Run create_validate to extract NAD name
+        - name: Run create_validate to extract subnet reference
           ansible.builtin.include_role:
             name: osac.templates.ocp_virt_vm
             tasks_from: create_validate.yaml
 
-        - name: Verify vm_cudn_nad_name matches first subnetRef
+        - name: Verify vm_subnet_ref matches first subnetRef
           ansible.builtin.assert:
             that:
-              - vm_cudn_nad_name is defined
-              - vm_cudn_nad_name == "test-subnet"
-            fail_msg: "Expected vm_cudn_nad_name='test-subnet', got {{ vm_cudn_nad_name | default('undefined') }}"
+              - vm_subnet_ref is defined
+              - vm_subnet_ref == "test-subnet"
+            fail_msg: "Expected vm_subnet_ref='test-subnet', got {{ vm_subnet_ref | default('undefined') }}"
 
 # ──────────────────────────────────────────────────────────────
 # Test 11: Missing networkAttachments must fail validation


### PR DESCRIPTION
### Chnage
Switch to the networking model documented by Red Hat for VMs on primary UDNs (supported on OpenShift 4.18, 4.19, and 4.20):
- Network: pod: {} instead of multus: {networkName: ...}. In a primary UDN namespace, the pod network IS the UDN — there's no fallback to the default cluster network. The namespace label already tells OVN which network to use.
- Interface binding: binding: {name: l2bridge} instead of bridge: {}. The l2bridge binding plugin is the only supported way to wire a VM NIC into a Layer2 UDN. A plain Linux bridge doesn't work here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated VM template default networking for both Linux and Windows to use pod-based configuration with the `l2bridge` binding.
  - Improved VM networking validation to derive and require the primary subnet reference from `networkAttachments[0].subnetRef`, along with clearer guidance on what to set.

- **Tests**
  - Refreshed test coverage to verify correct subnet reference extraction and expected values during VM creation validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->