### PR TITLE
OSAC-1960: Add GitHub Release creation to publish-charts workflow

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Publish osac-aap chart
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
     - name: Checkout repository
@@ -46,3 +46,15 @@ jobs:
       run: |
         helm push osac-aap-${{ steps.version.outputs.version }}.tgz \
           oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+
+    - name: Create GitHub Release
+      run: |
+        gh release create "${GITHUB_REF_NAME}" \
+          --repo "${{ github.repository }}" \
+          --title "osac-aap ${GITHUB_REF_NAME}" \
+          --generate-notes \
+        || gh release edit "${GITHUB_REF_NAME}" \
+          --repo "${{ github.repository }}" \
+          --title "osac-aap ${GITHUB_REF_NAME}"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a release step after chart push that creates a GitHub Release with auto-generated notes
- Change `contents` permission from `read` to `write` for `gh release create`
- Uses `gh release edit` fallback for idempotent re-runs

## Test plan
- [ ] Push a test tag and verify GitHub Release is created with auto-generated notes
- [ ] Re-run the workflow and verify `gh release edit` fallback works
- [ ] Verify chart publishing still works as before