### PR TITLE
Pass component-pr-author to e2e workflow

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -40,6 +40,8 @@ jobs:
       component-image-key: aap.bootstrap.image
       component-build-type: ansible-builder
       component-containerfile: execution-environment/execution-environment.yaml
+      # Pass author_association for fork PR authorization (empty for non-fork PRs)
+      fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}


### PR DESCRIPTION
Pass the PR author login to the e2e reusable workflow via the new
`component-pr-author` input so the org membership check uses the
actual PR author instead of `github.actor` (which changes on re-runs).