### PR TITLE
OSAC-1675: Add /ok-to-test support for fork PR E2E approval

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -43,6 +43,7 @@ jobs:
       # Pass author_association for fork PR authorization (empty for non-fork PRs)
       fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
       fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
+      pr-number: ${{ github.event.pull_request.number }}
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}

--- a/.github/workflows/ok-to-test-label-cleanup.yml
+++ b/.github/workflows/ok-to-test-label-cleanup.yml
@@ -1,0 +1,11 @@
+---
+name: Remove ok-to-test on new push
+on:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  remove-label:
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    uses: osac-project/osac-test-infra/.github/workflows/ok-to-test-label-cleanup.yml@main
+    secrets: inherit

--- a/.github/workflows/slash-command.yml
+++ b/.github/workflows/slash-command.yml
@@ -17,6 +17,7 @@ jobs:
       github.event.issue.pull_request &&
       (startsWith(github.event.comment.body, '/test') ||
        startsWith(github.event.comment.body, '/retest') ||
-       startsWith(github.event.comment.body, '/cancel'))
+       startsWith(github.event.comment.body, '/cancel') ||
+       startsWith(github.event.comment.body, '/ok-to-test'))
     uses: osac-project/osac-test-infra/.github/workflows/slash-command-handler.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

Caller-side changes for the `/ok-to-test` slash command ([osac-test-infra#151](https://github.com/osac-project/osac-test-infra/pull/151)).

- Add `/ok-to-test` to `slash-command.yml` filter
- Pass `pr-number` to the reusable e2e workflow
- Add `ok-to-test-label-cleanup.yml` to remove the label on new pushes

## Depends on

- https://github.com/osac-project/osac-test-infra/pull/151 (must merge first)

## Test plan

- [ ] `/ok-to-test` triggers the handler from this repo
- [ ] Label removed on new push to fork PR