### PR TITLE
OSAC-1828: add version-agnostic ocp_small cluster template

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_small/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/defaults/main.yaml
@@ -1,0 +1,2 @@
+ocp_release_version: "4.22.0"
+ocp_release_image: "quay.io/openshift-release-dev/ocp-release:{{ ocp_release_version }}-multi"

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/meta/osac.yaml
@@ -1,0 +1,10 @@
+title: OpenShift Small Cluster
+description: >
+  Builds a minimally configured OpenShift cluster with a configurable OCP
+  version. Default version: 4.22.0.
+
+default_node_request:
+- resourceClass: fc430
+  numberOfNodes: 2
+
+allowed_resource_classes: []

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/delete.yaml
@@ -1,0 +1,61 @@
+- name: Set delete step defaults
+  ansible.builtin.set_fact:
+    delete_step_pre_delete_hook_default:
+      name: osac.templates.ocp_small
+      tasks_from: noop.yaml
+    delete_step_hosted_cluster_default:
+      name: osac.service.hosted_cluster
+      tasks_from: main.yaml
+    delete_step_external_access_default:
+      name: osac.service.external_access
+      tasks_from: main.yaml
+    delete_step_cluster_infra_default:
+      name: osac.service.cluster_infra
+      tasks_from: main.yaml
+    delete_step_post_delete_hook_default:
+      name: osac.templates.ocp_small
+      tasks_from: noop.yaml
+
+- name: Step - Pre-delete hook
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_pre_delete_hook_override | default(delete_step_pre_delete_hook_default)).name }}"
+    tasks_from: "{{ (delete_step_pre_delete_hook_override | default(delete_step_pre_delete_hook_default)).tasks_from }}"
+
+- name: Step - Destroy hosted cluster
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_hosted_cluster_override | default(delete_step_hosted_cluster_default)).name }}"
+    tasks_from: "{{ (delete_step_hosted_cluster_override | default(delete_step_hosted_cluster_default)).tasks_from }}"
+  vars:
+    hosted_cluster_state: absent
+    hosted_cluster_name: "{{ cluster_order.metadata.name }}"
+    hosted_cluster_namespace: "{{ cluster_working_namespace }}"
+    hosted_cluster_settings:
+      ocp_release_image: "{{ ocp_release_image }}"
+      pull_secret: "{{ cluster_settings_pull_secret }}"
+      ssh_public_key: "{{ cluster_settings_ssh_public_key }}"
+    hosted_cluster_node_count: >-
+      {{ cluster_order.spec.nodeRequests | map(attribute="numberOfNodes") | sum }}
+
+- name: Step - Remove port forwarding
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_external_access_override | default(delete_step_external_access_default)).name }}"
+    tasks_from: "{{ (delete_step_external_access_override | default(delete_step_external_access_default)).tasks_from }}"
+  vars:
+    external_access_state: absent
+    external_access_name: "{{ cluster_order.metadata.name }}"
+    external_access_namespace: "{{ cluster_working_namespace }}"
+
+- name: Step - Destroy cluster infrastructure
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_cluster_infra_override | default(delete_step_cluster_infra_default)).name }}"
+    tasks_from: "{{ (delete_step_cluster_infra_override | default(delete_step_cluster_infra_default)).tasks_from }}"
+  vars:
+    cluster_infra_state: absent
+    cluster_infra_name: "{{ cluster_order.metadata.name }}"
+    cluster_infra_namespace: "{{ cluster_working_namespace }}"
+    cluster_infra_node_requests: []
+
+- name: Step - Post-delete hook
+  ansible.builtin.include_role:
+    name: "{{ (delete_step_post_delete_hook_override | default(delete_step_post_delete_hook_default)).name }}"
+    tasks_from: "{{ (delete_step_post_delete_hook_override | default(delete_step_post_delete_hook_default)).tasks_from }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/install.yaml
@@ -78,7 +78,7 @@
     tasks_from: "{{ (install_step_wait_for_nodes_override | default(install_step_wait_for_nodes_default)).tasks_from }}"
   vars:
     wait_for_kubeconfig: "{{ admin_kubeconfig }}"
-    wait_for_nodes_expected_count: "{{ cluster_order.spec.nodeRequests | map(attribute='numberOfNodes') | map('int') | sum }}"
+    wait_for_nodes_expected_count: "{{ cluster_order.spec.nodeRequests | unique(attribute='resourceClass') | map(attribute='numberOfNodes') | map('int') | sum }}"
 
 - name: Step - Wait for cluster operators
   ansible.builtin.include_role:

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/install.yaml
@@ -1,0 +1,93 @@
+- name: Set install step defaults
+  ansible.builtin.set_fact:
+    install_step_pre_install_hook_default:
+      name: osac.templates.ocp_small
+      tasks_from: noop.yaml
+    install_step_hosted_cluster_default:
+      name: osac.service.hosted_cluster
+      tasks_from: main.yaml
+    install_step_cluster_infra_default:
+      name: osac.service.cluster_infra
+      tasks_from: main.yaml
+    install_step_external_access_default:
+      name: osac.service.external_access
+      tasks_from: main.yaml
+    install_step_retrieve_kubeconfig_default:
+      name: osac.service.retrieve_kubeconfig
+      tasks_from: main.yaml
+    install_step_wait_for_nodes_default:
+      name: osac.service.wait_for
+      tasks_from: wait_for_nodes.yaml
+    install_step_wait_for_cluster_operators_default:
+      name: osac.service.wait_for
+      tasks_from: wait_for_cluster_operators.yaml
+    install_step_post_install_hook_default:
+      name: osac.templates.ocp_small
+      tasks_from: noop.yaml
+
+- name: Step - Pre-install hook
+  ansible.builtin.include_role:
+    name: "{{ (install_step_pre_install_hook_override | default(install_step_pre_install_hook_default)).name }}"
+    tasks_from: "{{ (install_step_pre_install_hook_override | default(install_step_pre_install_hook_default)).tasks_from }}"
+
+- name: Step - Create hosted cluster
+  ansible.builtin.include_role:
+    name: "{{ (install_step_hosted_cluster_override | default(install_step_hosted_cluster_default)).name }}"
+    tasks_from: "{{ (install_step_hosted_cluster_override | default(install_step_hosted_cluster_default)).tasks_from }}"
+  vars:
+    hosted_cluster_name: "{{ cluster_order.metadata.name }}"
+    hosted_cluster_namespace: "{{ cluster_working_namespace }}"
+    hosted_cluster_settings:
+      ocp_release_image: "{{ ocp_release_image }}"
+      pull_secret: "{{ cluster_settings_pull_secret }}"
+      ssh_public_key: "{{ cluster_settings_ssh_public_key }}"
+    hosted_cluster_node_requests: "{{ cluster_order.spec.nodeRequests | unique(attribute='resourceClass') }}"
+    hosted_cluster_state: present
+
+- name: Step - Create cluster infrastructure
+  ansible.builtin.include_role:
+    name: "{{ (install_step_cluster_infra_override | default(install_step_cluster_infra_default)).name }}"
+    tasks_from: "{{ (install_step_cluster_infra_override | default(install_step_cluster_infra_default)).tasks_from }}"
+  vars:
+    cluster_infra_state: present
+    cluster_infra_name: "{{ cluster_order.metadata.name }}"
+    cluster_infra_namespace: "{{ cluster_working_namespace }}"
+    cluster_infra_node_requests: "{{ cluster_order.spec.nodeRequests | unique(attribute='resourceClass') }}"
+
+- name: Step - Configure port forwarding
+  ansible.builtin.include_role:
+    name: "{{ (install_step_external_access_override | default(install_step_external_access_default)).name }}"
+    tasks_from: "{{ (install_step_external_access_override | default(install_step_external_access_default)).tasks_from }}"
+  vars:
+    external_access_name: "{{ cluster_order.metadata.name }}"
+    external_access_state: present
+    external_access_namespace: "{{ cluster_working_namespace }}"
+    external_access_ingress_internal_network: "network-{{ cluster_order.metadata.name }}"
+
+- name: Step - Retrieve kubeconfig
+  ansible.builtin.include_role:
+    name: "{{ (install_step_retrieve_kubeconfig_override | default(install_step_retrieve_kubeconfig_default)).name }}"
+    tasks_from: "{{ (install_step_retrieve_kubeconfig_override | default(install_step_retrieve_kubeconfig_default)).tasks_from }}"
+  vars:
+    retrieve_kubeconfig_cluster_name: "{{ cluster_order.metadata.name }}"
+    retrieve_kubeconfig_namespace: "{{ cluster_working_namespace }}"
+
+- name: Step - Wait for nodes to be ready
+  ansible.builtin.include_role:
+    name: "{{ (install_step_wait_for_nodes_override | default(install_step_wait_for_nodes_default)).name }}"
+    tasks_from: "{{ (install_step_wait_for_nodes_override | default(install_step_wait_for_nodes_default)).tasks_from }}"
+  vars:
+    wait_for_kubeconfig: "{{ admin_kubeconfig }}"
+    wait_for_nodes_expected_count: "{{ cluster_order.spec.nodeRequests | map(attribute='numberOfNodes') | map('int') | sum }}"
+
+- name: Step - Wait for cluster operators
+  ansible.builtin.include_role:
+    name: "{{ (install_step_wait_for_cluster_operators_override | default(install_step_wait_for_cluster_operators_default)).name }}"
+    tasks_from: "{{ (install_step_wait_for_cluster_operators_override | default(install_step_wait_for_cluster_operators_default)).tasks_from }}"
+  vars:
+    wait_for_kubeconfig: "{{ admin_kubeconfig }}"
+
+- name: Step - Post-install hook
+  ansible.builtin.include_role:
+    name: "{{ (install_step_post_install_hook_override | default(install_step_post_install_hook_default)).name }}"
+    tasks_from: "{{ (install_step_post_install_hook_override | default(install_step_post_install_hook_default)).tasks_from }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/noop.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/noop.yaml
@@ -1,0 +1,3 @@
+---
+# No-op task file for default hooks
+# This file makes the template self-contained without external collection dependencies

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/post_install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/post_install.yaml
@@ -1,0 +1,69 @@
+---
+- name: Ensure openshift-operators namespace exists
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-operators
+
+- name: Create cert-manager subscription
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: cert-manager
+        namespace: openshift-operators
+      spec:
+        channel: stable
+        installPlanApproval: Automatic
+        name: cert-manager
+        source: community-operators
+        sourceNamespace: openshift-marketplace
+
+- name: Create production issuer
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-production-http01
+      spec:
+        acme:
+          privateKeySecretRef:
+            name: letsencrypt-production-http01
+          server: 'https://acme-v02.api.letsencrypt.org/directory'
+          solvers:
+            - http01:
+                ingress:
+                  class: openshift-default
+  register: production_issuer_result
+  until: production_issuer_result is succeeded
+  retries: 30
+  delay: 30
+
+- name: Create staging issuer
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      metadata:
+        name: letsencrypt-staging-http01
+      spec:
+        acme:
+          privateKeySecretRef:
+            name: letsencrypt-staging-http01
+          server: 'https://acme-staging-v02.api.letsencrypt.org/directory'
+          solvers:
+            - http01:
+                ingress:
+                  class: openshift-default
+  register: staging_issuer_result
+  until: staging_issuer_result is succeeded
+  retries: 30
+  delay: 30

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/post_install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/tasks/post_install.yaml
@@ -1,6 +1,7 @@
 ---
 - name: Ensure openshift-operators namespace exists
   kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig | default(omit) }}"
     state: present
     definition:
       apiVersion: v1
@@ -10,6 +11,7 @@
 
 - name: Create cert-manager subscription
   kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig | default(omit) }}"
     state: present
     definition:
       apiVersion: operators.coreos.com/v1alpha1
@@ -26,6 +28,7 @@
 
 - name: Create production issuer
   kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig | default(omit) }}"
     state: present
     definition:
       apiVersion: cert-manager.io/v1
@@ -48,6 +51,7 @@
 
 - name: Create staging issuer
   kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig | default(omit) }}"
     state: present
     definition:
       apiVersion: cert-manager.io/v1


### PR DESCRIPTION
## [OSAC-1828](https://redhat.atlassian.net/browse/OSAC-1828): Add version-agnostic ocp_small cluster template

**Jira:** [OSAC-1828](https://redhat.atlassian.net/browse/OSAC-1828)

### Summary

Adds a new version-agnostic `ocp_small` cluster template role with a parameterized `ocp_release_version` defaulting to 4.22.0. This replaces the hardcoded version in the template name - users can now deploy any OCP version by overriding `ocp_release_version`. The existing `ocp_4_17_small` template is not modified (removal tracked in [OSAC-1829](https://redhat.atlassian.net/browse/OSAC-1829)).

**Companion PR:** innabox/fulfillment-service - adds the DB seed row for this template.

### Changes

- New `ocp_small` role under `collections/ansible_collections/osac/templates/roles/`:
  - `meta/osac.yaml` - version-agnostic title and description
  - `defaults/main.yaml` - `ocp_release_version: "4.22.0"` with derived `ocp_release_image`
  - `tasks/install.yaml` - cluster installation orchestration (from `ocp_4_17_small`)
  - `tasks/delete.yaml` - cluster deletion orchestration (from `ocp_4_17_small`)
  - `tasks/post_install.yaml` - cert-manager + LetsEncrypt setup
  - `tasks/noop.yaml` - no-op hook placeholder

### Testing

- **ansible-lint:** passes at production profile (0 failures, 0 warnings)
- **Integration tests:** N/A (requires AAP/cluster infrastructure)

### Acceptance Criteria

- [ ] New `ocp_small` template exists in osac-aap with parameterized `ocp_release_version`
- [ ] Default `ocp_release_version` set to 4.22.0
- [ ] `ocp_4_17_small` template remains functional (not modified or removed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added step-based install and delete workflows for the OpenShift small template, including cluster readiness checks, external access setup, kubeconfig retrieval, and full cleanup.
  * Introduced default OpenShift release settings (default version 4.22.0) and an associated release image reference.
  * Added automated post-install cert-manager setup with ACME HTTP-01 production and staging ClusterIssuers.
  * Added a no-operation default hook template for safer default behavior.
* **Metadata**
  * Added role metadata for the OpenShift small template, including default version and resource class defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->