### PR TITLE
OSAC-1681: Add E2E full install presubmit job

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -1,0 +1,43 @@
+---
+name: E2E VMaaS Full Install
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      test-suite:
+        description: "Test suite (vmaas, caas, or empty for all)"
+        required: false
+        default: "vmaas"
+      test-filter:
+        description: "pytest -k filter"
+        required: false
+        default: ""
+      test-infra-ref:
+        description: "Branch/ref of osac-test-infra"
+        required: false
+        default: "main"
+
+concurrency:
+  group: e2e-vmaas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  e2e-full-install:
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
+    with:
+      test-suite: ${{ inputs.test-suite || 'vmaas' }}
+      test-filter: ${{ inputs.test-filter || '' }}
+      # Build the component image from the PR's fork/branch
+      component-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      component-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      component-image-key: aap.bootstrap.image
+      component-build-type: ansible-builder
+      component-containerfile: execution-environment/execution-environment.yaml
+      # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
+      test-infra-repository: osac-project/osac-test-infra
+      test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}


### PR DESCRIPTION
## Summary
- Add `e2e-vmaas-full-install.yml` workflow that triggers on PRs to `main` and `workflow_dispatch`
- Calls the reusable workflow in `osac-test-infra` to run a full OSAC install + E2E tests
- Builds the osac-aap image from the PR branch and loads it onto the test cluster
- Uses `component-image-key: aap.bootstrap.image` for Helm override

## Test plan
- [ ] Verify workflow triggers on PR to main
- [ ] Verify `workflow_dispatch` works with optional inputs (test-suite, test-filter, test-infra-ref)
- [ ] Confirm the reusable workflow builds the PR's code (not main branch)

Jira: https://redhat.atlassian.net/browse/OSAC-1681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated end-to-end test workflow for pull requests and manual runs, including options to select a test suite, apply an optional pytest `-k` filter, and choose the test-infra branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->