### PR TITLE
OSAC-1123: enable storage role k8s calls to target remote CaaS clusters

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_csi_operator.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_csi_operator.yaml
@@ -17,6 +17,7 @@
 
 - name: Check which required VAST CSI drivers are already installed
   kubernetes.core.k8s_info:
+    kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
     api_version: storage.k8s.io/v1
     kind: CSIDriver
     name: "{{ item | trim }}"
@@ -43,6 +44,7 @@
   block:
     - name: Check if OLM is available on cluster
       kubernetes.core.k8s_info:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         api_version: operators.coreos.com/v1alpha1
         kind: CatalogSource
         namespace: "{{ vast_storage_csi_operator_catalog_namespace }}"
@@ -69,6 +71,7 @@
 
     - name: Ensure VAST CSI Operator namespace exists
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: present
         definition:
           apiVersion: v1
@@ -78,6 +81,7 @@
 
     - name: Ensure OperatorGroup exists for OwnNamespace install mode
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: present
         definition:
           apiVersion: operators.coreos.com/v1
@@ -91,6 +95,7 @@
 
     - name: Ensure VAST CSI Operator Subscription exists
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: present
         definition:
           apiVersion: operators.coreos.com/v1alpha1
@@ -107,6 +112,7 @@
 
     - name: Wait for VastCSIDriver CRD to be available
       kubernetes.core.k8s_info:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         api_version: apiextensions.k8s.io/v1
         kind: CustomResourceDefinition
         name: vastcsidrivers.storage.vastdata.com
@@ -117,6 +123,7 @@
 
     - name: Ensure VastCSIDriver CR exists for each required protocol
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: present
         definition:
           apiVersion: storage.vastdata.com/v1
@@ -130,6 +137,7 @@
 
     - name: Wait for all required VAST CSI drivers to be registered
       kubernetes.core.k8s_info:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         api_version: storage.k8s.io/v1
         kind: CSIDriver
         name: "{{ item | trim }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -41,6 +41,7 @@
 # Short-circuit -- check if ALL tiers' StorageClasses already exist (single API call)
 - name: Check existing tenant StorageClasses
   kubernetes.core.k8s_info:
+    kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
     api_version: storage.k8s.io/v1
     kind: StorageClass
     label_selectors:
@@ -147,6 +148,7 @@
 
     - name: Create CSI Secret with per-tenant manager credentials in tenant namespace
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: present
         definition:
           apiVersion: v1
@@ -214,6 +216,7 @@
     - name: Create NFS StorageClass per tier
       when: _vast_nfs_tiers | length > 0
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: present
         definition:
           apiVersion: storage.k8s.io/v1
@@ -240,6 +243,7 @@
     - name: Create block StorageClass per tier
       when: _vast_block_tiers | length > 0
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: present
         definition:
           apiVersion: storage.k8s.io/v1
@@ -269,6 +273,7 @@
     - name: Check if VolumeSnapshot CRD is installed
       when: storage_provider_snapshots_enabled | default(true)
       kubernetes.core.k8s_info:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         api_version: apiextensions.k8s.io/v1
         kind: CustomResourceDefinition
         name: volumesnapshotclasses.snapshot.storage.k8s.io
@@ -279,6 +284,7 @@
         (storage_provider_snapshots_enabled | default(true)) and
         (_vast_vsc_crd_check.resources | default([]) | length > 0)
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: present
         definition:
           apiVersion: snapshot.storage.k8s.io/v1

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/teardown_cluster_storage.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/teardown_cluster_storage.yaml
@@ -21,6 +21,7 @@
   block:
     - name: Find all tenant StorageClasses by label
       kubernetes.core.k8s_info:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         api_version: storage.k8s.io/v1
         kind: StorageClass
         label_selectors:
@@ -30,6 +31,7 @@
 
     - name: Delete tenant StorageClasses
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: absent
         api_version: storage.k8s.io/v1
         kind: StorageClass
@@ -41,6 +43,7 @@
 
     - name: Find all tenant VolumeSnapshotClasses by label
       kubernetes.core.k8s_info:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         api_version: snapshot.storage.k8s.io/v1
         kind: VolumeSnapshotClass
         label_selectors:
@@ -52,6 +55,7 @@
     - name: Delete tenant VolumeSnapshotClasses
       when: _vast_cleanup_vsc_list.resources is defined
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: absent
         api_version: snapshot.storage.k8s.io/v1
         kind: VolumeSnapshotClass
@@ -63,6 +67,7 @@
 
     - name: Delete CSI Secret in tenant namespace
       kubernetes.core.k8s:
+        kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"
         state: absent
         api_version: v1
         kind: Secret


### PR DESCRIPTION
## Summary

Add `kubeconfig` parameter to all `kubernetes.core.k8s` and `kubernetes.core.k8s_info` calls in the VAST storage role so that StorageClasses, CSI resources, and cleanup operations target the correct cluster ([OSAC-1123](https://redhat.atlassian.net/browse/OSAC-1123)).

## Why

The VAST storage role creates StorageClasses, CSI Secrets, and VolumeSnapshotClasses using `kubernetes.core.k8s` calls that default to the local cluster context. For CaaS clusters, these resources must be created on the tenant's hosted cluster, not the hub. Adding `kubeconfig: "{{ _remote_kubeconfig | default(omit) }}"` routes each call to the correct cluster when a remote kubeconfig is available, while preserving existing VMaaS behavior (where `_remote_kubeconfig` is unset and `default(omit)` drops the parameter).

## Testing

```
$ ansible-lint collections/ansible_collections/osac/templates/roles/vast_storage/
Passed with no violations
```

19 k8s calls updated across 3 files:
- `ensure_storage_class.yaml` (6 calls)
- `ensure_csi_operator.yaml` (8 calls)
- `teardown_cluster_storage.yaml` (5 calls)

## Pre-merge ToDos

1. Coordinate with osac-operator PR #324 (storage controller CaaS support)

## Post-merge ToDos

1. Update osac-installer submodule ref for `base/osac-aap`
2. Coordinate with PR #377 ([OSAC-1327](https://redhat.atlassian.net/browse/OSAC-1327), hcp_data_plane target) which resolves `_remote_kubeconfig` at the playbook level

## Related PRs

- osac-operator PR #324: CaaS cluster storage provisioning (sets `admin_kubeconfig` in extra_vars)
- osac-aap PR #377 ([OSAC-1327](https://redhat.atlassian.net/browse/OSAC-1327)): hcp_data_plane provisioning target and kubeconfig resolution (Will Gordon, WIP)

## Ticket

[OSAC-1123](https://redhat.atlassian.net/browse/OSAC-1123)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kubernetes actions now consistently use the provided remote kubeconfig when available, helping cluster setup, storage class management, and teardown run against the intended cluster.
  * Improved reliability for creating, checking, and removing CSI-related resources, including operator components, storage classes, snapshot classes, and tenant secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
