### PR TITLE
OSAC-1453: Add fabric_manager and k8s_manager to NetworkClass publish_templates

### DIFF
--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -288,6 +288,8 @@ class Metadata(Base):
     allowed_resource_classes: list[str] | None = None
     # Network-specific fields
     implementation_strategy: str | None = None
+    fabric_manager: str | None = None
+    k8s_manager: str | None = None
     is_default: bool = False
     capabilities: NetworkClassCapabilities | None = None
     parameters: list[TemplateParameterDefinition] = pydantic.Field(default_factory=list)
@@ -376,6 +378,8 @@ class NetworkClassTemplate(Base):
     title: str
     description: str | None = None
     implementation_strategy: str
+    fabric_manager: str | None = None
+    k8s_manager: str | None = None
     is_default: bool = False
     capabilities: NetworkClassCapabilities
 
@@ -546,6 +550,9 @@ class Collection(Base):
                             title=metadata.title,
                             description=metadata.description,
                             implementation_strategy=metadata.implementation_strategy,
+                            fabric_manager=metadata.fabric_manager,
+                            k8s_manager=metadata.k8s_manager,
+                            is_default=metadata.is_default,
                             capabilities=metadata.capabilities or NetworkClassCapabilities(),
                         )
                     elif metadata.template_type == TemplateTypeEnum.storage_provider:

--- a/collections/ansible_collections/osac/service/roles/enumerate_templates/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/enumerate_templates/tests/test.yml
@@ -107,9 +107,11 @@
           - item.title is defined
           - item.implementation_strategy is defined
           - item.implementation_strategy | length > 0
+          - item.fabric_manager is defined
+          - item.fabric_manager | length > 0
           - item.capabilities is defined
         fail_msg: "Network class '{{ item.id }}' missing required fields"
-        success_msg: "Network class '{{ item.id }}' has correct structure (strategy={{ item.implementation_strategy }})"
+        success_msg: "Network class '{{ item.id }}' has correct structure (strategy={{ item.implementation_strategy }}, fabric_manager={{ item.fabric_manager }})"
       loop: "{{ osac_network_classes }}"
       loop_control:
         label: "{{ item.id }}"

--- a/collections/ansible_collections/osac/service/roles/publish_templates/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/publish_templates/tests/test.yml
@@ -75,6 +75,7 @@
             title: "Test CI"
         osac_network_classes:
           - implementation_strategy: "new-network-class"
+            fabric_manager: "new-network-class"
             title: "Test NC"
       when: test_empty | default(false) | bool
 
@@ -150,8 +151,10 @@
             title: "Updated CI"
         osac_network_classes:
           - implementation_strategy: "cudn_net"
+            fabric_manager: "cudn_net"
             title: "Updated NC"
           - implementation_strategy: "brand-new-nc"
+            fabric_manager: "brand-new-nc"
             title: "New NC"
       when: test_populated | default(false) | bool
 
@@ -228,6 +231,7 @@
             title: "Edge CI"
         osac_network_classes:
           - implementation_strategy: "edge-case-nc"
+            fabric_manager: "edge-case-nc"
             title: "Edge NC"
       when: test_no_items_key | default(false) | bool
 

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/meta/osac.yaml
@@ -8,6 +8,8 @@ template_type: network
 
 # NetworkClass registration fields
 implementation_strategy: cudn_net
+fabric_manager: cudn_net
+k8s_manager: cudn_localnet
 is_default: true
 capabilities:
   supports_ipv4: true

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/osac.yaml
@@ -9,6 +9,7 @@ template_type: network
 
 # PublicIPPool registration fields
 implementation_strategy: metallb-l2
+fabric_manager: metallb_l2
 capabilities:
   supports_ipv4: true
   supports_ipv6: true

--- a/collections/ansible_collections/osac/templates/roles/netris/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/meta/osac.yaml
@@ -9,6 +9,7 @@ template_type: network
 
 # NetworkClass registration fields
 implementation_strategy: netris
+fabric_manager: netris
 capabilities:
   supports_ipv4: true
   supports_ipv6: false

--- a/collections/ansible_collections/osac/templates/roles/network_policy/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/network_policy/meta/osac.yaml
@@ -6,5 +6,6 @@ description: >
 
 template_type: network
 implementation_strategy: network_policy
+fabric_manager: network_policy
 capabilities:
   supports_security_groups: true

--- a/collections/ansible_collections/osac/templates/roles/openstack/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/openstack/meta/osac.yaml
@@ -7,6 +7,7 @@ template_type: network
 
 # NetworkClass registration fields
 implementation_strategy: openstack
+fabric_manager: openstack
 capabilities:
   supports_ipv4: true
   supports_ipv6: false


### PR DESCRIPTION
## Summary

- Add `fabric_manager` and `k8s_manager` optional fields to the `Metadata` and `NetworkClassTemplate` Pydantic models in `find_template_roles.py`
- Populate `fabric_manager` in all 5 network role `osac.yaml` files (`cudn_net`, `netris`, `metallb_l2`, `network_policy`, `openstack`); set `k8s_manager` for `cudn_net` only
- Pass `fabric_manager`, `k8s_manager`, and `is_default` from `Metadata` to `NetworkClassTemplate` in the `templates()` constructor (also fixes pre-existing `is_default` passthrough gap)
- Update `publish_templates` and `enumerate_templates` tests to include and assert on `fabric_manager`

The fulfillment-service now requires `fabric_manager` (non-empty string) when creating NetworkClasses via the private API. Without this field, the AAP `publish_templates` role gets 400 errors.

## Test plan

- [x] Run `publish_templates` mock API tests (`ansible-playbook -e test_empty=true`, `test_populated=true`, `test_no_items_key=true`)
- [x] Run `enumerate_templates` discovery tests (`ansible-playbook -e test_discover_all=true`)
- [x] Verify `fabric_manager` appears in serialized NetworkClass payloads
- [x] Confirm existing roles without `fabric_manager` in osac.yaml still parse (field is optional in Pydantic model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)