### PR TITLE
OSAC-1888: add osac.yaml metadata to bm_host_metal3_provisioning role

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/meta/osac.yaml
@@ -1,0 +1,8 @@
+---
+title: Default Bare Metal Instance Template
+description: >
+  General-purpose bare metal instance template. Provides a baseline hardware profile
+  for provisioning bare metal instances. Spec defaults will be extended in future
+  versions as tenant-configurable options (networking, OS image) are introduced.
+
+template_type: bare_metal_instance

--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/meta/osac.yaml
@@ -1,7 +1,7 @@
 ---
-title: Default Bare Metal Instance Template
+title: Metal3 Bare Metal Instance Template
 description: >
-  General-purpose bare metal instance template. Provides a baseline hardware profile
-  for provisioning bare metal instances.
+  Provisions bare metal instances using Metal3 (Bare Metal Operator) with Redfish-based
+  host provisioning. Provides a baseline hardware profile for metal3-managed hosts.
 
 template_type: bare_metal_instance

--- a/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_metal3_provisioning/meta/osac.yaml
@@ -2,7 +2,6 @@
 title: Default Bare Metal Instance Template
 description: >
   General-purpose bare metal instance template. Provides a baseline hardware profile
-  for provisioning bare metal instances. Spec defaults will be extended in future
-  versions as tenant-configurable options (networking, OS image) are introduced.
+  for provisioning bare metal instances.
 
 template_type: bare_metal_instance


### PR DESCRIPTION
## Summary
- Adds `meta/osac.yaml` to the `bm_host_metal3_provisioning` role so the `publish_templates` role discovers and publishes the metal3 BareMetalInstance template to the fulfillment-service
- Template id is auto-computed as `osac.templates.bm_host_metal3_provisioning` by the filter plugin

## Jira
https://redhat.atlassian.net/browse/OSAC-1888

## Test plan
- [ ] `ansible-lint` passes
- [ ] Run `playbook_osac_config_as_code.yml` to verify template is published to fulfillment-service

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new default Metal3 bare metal instance template for provisioning.
  * Included a clearer title and description to provide a baseline hardware profile users can select and use more easily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->