### PR TITLE
Fix EE build: work around UBI 10 glibc version conflict

### DIFF
--- a/execution-environment/execution-environment.yaml
+++ b/execution-environment/execution-environment.yaml
@@ -33,6 +33,10 @@ additional_build_files:
     dest: vendor
 
 additional_build_steps:
+  prepend_base:
+    # Workaround: UBI 10 repos have glibc-devel 2.39-126 but the base image
+    # ships glibc 2.39-124. Update glibc before system packages are installed.
+    - RUN dnf update -y --allowerasing glibc glibc-minimal-langpack && dnf clean all
   prepend_galaxy:
     - COPY _build/collections /usr/share/ansible/collections
     - COPY _build/vendor /usr/share/ansible/collections


### PR DESCRIPTION
## Summary
- UBI 10 repos now have `glibc-devel-2.39-126` but the `ubi10:10.2` base image ships `glibc-2.39-124`
- This breaks all EE builds that install `gcc` (all branches, including main)
- Add `prepend_base` step to update glibc before system packages are installed
- Tested and confirmed working on CI machines
- Can be removed once the UBI 10 base image is rebuilt with glibc 2.39-126