### PR TITLE
OSAC-1694: Add importBcmAgentsEnabled to config-as-code secret template

### DIFF
--- a/charts/aap/templates/bcm-certs.yaml
+++ b/charts/aap/templates/bcm-certs.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.configAsCode.importBcmAgentsEnabled }}
+{{- if not (and .Values.importBcmAgents.cert .Values.importBcmAgents.key) }}
+{{- fail "importBcmAgentsEnabled is true but importBcmAgents.cert/key are not set" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bcm-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "osac-aap.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  tls.crt: {{ .Values.importBcmAgents.cert | quote }}
+  tls.key: {{ .Values.importBcmAgents.key | quote }}
+{{- end }}

--- a/charts/aap/templates/config-as-code-secret.yaml
+++ b/charts/aap/templates/config-as-code-secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.configAsCode.eeImage .Values.configAsCode.importAgentsEnabled }}
+{{- if or .Values.configAsCode.eeImage .Values.configAsCode.importAgentsEnabled .Values.configAsCode.importBcmAgentsEnabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +9,9 @@ metadata:
 stringData:
   {{- if .Values.configAsCode.importAgentsEnabled }}
   OSAC_IMPORT_AGENTS_ENABLED: "true"
+  {{- end }}
+  {{- if .Values.configAsCode.importBcmAgentsEnabled }}
+  OSAC_IMPORT_BCM_AGENTS_ENABLED: "true"
   {{- end }}
   {{- with .Values.configAsCode.eeImage }}
   AAP_EE_IMAGE: {{ . | quote }}

--- a/charts/aap/values.yaml
+++ b/charts/aap/values.yaml
@@ -27,9 +27,14 @@ configAsCode:
   projectGitUri: ""
   projectGitBranch: ""
   importAgentsEnabled: false
+  importBcmAgentsEnabled: false
 
 importAgents:
   servers: []
+
+importBcmAgents:
+  cert: ""
+  key: ""
 
 serviceAccounts:
   osacSa: "osac-sa"


### PR DESCRIPTION
## Summary

Adds BCM (NVIDIA Base Command Manager) inventory backend support to the osac-aap subchart, following the same pattern as `importAgentsEnabled` (#374):

- Gate `config-as-code-ig` Secret creation on `importBcmAgentsEnabled`
- Add `OSAC_IMPORT_BCM_AGENTS_ENABLED` env var to the Secret
- Add `bcm-certs` Secret template for BCM mTLS client certificate and key
- Add `importBcmAgentsEnabled` and `importBcmAgents` (cert/key) values

## Related

- Depends on: osac-project/osac-installer#334 (installer-side BCM values)
- Pattern established by: #374 (importAgentsEnabled consolidation)

## Test plan

- `helm template` with defaults — no bcm-certs or config-as-code-ig Secret rendered
- `helm template --set configAsCode.importBcmAgentsEnabled=true` — both Secrets rendered with correct values
- `helm template --set configAsCode.importAgentsEnabled=true` — existing import-agents behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional BCM agent TLS Secret (`bcm-certs`) that is created during chart deployment when enabled.
  * Extended Config-as-Code with a new `importBcmAgentsEnabled` flag and certificate/key inputs.
  * Config-as-Code Secret now includes the BCM import environment value when enabled.
* **Bug Fixes**
  * Added validation to fail rendering with a clear error if the BCM certificate or key is missing when BCM import is enabled.
  * Config-as-Code Secret now renders when any Config-as-Code import feature (including BCM agents) is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->