### PR TITLE
OSAC-1816: Enhance ocp_4_20_ai_maas: observability, dashboard UI, multi-flavor deployment, version pinning resilience

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
@@ -5,6 +5,10 @@ ocp_4_20_ai_maas_ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.
 # Feature flags
 ocp_4_20_ai_maas_enable_maas: true
 ocp_4_20_ai_maas_enable_keycloak: true
+ocp_4_20_ai_maas_oidc_issuer: ""
+ocp_4_20_ai_maas_oidc_client_id: ""
+ocp_4_20_ai_maas_enable_observability: true
+ocp_4_20_ai_maas_enable_dashboard: true
 ocp_4_20_ai_maas_run_verify: true
 
 # --- Platform Operators ---
@@ -15,21 +19,30 @@ ocp_4_20_ai_maas_cert_manager_source: redhat-operators
 
 # Service Mesh (must install BEFORE RHCL)
 ocp_4_20_ai_maas_sm_channel: stable-3.2
-ocp_4_20_ai_maas_sm_starting_csv: servicemeshoperator3.v3.2.6
+ocp_4_20_ai_maas_sm_starting_csv: servicemeshoperator3.v3.2.7
 ocp_4_20_ai_maas_sm_source: redhat-operators
 
 # RHCL sub-operators (pre-create to prevent OLM auto-upgrade to v1.4.0)
-ocp_4_20_ai_maas_authorino_starting_csv: authorino-operator.v1.3.1
+ocp_4_20_ai_maas_authorino_starting_csv: authorino-operator.v1.3.2
 ocp_4_20_ai_maas_limitador_starting_csv: limitador-operator.v1.3.1
 ocp_4_20_ai_maas_dns_starting_csv: dns-operator.v1.3.1
 
 # RHCL operator
-ocp_4_20_ai_maas_rhcl_starting_csv: rhcl-operator.v1.3.4
+ocp_4_20_ai_maas_rhcl_starting_csv: rhcl-operator.v1.3.5
 ocp_4_20_ai_maas_rhcl_source: redhat-operators
 
 # Version to reject/accept in install plans
 ocp_4_20_ai_maas_reject_version: "v1.4.0"
 ocp_4_20_ai_maas_accept_version: "v1.3"
+
+# Observability operators (COO + OTel, installed in isolated namespaces)
+ocp_4_20_ai_maas_coo_starting_csv: cluster-observability-operator.v1.4.0
+ocp_4_20_ai_maas_coo_source: redhat-operators
+ocp_4_20_ai_maas_otel_package: opentelemetry-product
+ocp_4_20_ai_maas_otel_source: redhat-operators
+ocp_4_20_ai_maas_dsci_metrics_replicas: 1
+ocp_4_20_ai_maas_dsci_metrics_retention: 7d
+ocp_4_20_ai_maas_dsci_metrics_storage: 10Gi
 
 # Leader Worker Set
 ocp_4_20_ai_maas_lws_channel: stable-v1.0
@@ -63,7 +76,8 @@ ocp_4_20_ai_maas_gateway_cert_name: router-certs
 # PostgreSQL
 ocp_4_20_ai_maas_db_image: registry.redhat.io/rhel9/postgresql-16:latest
 ocp_4_20_ai_maas_db_user: maas
-ocp_4_20_ai_maas_db_password: maas-db-password  # Override in production
+# DEV ONLY — override all credential defaults in production deployments
+ocp_4_20_ai_maas_db_password: maas-db-password
 ocp_4_20_ai_maas_db_name: maas
 ocp_4_20_ai_maas_db_storage: 5Gi
 
@@ -71,16 +85,23 @@ ocp_4_20_ai_maas_db_storage: 5Gi
 ocp_4_20_ai_maas_keycloak_namespace: keycloak-maas
 ocp_4_20_ai_maas_keycloak_channel: stable-v26.4
 ocp_4_20_ai_maas_keycloak_instances: 1
-ocp_4_20_ai_maas_keycloak_db_password: keycloak-db-password  # Override in production
+ocp_4_20_ai_maas_keycloak_db_password: keycloak-db-password
 ocp_4_20_ai_maas_keycloak_db_storage: 5Gi
 ocp_4_20_ai_maas_keycloak_realm: maas
 ocp_4_20_ai_maas_keycloak_client_id: maas-client
-ocp_4_20_ai_maas_keycloak_client_secret: maas-client-secret-value  # Override in production
-ocp_4_20_ai_maas_keycloak_test_password: password123  # Override in production
+ocp_4_20_ai_maas_keycloak_client_secret: maas-client-secret-value
+ocp_4_20_ai_maas_keycloak_test_password: password123
 
 # Tenant
 ocp_4_20_ai_maas_tenant_name: default-tenant
 ocp_4_20_ai_maas_api_key_max_expiration_days: 90
+
+# Tenant telemetry (captureUser defaults to true for Usage tab; privacy-sensitive)
+ocp_4_20_ai_maas_telemetry_enabled: true
+ocp_4_20_ai_maas_telemetry_capture_user: true
+ocp_4_20_ai_maas_telemetry_capture_group: true
+ocp_4_20_ai_maas_telemetry_capture_organization: true
+ocp_4_20_ai_maas_telemetry_capture_model_usage: true
 
 # Model
 ocp_4_20_ai_maas_model_name: facebook-opt-125m-simulated

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/argument_specs.yaml
@@ -21,7 +21,38 @@ argument_specs:
         type: bool
         required: false
         default: true
-        description: Deploy a dedicated Keycloak instance for MaaS OIDC authentication.
+        description: >
+          Deploy a dedicated Keycloak instance for MaaS OIDC authentication.
+          When false and enable_maas is true, oidc_issuer must be provided.
+      ocp_4_20_ai_maas_oidc_issuer:
+        type: str
+        required: false
+        default: ""
+        description: >
+          External OIDC issuer URL (e.g., shared OSAC Keycloak or customer IdP).
+          Kuadrant AuthPolicy auto-discovers JWKS via OIDC discovery.
+          Required when enable_maas is true and enable_keycloak is false.
+      ocp_4_20_ai_maas_oidc_client_id:
+        type: str
+        required: false
+        default: ""
+        description: >
+          OIDC client ID registered in the external identity provider.
+          Required when enable_maas is true and enable_keycloak is false.
+      ocp_4_20_ai_maas_enable_observability:
+        type: bool
+        required: false
+        default: true
+        description: >
+          Install COO v1.4 + OTel operators and configure DSCI metrics for
+          the observability dashboard (Cluster/Models/Usage tabs).
+      ocp_4_20_ai_maas_enable_dashboard:
+        type: bool
+        required: false
+        default: true
+        description: >
+          Deploy the RHOAI web console for model management and monitoring.
+          Set to false for headless inference clusters managed via API only.
       ocp_4_20_ai_maas_run_verify:
         type: bool
         required: false
@@ -56,7 +87,7 @@ argument_specs:
       ocp_4_20_ai_maas_sm_starting_csv:
         type: str
         required: false
-        default: "servicemeshoperator3.v3.2.6"
+        default: "servicemeshoperator3.v3.2.7"
         description: Starting CSV for Service Mesh subscription (Manual approval).
       ocp_4_20_ai_maas_sm_source:
         type: str
@@ -66,7 +97,7 @@ argument_specs:
       ocp_4_20_ai_maas_authorino_starting_csv:
         type: str
         required: false
-        default: "authorino-operator.v1.3.1"
+        default: "authorino-operator.v1.3.2"
         description: Starting CSV for Authorino operator. Pre-created to prevent OLM auto-upgrade to v1.4.0.
       ocp_4_20_ai_maas_limitador_starting_csv:
         type: str
@@ -81,9 +112,9 @@ argument_specs:
       ocp_4_20_ai_maas_rhcl_starting_csv:
         type: str
         required: false
-        default: "rhcl-operator.v1.3.4"
+        default: "rhcl-operator.v1.3.5"
         description: >
-          Starting CSV for RHCL operator. Pinned to 1.3.4 per
+          Starting CSV for RHCL operator. Pinned to v1.3.x per
           https://access.redhat.com/articles/7092611.
       ocp_4_20_ai_maas_rhcl_source:
         type: str
@@ -103,6 +134,46 @@ argument_specs:
           Version pattern to accept in sub-operator install plan approval. OLM may
           bundle v1.4.0 upgrades with v1.3.x installs non-deterministically; this
           ensures plans containing v1.3.x CSVs are approved regardless.
+      # --- Observability Operators ---
+      ocp_4_20_ai_maas_coo_starting_csv:
+        type: str
+        required: false
+        default: "cluster-observability-operator.v1.4.0"
+        description: >
+          Starting CSV for COO. Pinned to v1.4.0 — v1.5 breaks RHOAI 3.4
+          (CEL validation + Perses image incompatibility). See RHOAIENG-69180.
+      ocp_4_20_ai_maas_coo_source:
+        type: str
+        required: false
+        default: "redhat-operators"
+        description: OLM catalog source for Cluster Observability Operator.
+      ocp_4_20_ai_maas_otel_package:
+        type: str
+        required: false
+        default: "opentelemetry-product"
+        description: OLM package name for Red Hat OpenTelemetry operator.
+      ocp_4_20_ai_maas_otel_source:
+        type: str
+        required: false
+        default: "redhat-operators"
+        description: OLM catalog source for OpenTelemetry operator.
+      ocp_4_20_ai_maas_dsci_metrics_replicas:
+        type: int
+        required: false
+        default: 1
+        description: Number of Prometheus replicas for DSCI metrics collection.
+      ocp_4_20_ai_maas_dsci_metrics_retention:
+        type: str
+        required: false
+        default: "7d"
+        description: Prometheus metrics retention period for DSCI.
+      ocp_4_20_ai_maas_dsci_metrics_storage:
+        type: str
+        required: false
+        default: "10Gi"
+        description: PVC size for DSCI Prometheus metrics storage.
+
+      # --- Leader Worker Set ---
       ocp_4_20_ai_maas_lws_channel:
         type: str
         required: false
@@ -164,7 +235,7 @@ argument_specs:
         type: str
         required: false
         default: "maas-db-password"
-        description: PostgreSQL password for the maas-api database. Override in production.
+        description: "DEV ONLY — PostgreSQL password for the maas-api database. Must be overridden for production."
       ocp_4_20_ai_maas_db_name:
         type: str
         required: false
@@ -196,7 +267,7 @@ argument_specs:
         type: str
         required: false
         default: "keycloak-db-password"
-        description: PostgreSQL password for Keycloak database. Override in production.
+        description: "DEV ONLY — PostgreSQL password for Keycloak database. Must be overridden for production."
       ocp_4_20_ai_maas_keycloak_db_storage:
         type: str
         required: false
@@ -216,12 +287,12 @@ argument_specs:
         type: str
         required: false
         default: "maas-client-secret-value"
-        description: OIDC client secret for MaaS. Override in production.
+        description: "DEV ONLY — OIDC client secret for MaaS. Must be overridden for production."
       ocp_4_20_ai_maas_keycloak_test_password:
         type: str
         required: false
         default: "password123"
-        description: Password for test users created in the Keycloak realm. Override in production.
+        description: "DEV ONLY — Password for test users in the Keycloak realm. Must be overridden for production."
 
       # --- Tenant ---
       ocp_4_20_ai_maas_tenant_name:
@@ -234,6 +305,38 @@ argument_specs:
         required: false
         default: 90
         description: Maximum API key expiration in days.
+
+      # --- Tenant Telemetry ---
+      ocp_4_20_ai_maas_telemetry_enabled:
+        type: bool
+        required: false
+        default: true
+        description: Enable telemetry collection in the MaaS Tenant.
+      ocp_4_20_ai_maas_telemetry_capture_user:
+        type: bool
+        required: false
+        default: true
+        description: >
+          Include user identity in Limitador metrics. Required for
+          the Usage tab to show per-user data. Privacy-sensitive —
+          set to false if user tracking is not desired.
+      ocp_4_20_ai_maas_telemetry_capture_group:
+        type: bool
+        required: false
+        default: true
+        description: >
+          Include group labels in Limitador metrics. Increases
+          metric cardinality.
+      ocp_4_20_ai_maas_telemetry_capture_organization:
+        type: bool
+        required: false
+        default: true
+        description: Include organization_id in Limitador metrics.
+      ocp_4_20_ai_maas_telemetry_capture_model_usage:
+        type: bool
+        required: false
+        default: true
+        description: Include model labels in usage metrics.
 
       # --- Model ---
       ocp_4_20_ai_maas_model_name:

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
@@ -2,11 +2,62 @@
 title: OpenShift AI 4.20 Cluster with MaaS
 description: >
   Builds an OpenShift 4.20 cluster with RHOAI 3.4, Models-as-a-Service (GA),
-  Keycloak SSO, and GPU support. Includes RHCL 1.3 version pinning for auth
-  enforcement compatibility with Service Mesh 3.2.
+  Keycloak SSO, and observability (COO + OTel). Supports both GPU deployments
+  and CPU-only simulator mode for testing. Includes RHCL 1.3 version pinning
+  for auth enforcement compatibility with Service Mesh 3.2. Single-tenant
+  deployment — one organization per cluster.
 template_type: cluster
 implementation_strategy: ocp_4_20_ai_maas
 default_node_request:
   - resourceClass: dgx
     numberOfNodes: 2
 allowed_resource_classes: []
+parameters:
+  - name: enable_maas
+    title: Enable MaaS Gateway
+    description: >
+      Install MaaS governance layer (auth, rate limiting, API keys).
+      Set to false for inference-only shared clusters.
+    type: boolean
+    required: false
+    default: true
+  - name: enable_keycloak
+    title: Enable Managed Keycloak
+    description: >
+      Deploy per-cluster Keycloak for MaaS identity management.
+      Set to false when using shared OSAC Keycloak or BYOIDP.
+      When false and enable_maas is true, oidc_issuer must be provided.
+    type: boolean
+    required: false
+    default: true
+  - name: oidc_issuer
+    title: External OIDC Issuer URL
+    description: >
+      OIDC issuer URL for external identity provider (e.g., shared OSAC Keycloak
+      or customer IdP). Kuadrant AuthPolicy auto-discovers JWKS via OIDC discovery
+      ({issuerUrl}/.well-known/openid-configuration -> jwks_uri).
+      Required when enable_maas is true and enable_keycloak is false.
+    type: string
+    required: false
+  - name: oidc_client_id
+    title: External OIDC Client ID
+    description: >
+      OIDC client ID registered in the external identity provider.
+      Required when enable_maas is true and enable_keycloak is false.
+    type: string
+    required: false
+  - name: enable_observability
+    title: Enable Observability Stack
+    description: >
+      Install COO v1.4, OTel, and Perses dashboards for model monitoring.
+    type: boolean
+    required: false
+    default: true
+  - name: enable_dashboard
+    title: Enable OpenShift AI Dashboard
+    description: >
+      Deploy the RHOAI web console for model management and monitoring.
+      Set to false for headless inference clusters managed via API only.
+    type: boolean
+    required: false
+    default: true

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_cluster.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_cluster.yaml
@@ -1,0 +1,226 @@
+---
+# Cluster-level configuration that runs regardless of MaaS.
+# Discovers cluster domain, creates inference gateway, verifies observability.
+
+# --- Discover cluster domain ---
+
+- name: Get cluster ingress domain
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: _ingress_config
+
+- name: Set cluster domain
+  ansible.builtin.set_fact:
+    _cluster_domain: "{{ _ingress_config.resources[0].spec.domain }}"
+
+- name: Get ingress certificate name
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operator.openshift.io/v1
+    kind: IngressController
+    name: default
+    namespace: openshift-ingress-operator
+  register: _ingress_controller
+
+- name: Set certificate name
+  ansible.builtin.set_fact:
+    _cert_name: >-
+      {{ (_ingress_controller.resources[0].spec.defaultCertificate | default({})).name
+         | default(ocp_4_20_ai_maas_gateway_cert_name) }}
+
+- name: Report cluster info
+  ansible.builtin.debug:
+    msg:
+      - "Cluster domain: {{ _cluster_domain }}"
+      - "Certificate: {{ _cert_name }}"
+
+# --- User Workload Monitoring (required for vLLM metrics scraping) ---
+
+- name: Apply User Workload Monitoring
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ item }}"
+  loop: "{{ lookup('ansible.builtin.template', 'user-workload-monitoring.yaml.j2') | from_yaml_all | list }}"
+  loop_control:
+    label: "{{ item.kind }}/{{ item.metadata.name }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_observability | bool
+
+# --- openshift-ai-inference gateway ---
+# TEMPORARY WORKAROUND: RHOAI operator does not create openshift-ai-inference
+# gateway. Dashboard-deployed LLMInferenceService models need it. See: RHOAIENG-38214
+
+- name: Create openshift-ai-inference gateway
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    template: openshift-ai-inference-gateway.yaml.j2
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Wait for openshift-ai-inference gateway Programmed
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: gateway.networking.k8s.io/v1
+    kind: Gateway
+    name: openshift-ai-inference
+    namespace: openshift-ingress
+  register: _ai_gw
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _ai_gw.resources is defined
+    - _ai_gw.resources | length > 0
+    - >-
+      _ai_gw.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Programmed')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+- name: Fail if openshift-ai-inference gateway never became Programmed
+  ansible.builtin.fail:
+    msg: >-
+      openshift-ai-inference gateway did not become Programmed after
+      {{ ocp_4_20_ai_maas_operator_retries }} retries.
+  when: >-
+    _ai_gw.resources is not defined
+    or _ai_gw.resources | length == 0
+    or (_ai_gw.resources[0].status.conditions | default([])
+       | selectattr('type', 'equalto', 'Programmed')
+       | selectattr('status', 'equalto', 'True')
+       | list | length == 0)
+
+# --- Dashboard feature flags (non-MaaS) ---
+
+- name: Patch OdhDashboardConfig with observability flag
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    merge_type: merge
+    definition:
+      apiVersion: opendatahub.io/v1alpha
+      kind: OdhDashboardConfig
+      metadata:
+        name: odh-dashboard-config
+        namespace: redhat-ods-applications
+      spec:
+        dashboardConfig:
+          observabilityDashboard: true
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when:
+    - ocp_4_20_ai_maas_enable_observability | bool
+    - ocp_4_20_ai_maas_enable_dashboard | bool
+
+- name: Patch OdhDashboardConfig with general flags
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    merge_type: merge
+    definition:
+      apiVersion: opendatahub.io/v1alpha
+      kind: OdhDashboardConfig
+      metadata:
+        name: odh-dashboard-config
+        namespace: redhat-ods-applications
+      spec:
+        dashboardConfig:
+          deploymentWizardYAMLViewer: true
+          vLLMDeploymentOnMaaS: true
+          llmGatewayField: true
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_dashboard | bool
+
+# --- Verify observability resources (auto-created by RHOAI operator) ---
+
+- name: Wait for Monitoring CR Ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: services.platform.opendatahub.io/v1alpha1
+    kind: Monitoring
+    name: default-monitoring
+  register: _monitoring
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _monitoring.resources is defined
+    - _monitoring.resources | length > 0
+    - >-
+      _monitoring.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Ready')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+  when: ocp_4_20_ai_maas_enable_observability | bool
+
+- name: Verify Perses pod running
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: v1
+    kind: Pod
+    namespace: redhat-ods-monitoring
+    label_selectors:
+      - app.kubernetes.io/name=data-science-perses
+  register: _perses_pods
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _perses_pods.resources is defined
+    - _perses_pods.resources | length > 0
+    - _perses_pods.resources[0].status.phase | default('') == 'Running'
+  when: ocp_4_20_ai_maas_enable_observability | bool
+
+- name: Verify PersesDatasources created
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: perses.dev/v1alpha2
+    kind: PersesDatasource
+    namespace: redhat-ods-monitoring
+  register: _datasources
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _datasources.resources is defined
+    - _datasources.resources | length >= 2
+  when: ocp_4_20_ai_maas_enable_observability | bool
+
+- name: Verify PersesDashboards created
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: perses.dev/v1alpha2
+    kind: PersesDashboard
+    namespace: redhat-ods-monitoring
+  register: _dashboards
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _dashboards.resources is defined
+    - _dashboards.resources | length >= 2
+  when:
+    - ocp_4_20_ai_maas_enable_observability | bool
+    - ocp_4_20_ai_maas_enable_dashboard | bool
+
+- name: Report observability status
+  ansible.builtin.debug:
+    msg: >-
+      Observability: Monitoring=Ready, Perses=Running,
+      Datasources={{ _datasources.resources | map(attribute='metadata.name') | list }}{{ ', Dashboards=' + (_dashboards.resources | map(attribute='metadata.name') | list | string) if (ocp_4_20_ai_maas_enable_dashboard | bool) else ' (headless — no dashboard UI)' }}
+  when: ocp_4_20_ai_maas_enable_observability | bool

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_maas.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_maas.yaml
@@ -1,46 +1,29 @@
 ---
 # MaaS deployment: Keycloak → prereqs → enable MaaS → model → subscriptions
 # Translates design-thinking/maas/README.md Phases 1-5 into Ansible tasks.
+# Cluster domain (_cluster_domain, _cert_name) set by configure_cluster.yaml.
 
-# --- Discover cluster domain ---
+# --- Validate parameters ---
 
-- name: Get cluster ingress domain
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    api_version: config.openshift.io/v1
-    kind: Ingress
-    name: cluster
-  register: _ingress_config
-
-- name: Set cluster domain
-  ansible.builtin.set_fact:
-    _cluster_domain: "{{ _ingress_config.resources[0].spec.domain }}"
-
-- name: Get ingress certificate name
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    api_version: operator.openshift.io/v1
-    kind: IngressController
-    name: default
-    namespace: openshift-ingress-operator
-  register: _ingress_controller
-
-- name: Set certificate name
-  ansible.builtin.set_fact:
-    _cert_name: >-
-      {{ (_ingress_controller.resources[0].spec.defaultCertificate | default({})).name
-         | default(ocp_4_20_ai_maas_gateway_cert_name) }}
-
-- name: Report cluster info
-  ansible.builtin.debug:
-    msg:
-      - "Cluster domain: {{ _cluster_domain }}"
-      - "Certificate: {{ _cert_name }}"
+- name: Validate oidc_issuer and oidc_client_id when using external IdP
+  ansible.builtin.assert:
+    that:
+      - ocp_4_20_ai_maas_oidc_issuer is defined
+      - ocp_4_20_ai_maas_oidc_issuer | length > 0
+      - ocp_4_20_ai_maas_oidc_client_id is defined
+      - ocp_4_20_ai_maas_oidc_client_id | length > 0
+    fail_msg: >-
+      oidc_issuer and oidc_client_id are required when enable_maas=true and
+      enable_keycloak=false. Provide the OIDC issuer URL and client ID of
+      your external identity provider.
+  when:
+    - ocp_4_20_ai_maas_enable_maas | bool
+    - not (ocp_4_20_ai_maas_enable_keycloak | bool)
 
 # --- Phase 1: Keycloak (conditional) ---
 
 - name: Deploy Keycloak MaaS instance
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
   block:
     - name: Apply Keycloak resources (namespace, RHBK, PostgreSQL, instance, route)
       kubernetes.core.k8s:
@@ -147,19 +130,6 @@
 
 # --- Phase 2: MaaS Prerequisites ---
 
-- name: Apply User Workload Monitoring
-  kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    state: present
-    definition: "{{ item }}"
-  loop: "{{ lookup('ansible.builtin.template', 'user-workload-monitoring.yaml.j2') | from_yaml_all | list }}"
-  loop_control:
-    label: "{{ item.kind }}/{{ item.metadata.name }}"
-  register: _r
-  retries: 5
-  delay: 10
-  until: _r is not failed
-
 - name: Apply Kuadrant resources (namespace, service, Kuadrant, Authorino)
   kubernetes.core.k8s:
     kubeconfig: "{{ admin_kubeconfig }}"
@@ -230,6 +200,43 @@
       | selectattr('type', 'equalto', 'Programmed')
       | selectattr('status', 'equalto', 'True')
       | list | length > 0
+
+# Create maas-db namespace first — PVC creation can fail silently if namespace
+# isn't fully active (admission webhooks, quota controllers need time).
+- name: Create maas-db namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: maas-db
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+
+- name: Create maas-postgres PVC
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: maas-postgres-pvc
+        namespace: maas-db
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "{{ ocp_4_20_ai_maas_db_storage }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
 
 - name: Apply PostgreSQL for maas-api
   kubernetes.core.k8s:
@@ -352,11 +359,18 @@
         externalOIDC: >-
           {{ {'issuerUrl': 'https://' + ocp_4_20_ai_maas_keycloak_namespace + '.' + _cluster_domain + '/realms/' + ocp_4_20_ai_maas_keycloak_realm,
               'clientId': ocp_4_20_ai_maas_keycloak_client_id}
-             if ocp_4_20_ai_maas_enable_keycloak else omit }}
+             if ocp_4_20_ai_maas_enable_keycloak | bool
+             else {'issuerUrl': ocp_4_20_ai_maas_oidc_issuer,
+                   'clientId': ocp_4_20_ai_maas_oidc_client_id} }}
         apiKeys:
           maxExpirationDays: "{{ ocp_4_20_ai_maas_api_key_max_expiration_days }}"
         telemetry:
-          enabled: true
+          enabled: "{{ ocp_4_20_ai_maas_telemetry_enabled }}"
+          metrics:
+            captureUser: "{{ ocp_4_20_ai_maas_telemetry_capture_user }}"
+            captureGroup: "{{ ocp_4_20_ai_maas_telemetry_capture_group }}"
+            captureOrganization: "{{ ocp_4_20_ai_maas_telemetry_capture_organization }}"
+            captureModelUsage: "{{ ocp_4_20_ai_maas_telemetry_capture_model_usage }}"
     merge_type: merge
   register: _r
   retries: 5
@@ -378,6 +392,39 @@
     - _tenant.resources is defined
     - _tenant.resources | length > 0
     - _tenant.resources[0].status.phase | default('') == 'Active'
+
+- name: Fail if Tenant never became Active
+  ansible.builtin.fail:
+    msg: >-
+      Tenant {{ ocp_4_20_ai_maas_tenant_name }} did not become Active after
+      {{ ocp_4_20_ai_maas_operator_retries }} retries.
+  when: >-
+    _tenant.resources is not defined
+    or _tenant.resources | length == 0
+    or _tenant.resources[0].status.phase | default('') != 'Active'
+
+# --- Phase 3b: Dashboard feature flags ---
+
+- name: Patch OdhDashboardConfig with MaaS feature flags
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    merge_type: merge
+    definition:
+      apiVersion: opendatahub.io/v1alpha
+      kind: OdhDashboardConfig
+      metadata:
+        name: odh-dashboard-config
+        namespace: redhat-ods-applications
+      spec:
+        dashboardConfig:
+          modelAsService: true
+          maasAuthPolicies: true
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_dashboard | bool
 
 # --- Phase 4: Deploy Model ---
 
@@ -424,6 +471,18 @@
       | selectattr('status', 'equalto', 'True')
       | list | length > 0
 
+- name: Fail if LLMInferenceService never became Ready
+  ansible.builtin.fail:
+    msg: >-
+      LLMInferenceService {{ ocp_4_20_ai_maas_model_name }} did not become Ready.
+  when: >-
+    _llm.resources is not defined
+    or _llm.resources | length == 0
+    or (_llm.resources[0].status.conditions | default([])
+       | selectattr('type', 'equalto', 'Ready')
+       | selectattr('status', 'equalto', 'True')
+       | list | length == 0)
+
 - name: Create MaaSModelRef
   kubernetes.core.k8s:
     kubeconfig: "{{ admin_kubeconfig }}"
@@ -449,6 +508,15 @@
     - _modelref.resources is defined
     - _modelref.resources | length > 0
     - _modelref.resources[0].status.phase | default('') == 'Ready'
+
+- name: Fail if MaaSModelRef never became Ready
+  ansible.builtin.fail:
+    msg: >-
+      MaaSModelRef {{ ocp_4_20_ai_maas_model_name }} did not become Ready.
+  when: >-
+    _modelref.resources is not defined
+    or _modelref.resources | length == 0
+    or _modelref.resources[0].status.phase | default('') != 'Ready'
 
 # --- Phase 5: Auth Policies + Subscriptions ---
 
@@ -488,6 +556,86 @@
   until:
     - _auth_policy.resources is defined
     - _auth_policy.resources | length > 0
+
+# Restart maas-controller to force fresh subscription reconciliation.
+# The controller can hit a leader election timeout during initial subscription
+# creation, reading TRLP status before Kuadrant fully accepts it. Without a
+# restart, subscriptions stay Degraded and inference returns 403.
+- name: Restart maas-controller for subscription reconciliation
+  environment:
+    KUBECONFIG: "{{ admin_kubeconfig | expanduser }}"
+  ansible.builtin.shell: |
+    oc rollout restart deployment/maas-controller -n redhat-ods-applications
+    oc rollout status deployment/maas-controller -n redhat-ods-applications --timeout=180s
+  args:
+    executable: /bin/bash
+  changed_when: true
+
+- name: Wait for all subscriptions Active
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: MaaSSubscription
+    namespace: models-as-a-service
+  register: _subs
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _subs.resources is defined
+    - _subs.resources | length > 0
+    - >-
+      _subs.resources
+      | selectattr('status.phase', 'defined')
+      | selectattr('status.phase', 'equalto', 'Active')
+      | list | length == _subs.resources | length
+
+- name: Fail if subscriptions never became Active
+  ansible.builtin.fail:
+    msg: >-
+      Not all MaaSSubscriptions became Active after
+      {{ ocp_4_20_ai_maas_operator_retries }} retries.
+  when: >-
+    _subs.resources is not defined
+    or _subs.resources | length == 0
+    or (_subs.resources
+       | selectattr('status.phase', 'defined')
+       | selectattr('status.phase', 'equalto', 'Active')
+       | list | length != _subs.resources | length)
+
+# Wait for TokenRateLimitPolicy to fully propagate to Limitador after controller
+# restart. Without this, rate limiting verify tests fail (all 200, no 429).
+- name: Wait for TokenRateLimitPolicy enforcement
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: kuadrant.io/v1alpha1
+    kind: TokenRateLimitPolicy
+    namespace: "{{ ocp_4_20_ai_maas_model_namespace }}"
+  register: _trlp
+  retries: 12
+  delay: 10
+  ignore_errors: true
+  until:
+    - _trlp.resources is defined
+    - _trlp.resources | length > 0
+    - >-
+      _trlp.resources[0].status.conditions | default([])
+      | selectattr('type', 'equalto', 'Enforced')
+      | selectattr('status', 'equalto', 'True')
+      | list | length > 0
+
+- name: Fail if TRLP enforcement never converged
+  ansible.builtin.fail:
+    msg: >-
+      TokenRateLimitPolicy did not reach Enforced state.
+      Rate limiting may not be active.
+  when: >-
+    _trlp.resources is not defined
+    or _trlp.resources | length == 0
+    or (_trlp.resources[0].status.conditions | default([])
+       | selectattr('type', 'equalto', 'Enforced')
+       | selectattr('status', 'equalto', 'True')
+       | list | length == 0)
 
 - name: Report MaaS configuration complete
   ansible.builtin.debug:

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
@@ -147,7 +147,7 @@
       metadata:
         name: "{{ ocp_4_20_ai_maas_keycloak_namespace }}"
   ignore_errors: true
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 - name: Remove models-as-a-service namespace
   kubernetes.core.k8s:

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install.yaml
@@ -3,6 +3,20 @@
 # Delegates cluster creation to ocp_4_17_small and overrides the
 # post-install hook to install operators and configure MaaS.
 
+# Bridge templateParameters (short names from OSAC pipeline) to role variables
+# (prefixed names). Only runs when called via the OSAC pipeline where
+# cluster_settings has parsed spec.templateParameters into template_parameters dict.
+# When running standalone with -e, template_parameters is not defined — skipped.
+- name: Bridge templateParameters to role variables
+  ansible.builtin.set_fact:
+    ocp_4_20_ai_maas_enable_maas: "{{ template_parameters.enable_maas | default(true) | bool }}"
+    ocp_4_20_ai_maas_enable_keycloak: "{{ (template_parameters.enable_keycloak | default(true) | bool) and (template_parameters.enable_maas | default(true) | bool) }}"
+    ocp_4_20_ai_maas_oidc_issuer: "{{ template_parameters.oidc_issuer | default('') }}"
+    ocp_4_20_ai_maas_oidc_client_id: "{{ template_parameters.oidc_client_id | default('') }}"
+    ocp_4_20_ai_maas_enable_observability: "{{ template_parameters.enable_observability | default(true) | bool }}"
+    ocp_4_20_ai_maas_enable_dashboard: "{{ template_parameters.enable_dashboard | default(true) | bool }}"
+  when: template_parameters is defined
+
 - name: Create cluster with RHOAI + MaaS post-install
   ansible.builtin.include_role:
     name: osac.templates.ocp_4_17_small

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
@@ -3,6 +3,31 @@
 # Critical ordering: cert-manager → SM 3.2 → sub-operators → RHCL → LWS → RHOAI → DSC
 # SM must be installed BEFORE RHCL subscriptions exist to prevent OLM bundling v1.4.0 upgrades.
 
+- name: Validate enable_keycloak requires enable_maas
+  ansible.builtin.assert:
+    that:
+      - ocp_4_20_ai_maas_enable_maas | bool
+    fail_msg: >-
+      enable_keycloak=true requires enable_maas=true. Keycloak without MaaS
+      has no gateway to authenticate against.
+  when:
+    - ocp_4_20_ai_maas_enable_keycloak | bool
+
+- name: Validate BYOIDP parameters before operator installation
+  ansible.builtin.assert:
+    that:
+      - ocp_4_20_ai_maas_oidc_issuer is defined
+      - ocp_4_20_ai_maas_oidc_issuer | length > 0
+      - ocp_4_20_ai_maas_oidc_client_id is defined
+      - ocp_4_20_ai_maas_oidc_client_id | length > 0
+    fail_msg: >-
+      oidc_issuer and oidc_client_id are required when enable_maas=true and
+      enable_keycloak=false. Provide the OIDC issuer URL and client ID of
+      your external identity provider.
+  when:
+    - ocp_4_20_ai_maas_enable_maas | bool
+    - not (ocp_4_20_ai_maas_enable_keycloak | bool)
+
 - name: Validate shell-interpolated variables (prevent injection)
   ansible.builtin.assert:
     that:
@@ -13,6 +38,7 @@
       - ocp_4_20_ai_maas_dns_starting_csv is regex('^[\w.\-]+$')
       - ocp_4_20_ai_maas_rhcl_starting_csv is regex('^[\w.\-]+$')
       - ocp_4_20_ai_maas_sm_starting_csv is regex('^[\w.\-]+$')
+      - ocp_4_20_ai_maas_coo_starting_csv is regex('^[\w.\-]+$')
     fail_msg: "Shell-interpolated variables contain invalid characters"
 
 # --- Step 1: cert-manager ---
@@ -98,321 +124,351 @@
         - _cert_manager_sub.resources | length > 0
         - _cert_manager_sub.resources[0].status.installedCSV is defined
 
-# --- Step 2: Service Mesh 3.2 (MUST be before RHCL) ---
-# TEMPORARY WORKAROUND: OCP Ingress Operator pre-creates a SM subscription on
-# 'stable' channel and continuously reconciles it (ingress.operator.openshift.io/owned).
-# We scale down the Ingress Operator for the entire operator install phase, replace
-# the subscription without the owned annotation, then scale it back up at the end.
-# Remove once RHCL v1.4.0 compatibility with SM is resolved and SM version pinning
-# is no longer needed. See: https://access.redhat.com/solutions/7097633
-
-- name: Scale down Ingress Operator (prevents SM subscription override)
-  kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    state: present
-    definition:
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: ingress-operator
-        namespace: openshift-ingress-operator
-      spec:
-        replicas: 0
-    merge_type: merge
-  register: _r
-  retries: 5
-  delay: 10
-  until: _r is not failed
-
-- name: Wait for Ingress Operator to stop
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    api_version: apps/v1
-    kind: Deployment
-    name: ingress-operator
-    namespace: openshift-ingress-operator
-  register: _ingress_op
-  retries: 6
-  delay: 5
-  until:
-    - _ingress_op.resources | length > 0
-    - (_ingress_op.resources[0].status.replicas | default(0)) == 0
-
-- name: Delete Ingress Operator SM subscription
-  kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    state: absent
-    api_version: operators.coreos.com/v1alpha1
-    kind: Subscription
-    name: servicemeshoperator3
-    namespace: openshift-operators
-  ignore_errors: true
-
-- name: Create Service Mesh Subscription (stable-3.2, Manual, no owned annotation)
-  kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    state: present
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: servicemeshoperator3
-        namespace: openshift-operators
-      spec:
-        channel: "{{ ocp_4_20_ai_maas_sm_channel }}"
-        installPlanApproval: Manual
-        name: servicemeshoperator3
-        source: "{{ ocp_4_20_ai_maas_sm_source }}"
-        sourceNamespace: openshift-marketplace
-        startingCSV: "{{ ocp_4_20_ai_maas_sm_starting_csv }}"
-  register: _r
-  retries: 5
-  delay: 10
-  until: _r is not failed
-
-- name: Find stale SM CSVs (not v3.2.x)
-  kubernetes.core.k8s_info:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    namespace: openshift-operators
-    label_selectors:
-      - "operators.coreos.com/servicemeshoperator3.openshift-operators"
-  register: _sm_stale_csvs
-
-- name: Delete stale SM CSVs
-  kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    state: absent
-    api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    name: "{{ item.metadata.name }}"
-    namespace: openshift-operators
-  loop: "{{ _sm_stale_csvs.resources | default([]) }}"
-  loop_control:
-    label: "{{ item.metadata.name }}"
-  when: "'v3.2' not in item.metadata.name"
-  ignore_errors: true
-
-# TEMPORARY WORKAROUND: RHCL v1.4.0 breaks MaaS auth enforcement (Envoy
-# allow_on_headers_stop_iteration not supported by SM 3.2/3.3). Tasks from here
-# through "Approve install plans and wait for RHCL CSV" implement a two-pass
-# install plan approval strategy to pin RHCL at v1.3.x. Remove once RHCL v1.4.0
-# compatibility with SM is resolved. See: https://access.redhat.com/solutions/7097633
-- name: Clear stale installedCSV from SM subscription
+# --- Guard: clean stale sailoperator CRDs ---
+- name: Clean stale sailoperator CRDs (prevents SM install plan failure)
   environment:
     KUBECONFIG: "{{ admin_kubeconfig }}"
   ansible.builtin.shell: |
     export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
-    oc patch sub servicemeshoperator3 -n openshift-operators --type merge \
-      --subresource status -p '{"status":{"installedCSV":"","currentCSV":""}}' 2>/dev/null || true
+    SM_OK=$(oc get csv -n openshift-operators -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | tr ' ' '\n' | grep servicemeshoperator3 | head -1)
+    if [ -n "$SM_OK" ]; then
+      # SM CSV exists (any state) — CRDs are actively needed, don't delete.
+      # On retry, Ingress Operator may have overwritten the subscription so
+      # CSV can be Pending/Installing/Replacing — deleting CRDs would make
+      # SM unrecoverable (install plans already Complete, won't recreate).
+      exit 0
+    fi
+    for crd in $(oc get crd -o jsonpath='{.items[*].metadata.name}' 2>/dev/null | tr ' ' '\n' | grep sailoperator); do
+      oc delete crd "$crd" --timeout=15s 2>/dev/null || true
+    done
   args:
     executable: /bin/bash
   changed_when: false
 
-- name: Delete stale SM install plans
-  environment:
-    KUBECONFIG: "{{ admin_kubeconfig }}"
-  ansible.builtin.shell: |
-    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
-    oc get installplan -n openshift-operators -o json 2>/dev/null | \
-      jq -r '.items[] | select(.spec.clusterServiceVersionNames | join(",") | test("servicemeshoperator3")) |
-        select(.spec.clusterServiceVersionNames | join(",") | test("v3\\.2") | not) |
-        .metadata.name' 2>/dev/null | \
-      while read -r plan; do
-        oc delete installplan "$plan" -n openshift-operators 2>/dev/null || true
-      done || true
-  args:
-    executable: /bin/bash
-  changed_when: false
+# --- Steps 2-4: MaaS gateway operators (SM, sub-operators, RHCL) ---
+# Only installed when enable_maas is true. For inference-only clusters, SM 3
+# auto-installs via RHOAI DSC — no version pinning or sub-operators needed.
+- name: Install MaaS gateway operators (SM, RHCL, sub-operators)
+  when: ocp_4_20_ai_maas_enable_maas | bool
+  block:
+    # Delete stale subscriptions, CSVs, and install plans from prior runs.
+    # state:present updates spec but NOT status.installedCSV — stale installedCSV
+    # from prior runs makes OLM think operators are already installed → generates
+    # upgrade plans instead of install plans → UpgradePending.
+    # Already-approved v1.4.0 install plans also survive and cause immediate
+    # v1.4.0 installation before hold-until-clean can reject.
+    - name: Delete stale subscriptions, CSVs, and install plans in openshift-operators
+      environment:
+        KUBECONFIG: "{{ admin_kubeconfig }}"
+        ACCEPT: "{{ ocp_4_20_ai_maas_accept_version }}"
+      ansible.builtin.shell: |
+        export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+        # Skip cleanup if all operators have a v1.3.x CSV Succeeded
+        ALL_OK=true
+        for op in authorino-operator limitador-operator dns-operator rhcl-operator; do
+          phase=$(oc get csv -n openshift-operators --no-headers 2>/dev/null | \
+            grep "${op}.*${ACCEPT}" | head -1 | awk '{print $NF}')
+          [ "$phase" != "Succeeded" ] && ALL_OK=false && break
+        done
+        [ "$ALL_OK" = "true" ] && echo "All operators at v1.3.x, skipping cleanup" && exit 0
 
-- name: Approve install plans and wait for SM CSV
-  environment:
-    KUBECONFIG: "{{ admin_kubeconfig }}"
-  ansible.builtin.shell: |
-    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
-    # Approve unapproved install plans that do not contain the reject version
-    oc get installplan -n openshift-operators -o json 2>/dev/null | \
-      jq -r '.items[] | select(.spec.approved == false) |
-        select((.spec.clusterServiceVersionNames | join(",") | contains("{{ ocp_4_20_ai_maas_reject_version }}")) | not) |
-        .metadata.name' 2>/dev/null | \
-      while read -r plan; do
-        oc patch installplan "$plan" -n openshift-operators \
-          --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
-      done || true
-    # Check SM CSV is Succeeded (any version via label selector)
-    oc get csv -n openshift-operators \
-      -l operators.coreos.com/servicemeshoperator3.openshift-operators \
-      -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Succeeded
-  args:
-    executable: /bin/bash
-  register: _sm_result
-  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
-  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
-  until: _sm_result.rc == 0
-  changed_when: false
+        # Stale state detected — clean subscriptions, CSVs, and install plans
+        for sub in authorino-operator limitador-operator dns-operator rhcl-operator; do
+          oc delete sub "$sub" -n openshift-operators --ignore-not-found 2>/dev/null || true
+        done
+        for csv in $(oc get csv -n openshift-operators --no-headers \
+          -o custom-columns=NAME:.metadata.name 2>/dev/null | \
+          grep -E 'authorino|limitador|dns-operator|rhcl'); do
+          oc delete csv "$csv" -n openshift-operators --ignore-not-found 2>/dev/null || true
+        done
+        for plan in $(oc get installplan -n openshift-operators --no-headers \
+          -o custom-columns=NAME:.metadata.name,CSVS:.spec.clusterServiceVersionNames 2>/dev/null | \
+          grep -E 'authorino|limitador|dns-operator|rhcl' | awk '{print $1}'); do
+          oc delete installplan "$plan" -n openshift-operators --ignore-not-found 2>/dev/null || true
+        done
+      args:
+        executable: /bin/bash
+      changed_when: false
 
-# --- Step 3: Pre-create sub-operator subscriptions (v1.3.x, Manual) ---
-# TEMPORARY WORKAROUND (continued): Pre-creating sub-operator subscriptions with
-# Manual approval and startingCSV pins them to v1.3.1 before RHCL creates its own.
-# Remove once RHCL v1.4.0 compatibility is resolved.
+    # --- Step 2: Service Mesh 3.2 (MUST be before RHCL) ---
+    # TEMPORARY WORKAROUND: OCP Ingress Operator's gatewayclass_controller actively
+    # watches and overwrites the SM subscription (channel → stable, startingCSV → v3.1.0)
+    # on every reconciliation (~3s). CVO restores the Ingress Operator if scaled down.
+    # Solution: single atomic shell task that races the Ingress Operator — scale down,
+    # delete+create subscription, approve install plan, all in one shot with inner retry.
+    # Once SM CSV is Succeeded, the Ingress Operator can overwrite the subscription
+    # freely — the CSV is already installed and OLM won't downgrade.
+    # Remove once RHCL v1.4.0 compatibility with SM is resolved.
+    # See: https://access.redhat.com/solutions/7097633
+    - name: Install SM with Ingress Operator race protection
+      environment:
+        KUBECONFIG: "{{ admin_kubeconfig | expanduser }}"
+        SM_CSV: "{{ ocp_4_20_ai_maas_sm_starting_csv }}"
+        SM_CHANNEL: "{{ ocp_4_20_ai_maas_sm_channel }}"
+        SM_SOURCE: "{{ ocp_4_20_ai_maas_sm_source }}"
+        REJECT: "{{ ocp_4_20_ai_maas_reject_version }}"
+      ansible.builtin.shell: |
+        PHASE=$(oc get csv "$SM_CSV" -n openshift-operators \
+          -o jsonpath='{.status.phase}' 2>/dev/null)
+        [ "$PHASE" = "Succeeded" ] && exit 0
 
-- name: Pre-create Authorino Subscription (v1.3.1, Manual)
-  kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    state: present
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: authorino-operator
-        namespace: openshift-operators
-      spec:
-        channel: stable
-        installPlanApproval: Manual
-        name: authorino-operator
-        source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
-        sourceNamespace: openshift-marketplace
-        startingCSV: "{{ ocp_4_20_ai_maas_authorino_starting_csv }}"
-  register: _r
-  retries: 5
-  delay: 10
-  until: _r is not failed
+        if [ -z "$PHASE" ]; then
+          for csv in $(oc get csv -n openshift-operators --no-headers \
+            -o custom-columns=NAME:.metadata.name 2>/dev/null | grep servicemeshoperator3); do
+            oc delete csv "$csv" -n openshift-operators --ignore-not-found 2>/dev/null || true
+          done
+        fi
 
-- name: Pre-create Limitador Subscription (v1.3.1, Manual)
-  kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    state: present
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: limitador-operator
-        namespace: openshift-operators
-      spec:
-        channel: stable
-        installPlanApproval: Manual
-        name: limitador-operator
-        source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
-        sourceNamespace: openshift-marketplace
-        startingCSV: "{{ ocp_4_20_ai_maas_limitador_starting_csv }}"
-  register: _r
-  retries: 5
-  delay: 10
-  until: _r is not failed
+        oc scale deployment ingress-operator -n openshift-ingress-operator \
+          --replicas=0 --timeout=15s 2>/dev/null || true
+        sleep 3
 
-- name: Pre-create DNS Subscription (v1.3.1, Manual)
-  kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    state: present
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: dns-operator
-        namespace: openshift-operators
-      spec:
-        channel: stable
-        installPlanApproval: Manual
-        name: dns-operator
-        source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
-        sourceNamespace: openshift-marketplace
-        startingCSV: "{{ ocp_4_20_ai_maas_dns_starting_csv }}"
-  register: _r
-  retries: 5
-  delay: 10
-  until: _r is not failed
+        for attempt in $(seq 1 10); do
+          CHANNEL=$(oc get sub servicemeshoperator3 -n openshift-operators \
+            -o jsonpath='{.spec.channel}' 2>/dev/null)
 
-# TEMPORARY WORKAROUND (continued): Two-pass install plan approval — approve
-# v1.3.x-only plans, delete v1.4.0-bundled plans so OLM regenerates clean ones.
-- name: Approve install plans and wait for sub-operator CSVs
-  environment:
-    KUBECONFIG: "{{ admin_kubeconfig }}"
-  ansible.builtin.shell: |
-    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
-    # Approve plans without v1.4.0, then delete unapproved v1.4.0 upgrade plans
-    # so OLM creates fresh plans for any remaining v1.3.x CSVs without bundling.
-    oc get installplan -n openshift-operators -o json 2>/dev/null | \
-      jq -r '.items[] | select(.spec.approved == false) |
-        select((.spec.clusterServiceVersionNames | join(",") | contains("{{ ocp_4_20_ai_maas_reject_version }}")) | not) |
-        .metadata.name' 2>/dev/null | \
-      while read -r plan; do
-        oc patch installplan "$plan" -n openshift-operators \
-          --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
-      done || true
-    # Delete unapproved plans containing v1.4.0 to prevent bundling
-    oc get installplan -n openshift-operators -o json 2>/dev/null | \
-      jq -r '.items[] | select(.spec.approved == false) |
-        select((.spec.clusterServiceVersionNames | join(",") | contains("{{ ocp_4_20_ai_maas_reject_version }}"))) |
-        .metadata.name' 2>/dev/null | \
-      while read -r plan; do
-        oc delete installplan "$plan" -n openshift-operators 2>/dev/null || true
-      done || true
-    oc get csv "{{ ocp_4_20_ai_maas_authorino_starting_csv }}" -n openshift-operators \
-      -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Succeeded || exit 1
-    oc get csv "{{ ocp_4_20_ai_maas_limitador_starting_csv }}" -n openshift-operators \
-      -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Succeeded || exit 1
-    oc get csv "{{ ocp_4_20_ai_maas_dns_starting_csv }}" -n openshift-operators \
-      -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Succeeded || exit 1
-  args:
-    executable: /bin/bash
-  register: _sub_op_result
-  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
-  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
-  until: _sub_op_result.rc == 0
-  changed_when: false
+          if [ -z "$CHANNEL" ]; then
+            echo "Attempt $attempt: subscription missing, creating..."
+            echo "{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"Subscription\",\"metadata\":{\"name\":\"servicemeshoperator3\",\"namespace\":\"openshift-operators\"},\"spec\":{\"channel\":\"${SM_CHANNEL}\",\"installPlanApproval\":\"Manual\",\"name\":\"servicemeshoperator3\",\"source\":\"${SM_SOURCE}\",\"sourceNamespace\":\"openshift-marketplace\",\"startingCSV\":\"${SM_CSV}\"}}" | oc apply -f - 2>/dev/null
+            sleep 3
+            continue
+          elif [ "$CHANNEL" != "$SM_CHANNEL" ]; then
+            echo "Attempt $attempt: channel=$CHANNEL (wrong), deleting+recreating..."
+            oc delete sub servicemeshoperator3 -n openshift-operators \
+              --ignore-not-found 2>/dev/null || true
+            sleep 2
+            echo "{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"Subscription\",\"metadata\":{\"name\":\"servicemeshoperator3\",\"namespace\":\"openshift-operators\"},\"spec\":{\"channel\":\"${SM_CHANNEL}\",\"installPlanApproval\":\"Manual\",\"name\":\"servicemeshoperator3\",\"source\":\"${SM_SOURCE}\",\"sourceNamespace\":\"openshift-marketplace\",\"startingCSV\":\"${SM_CSV}\"}}" | oc apply -f - 2>/dev/null
+            sleep 2
+            continue
+          fi
 
-# --- Step 4: RHCL operator (v1.3.4, Manual) ---
+          CSV_EXISTS=$(oc get csv "$SM_CSV" -n openshift-operators \
+            -o jsonpath='{.metadata.name}' 2>/dev/null)
+          if [ -z "$CSV_EXISTS" ]; then
+            INSTALLED_CSV=$(oc get sub servicemeshoperator3 -n openshift-operators \
+              -o jsonpath='{.status.installedCSV}' 2>/dev/null)
+            if [ -n "$INSTALLED_CSV" ]; then
+              echo "Attempt $attempt: stale installedCSV=$INSTALLED_CSV but CSV gone, recreating..."
+              oc delete sub servicemeshoperator3 -n openshift-operators \
+                --ignore-not-found 2>/dev/null || true
+              sleep 2
+              echo "{\"apiVersion\":\"operators.coreos.com/v1alpha1\",\"kind\":\"Subscription\",\"metadata\":{\"name\":\"servicemeshoperator3\",\"namespace\":\"openshift-operators\"},\"spec\":{\"channel\":\"${SM_CHANNEL}\",\"installPlanApproval\":\"Manual\",\"name\":\"servicemeshoperator3\",\"source\":\"${SM_SOURCE}\",\"sourceNamespace\":\"openshift-marketplace\",\"startingCSV\":\"${SM_CSV}\"}}" | oc apply -f - 2>/dev/null
+              sleep 3
+              continue
+            fi
+          fi
 
-- name: Create RHCL Subscription (v1.3.4, Manual)
-  kubernetes.core.k8s:
-    kubeconfig: "{{ admin_kubeconfig }}"
-    state: present
-    definition:
-      apiVersion: operators.coreos.com/v1alpha1
-      kind: Subscription
-      metadata:
-        name: rhcl-operator
-        namespace: openshift-operators
-      spec:
-        channel: stable
-        installPlanApproval: Manual
-        name: rhcl-operator
-        source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
-        sourceNamespace: openshift-marketplace
-        startingCSV: "{{ ocp_4_20_ai_maas_rhcl_starting_csv }}"
-  register: _r
-  retries: 5
-  delay: 10
-  until: _r is not failed
+          for plan in $(oc get installplan -n openshift-operators \
+            -o jsonpath='{range .items[?(@.spec.approved==false)]}{.metadata.name}{" "}{end}' 2>/dev/null); do
+            csvs=$(oc get installplan "$plan" -n openshift-operators \
+              -o jsonpath='{.spec.clusterServiceVersionNames}' 2>/dev/null)
+            if ! echo "$csvs" | grep -q "$REJECT"; then
+              oc patch installplan "$plan" -n openshift-operators \
+                --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
+            fi
+          done
 
-# TEMPORARY WORKAROUND (continued): Final pass — approve remaining v1.3.x plans
-# for RHCL itself. End of RHCL version pinning workaround block.
-- name: Approve install plans and wait for RHCL CSV
-  environment:
-    KUBECONFIG: "{{ admin_kubeconfig }}"
-  ansible.builtin.shell: |
-    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
-    # Approve unapproved install plans that do not contain the reject version
-    oc get installplan -n openshift-operators -o json 2>/dev/null | \
-      jq -r '.items[] | select(.spec.approved == false) |
-        select((.spec.clusterServiceVersionNames | join(",") | contains("{{ ocp_4_20_ai_maas_reject_version }}")) | not) |
-        .metadata.name' 2>/dev/null | \
-      while read -r plan; do
-        oc patch installplan "$plan" -n openshift-operators \
-          --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
-      done || true
-    # Check RHCL CSV is Succeeded (any version via label selector)
-    oc get csv -n openshift-operators \
-      -l operators.coreos.com/rhcl-operator.openshift-operators \
-      -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q Succeeded
-  args:
-    executable: /bin/bash
-  register: _rhcl_result
-  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
-  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
-  until: _rhcl_result.rc == 0
-  changed_when: false
+          PHASE=$(oc get csv "$SM_CSV" -n openshift-operators \
+            -o jsonpath='{.status.phase}' 2>/dev/null)
+          [ "$PHASE" = "Succeeded" ] && exit 0
+          echo "Attempt $attempt: channel=OK, CSV phase=$PHASE, waiting..."
+          sleep 5
+        done
+        exit 1
+      args:
+        executable: /bin/bash
+      register: _sm_result
+      retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+      delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+      until: _sm_result.rc == 0
+      changed_when: false
+
+    # --- Step 3: Pre-create sub-operator subscriptions (v1.3.x, Manual) ---
+    # TEMPORARY WORKAROUND (continued): Pre-creating sub-operator subscriptions with
+    # Manual approval and startingCSV pins them to v1.3.1 before RHCL creates its own.
+    # Remove once RHCL v1.4.0 compatibility is resolved.
+
+    - name: Pre-create Authorino Subscription (v1.3.1, Manual)
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: authorino-operator
+            namespace: openshift-operators
+          spec:
+            channel: stable
+            installPlanApproval: Manual
+            name: authorino-operator
+            source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
+            sourceNamespace: openshift-marketplace
+            startingCSV: "{{ ocp_4_20_ai_maas_authorino_starting_csv }}"
+      register: _r
+      retries: 5
+      delay: 10
+      until: _r is not failed
+
+    - name: Pre-create Limitador Subscription (v1.3.1, Manual)
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: limitador-operator
+            namespace: openshift-operators
+          spec:
+            channel: stable
+            installPlanApproval: Manual
+            name: limitador-operator
+            source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
+            sourceNamespace: openshift-marketplace
+            startingCSV: "{{ ocp_4_20_ai_maas_limitador_starting_csv }}"
+      register: _r
+      retries: 5
+      delay: 10
+      until: _r is not failed
+
+    - name: Pre-create DNS Subscription (v1.3.1, Manual)
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: dns-operator
+            namespace: openshift-operators
+          spec:
+            channel: stable
+            installPlanApproval: Manual
+            name: dns-operator
+            source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
+            sourceNamespace: openshift-marketplace
+            startingCSV: "{{ ocp_4_20_ai_maas_dns_starting_csv }}"
+      register: _r
+      retries: 5
+      delay: 10
+      until: _r is not failed
+
+    # TEMPORARY WORKAROUND (continued): Hold-until-clean install plan approval.
+    # Wait for all three subs to have install plans. Only approve when NONE contain
+    # v1.4.0. Approving a partial plan (2 of 3) causes the third to always bundle
+    # v1.4.0 upgrades, leading to an infinite loop or stuck Replacing CSVs.
+    - name: Approve install plans and wait for sub-operator CSVs
+      environment:
+        KUBECONFIG: "{{ admin_kubeconfig }}"
+        REJECT: "{{ ocp_4_20_ai_maas_reject_version }}"
+        ACCEPT: "{{ ocp_4_20_ai_maas_accept_version }}"
+      ansible.builtin.shell: |
+        export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+
+        # Early exit if all three have a v1.3.x CSV Succeeded
+        ALL_OK=true
+        for op in authorino-operator limitador-operator dns-operator; do
+          phase=$(oc get csv -n openshift-operators --no-headers 2>/dev/null | \
+            grep "${op}.*${ACCEPT}" | head -1 | awk '{print $NF}')
+          [ "$phase" != "Succeeded" ] && ALL_OK=false
+        done
+        [ "$ALL_OK" = "true" ] && exit 0
+
+        # Wait until all three subs have an installPlanRef
+        PLANS=""
+        for sub in authorino-operator limitador-operator dns-operator; do
+          plan=$(oc get sub "$sub" -n openshift-operators \
+            -o jsonpath='{.status.installPlanRef.name}' 2>/dev/null)
+          [ -z "$plan" ] && exit 1
+          PLANS="$PLANS $plan"
+        done
+        PLANS=$(echo "$PLANS" | tr ' ' '\n' | sort -u | grep -v '^$')
+
+        # If any referenced plan contains v1.4.0, delete it and retry
+        HAS_REJECT=false
+        for plan in $PLANS; do
+          csvs=$(oc get installplan "$plan" -n openshift-operators \
+            -o jsonpath='{.spec.clusterServiceVersionNames}' 2>/dev/null)
+          if echo "$csvs" | grep -q "$REJECT"; then
+            HAS_REJECT=true
+            oc delete installplan "$plan" -n openshift-operators 2>/dev/null || true
+          fi
+        done
+        [ "$HAS_REJECT" = "true" ] && exit 1
+
+        # All plans are clean — approve them all
+        for plan in $PLANS; do
+          oc patch installplan "$plan" -n openshift-operators \
+            --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
+        done
+
+        # Wait for all v1.3.x CSVs to be Succeeded
+        for op in authorino-operator limitador-operator dns-operator; do
+          phase=$(oc get csv -n openshift-operators --no-headers 2>/dev/null | \
+            grep "${op}.*${ACCEPT}" | head -1 | awk '{print $NF}')
+          [ "$phase" != "Succeeded" ] && exit 1
+        done
+      args:
+        executable: /bin/bash
+      register: _sub_op_result
+      retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+      delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+      until: _sub_op_result.rc == 0
+      changed_when: false
+
+    # --- Step 4: RHCL operator (v1.3.4, Manual) ---
+
+    - name: Create RHCL Subscription (v1.3.4, Manual)
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: rhcl-operator
+            namespace: openshift-operators
+          spec:
+            channel: stable
+            installPlanApproval: Manual
+            name: rhcl-operator
+            source: "{{ ocp_4_20_ai_maas_rhcl_source }}"
+            sourceNamespace: openshift-marketplace
+            startingCSV: "{{ ocp_4_20_ai_maas_rhcl_starting_csv }}"
+      register: _r
+      retries: 5
+      delay: 10
+      until: _r is not failed
+
+    # TEMPORARY WORKAROUND (continued): Final pass — approve remaining v1.3.x plans
+    # for RHCL itself. End of RHCL version pinning workaround block.
+    - name: Approve install plans and wait for RHCL CSV
+      environment:
+        KUBECONFIG: "{{ admin_kubeconfig }}"
+        REJECT: "{{ ocp_4_20_ai_maas_reject_version }}"
+        ACCEPT: "{{ ocp_4_20_ai_maas_accept_version }}"
+      ansible.builtin.shell: |
+        export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+        for plan in $(oc get installplan -n openshift-operators \
+          -o jsonpath='{range .items[?(@.spec.approved==false)]}{.metadata.name}{" "}{end}' 2>/dev/null); do
+          csvs=$(oc get installplan "$plan" -n openshift-operators \
+            -o jsonpath='{.spec.clusterServiceVersionNames}' 2>/dev/null)
+          if ! echo "$csvs" | grep -q "$REJECT"; then
+            oc patch installplan "$plan" -n openshift-operators \
+              --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
+          fi
+        done
+        # Check any RHCL v1.3.x CSV is Succeeded
+        oc get csv -n openshift-operators --no-headers 2>/dev/null | \
+          grep "rhcl-operator.*${ACCEPT}" | head -1 | awk '{print $NF}' | grep -q Succeeded
+      args:
+        executable: /bin/bash
+      register: _rhcl_result
+      retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+      delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+      until: _rhcl_result.rc == 0
+      changed_when: false
 
 # --- Step 5: Leader Worker Set ---
 
@@ -550,6 +606,236 @@
     - _rhoai_sub.resources | length > 0
     - _rhoai_sub.resources[0].status.installedCSV is defined
 
+# When MaaS is disabled, SM auto-installs via RHOAI DSC + Ingress Operator.
+# After a prior MaaS run + cleanup, the Ingress Operator's SM subscription may
+# retain Manual installPlanApproval. Approve any unapproved SM install plans.
+- name: Approve SM install plans for auto-install (inference-only)
+  environment:
+    KUBECONFIG: "{{ admin_kubeconfig }}"
+  ansible.builtin.shell: |
+    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    SM_CSV=$(oc get csv -n openshift-operators --no-headers 2>/dev/null | grep servicemeshoperator3 | head -1 | awk '{print $1}')
+    if [ -n "$SM_CSV" ]; then
+      PHASE=$(oc get csv "$SM_CSV" -n openshift-operators -o jsonpath='{.status.phase}' 2>/dev/null)
+      [ "$PHASE" = "Succeeded" ] && exit 0
+      # CRD loss recovery: on retry, Ingress Operator subscription overwrite can
+      # leave SM CSV Pending with missing sailoperator CRDs. Install plans show
+      # Complete but CRDs were cascade-deleted. Clean everything and let Ingress
+      # Operator recreate from scratch.
+      if [ "$PHASE" = "Pending" ]; then
+        CRD_COUNT=$(oc get crd -o name 2>/dev/null | grep -c sailoperator || echo 0)
+        if [ "$CRD_COUNT" -eq 0 ]; then
+          oc delete sub servicemeshoperator3 -n openshift-operators --ignore-not-found 2>/dev/null || true
+          oc delete csv "$SM_CSV" -n openshift-operators --ignore-not-found 2>/dev/null || true
+          for plan in $(oc get installplan -n openshift-operators --no-headers \
+            -o custom-columns=NAME:.metadata.name,CSVS:.spec.clusterServiceVersionNames 2>/dev/null | \
+            grep servicemeshoperator3 | awk '{print $1}'); do
+            oc delete installplan "$plan" -n openshift-operators --ignore-not-found 2>/dev/null || true
+          done
+          exit 1
+        fi
+      fi
+    fi
+    for plan in $(oc get installplan -n openshift-operators --no-headers \
+      -o custom-columns=NAME:.metadata.name,CSVS:.spec.clusterServiceVersionNames,APPROVED:.spec.approved 2>/dev/null | \
+      grep servicemeshoperator3 | grep false | awk '{print $1}'); do
+      oc patch installplan "$plan" -n openshift-operators \
+        --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
+    done
+    SM_CSV=$(oc get csv -n openshift-operators --no-headers 2>/dev/null | grep servicemeshoperator3 | head -1 | awk '{print $1}')
+    [ -n "$SM_CSV" ] && oc get csv "$SM_CSV" -n openshift-operators \
+      -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Succeeded
+  args:
+    executable: /bin/bash
+  register: _sm_auto_result
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until: _sm_auto_result.rc == 0
+  changed_when: false
+  when: not (ocp_4_20_ai_maas_enable_maas | bool)
+
+# --- Step 6a: OpenTelemetry Operator (isolated namespace, before DSC) ---
+# Required by RHOAI Monitoring controller — fails without OpenTelemetryCollector CRD.
+# Installed in isolated namespace to prevent OLM bundling with RHCL v1.4.0 plans.
+
+- name: Create OTel namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-opentelemetry-operator
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_observability | default(false) | bool
+
+- name: Create OTel OperatorGroup
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: opentelemetry-operator
+        namespace: openshift-opentelemetry-operator
+      spec: {}
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_observability | default(false) | bool
+
+- name: Create OTel Subscription
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: "{{ ocp_4_20_ai_maas_otel_package }}"
+        namespace: openshift-opentelemetry-operator
+      spec:
+        channel: stable
+        installPlanApproval: Automatic
+        name: "{{ ocp_4_20_ai_maas_otel_package }}"
+        source: "{{ ocp_4_20_ai_maas_otel_source }}"
+        sourceNamespace: openshift-marketplace
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_observability | default(false) | bool
+
+- name: Wait for OTel CSV
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: "{{ ocp_4_20_ai_maas_otel_package }}"
+    namespace: openshift-opentelemetry-operator
+  register: _otel_sub
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _otel_sub.resources is defined
+    - _otel_sub.resources | length > 0
+    - _otel_sub.resources[0].status.installedCSV is defined
+  when: ocp_4_20_ai_maas_enable_observability | default(false) | bool
+
+# --- Step 6b: Cluster Observability Operator v1.4.0 (isolated namespace, before DSC) ---
+# TEMPORARY WORKAROUND: Pin COO to v1.4.0 — v1.5 breaks RHOAI 3.4 observability
+# (CEL validation on caCert + Perses image flag mismatch). See: RHOAIENG-69180
+
+- name: Create COO namespace
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: openshift-cluster-observability-operator
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_observability | default(false) | bool
+
+- name: Create COO OperatorGroup
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1
+      kind: OperatorGroup
+      metadata:
+        name: cluster-observability-operator
+        namespace: openshift-cluster-observability-operator
+      spec: {}
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_observability | default(false) | bool
+
+- name: Delete stale COO subscription, CSVs, and install plans
+  environment:
+    KUBECONFIG: "{{ admin_kubeconfig }}"
+    COO_CSV: "{{ ocp_4_20_ai_maas_coo_starting_csv }}"
+  ansible.builtin.shell: |
+    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    # Skip if COO already at target version
+    phase=$(oc get csv "$COO_CSV" -n openshift-cluster-observability-operator \
+      -o jsonpath='{.status.phase}' 2>/dev/null)
+    [ "$phase" = "Succeeded" ] && echo "COO at target version, skipping cleanup" && exit 0
+
+    oc delete sub cluster-observability-operator \
+      -n openshift-cluster-observability-operator --ignore-not-found 2>/dev/null || true
+    oc delete csv --all -n openshift-cluster-observability-operator \
+      --ignore-not-found 2>/dev/null || true
+    oc delete installplan --all -n openshift-cluster-observability-operator \
+      --ignore-not-found 2>/dev/null || true
+  args:
+    executable: /bin/bash
+  changed_when: false
+  when: ocp_4_20_ai_maas_enable_observability | default(false) | bool
+
+- name: Create COO Subscription (Manual approval, pinned to v1.4.0)
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition:
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: cluster-observability-operator
+        namespace: openshift-cluster-observability-operator
+      spec:
+        channel: stable
+        installPlanApproval: Manual
+        name: cluster-observability-operator
+        source: "{{ ocp_4_20_ai_maas_coo_source }}"
+        sourceNamespace: openshift-marketplace
+        startingCSV: "{{ ocp_4_20_ai_maas_coo_starting_csv }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_observability | default(false) | bool
+
+- name: Approve COO v1.4.0 install plan
+  environment:
+    KUBECONFIG: "{{ admin_kubeconfig }}"
+    COO_CSV: "{{ ocp_4_20_ai_maas_coo_starting_csv }}"
+  ansible.builtin.shell: |
+    export KUBECONFIG="{{ admin_kubeconfig | expanduser }}"
+    for plan in $(oc get installplan -n openshift-cluster-observability-operator \
+      -o jsonpath='{range .items[?(@.spec.approved==false)]}{.metadata.name}{" "}{end}' 2>/dev/null); do
+      csvs=$(oc get installplan "$plan" -n openshift-cluster-observability-operator \
+        -o jsonpath='{.spec.clusterServiceVersionNames}' 2>/dev/null)
+      if echo "$csvs" | grep -q "$COO_CSV"; then
+        oc patch installplan "$plan" -n openshift-cluster-observability-operator \
+          --type merge -p '{"spec":{"approved":true}}' 2>/dev/null || true
+      fi
+    done
+    oc get csv "$COO_CSV" -n openshift-cluster-observability-operator \
+      -o jsonpath='{.status.phase}' 2>/dev/null | grep -q Succeeded
+  args:
+    executable: /bin/bash
+  register: _coo_result
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until: _coo_result.rc == 0
+  changed_when: false
+  when: ocp_4_20_ai_maas_enable_observability | default(false) | bool
+
 # --- Step 7: DSCInitialization + DataScienceCluster ---
 
 - name: Wait for DSCInitialization to be ready
@@ -577,6 +863,30 @@
     or _dsci.resources | length == 0
     or _dsci.resources[0].status.phase | default('') != 'Ready'
 
+# Step 6c: Patch DSCI metrics (before DSC creation so operator sees it on first reconciliation)
+- name: Patch DSCI with monitoring metrics configuration
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    merge_type: merge
+    definition:
+      apiVersion: dscinitialization.opendatahub.io/v1
+      kind: DSCInitialization
+      metadata:
+        name: default-dsci
+      spec:
+        monitoring:
+          metrics:
+            replicas: "{{ ocp_4_20_ai_maas_dsci_metrics_replicas }}"
+            storage:
+              retention: "{{ ocp_4_20_ai_maas_dsci_metrics_retention }}"
+              size: "{{ ocp_4_20_ai_maas_dsci_metrics_storage }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_observability | default(false) | bool
+
 - name: Wait for RHOAI webhook endpoints ready
   kubernetes.core.k8s_info:
     kubeconfig: "{{ admin_kubeconfig }}"
@@ -590,6 +900,13 @@
   until:
     - _webhook_ep.resources | length > 0
     - (_webhook_ep.resources[0].subsets | default([])) | length > 0
+
+- name: Override DSC dashboard component based on enable_dashboard
+  ansible.builtin.set_fact:
+    ocp_4_20_ai_maas_dsc_components: >-
+      {{ ocp_4_20_ai_maas_dsc_components | combine({
+        'dashboard': (ocp_4_20_ai_maas_enable_dashboard | bool) | ternary('Managed', 'Removed')
+      }) }}
 
 - name: Build DSC components spec
   ansible.builtin.set_fact:
@@ -660,6 +977,7 @@
   retries: 5
   delay: 10
   until: _r is not failed
+  when: ocp_4_20_ai_maas_enable_maas | bool
 
 - name: Report operator installation complete
   ansible.builtin.debug:

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
@@ -16,9 +16,12 @@
 - name: Install platform operators (BOM Phase 2 + 3)
   ansible.builtin.include_tasks: install_operators.yaml
 
+- name: Configure cluster (gateway, observability)
+  ansible.builtin.include_tasks: configure_cluster.yaml
+
 - name: Configure MaaS platform (Phases 1-5)
   ansible.builtin.include_tasks: configure_maas.yaml
-  when: ocp_4_20_ai_maas_enable_maas | default(true)
+  when: ocp_4_20_ai_maas_enable_maas | default(true) | bool
 
 - name: Run verification smoke tests
   ansible.builtin.include_tasks: verify.yaml

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/verify.yaml
@@ -22,9 +22,29 @@
 
 - name: Derive test users from tiers
   ansible.builtin.set_fact:
-    _premium_tier: "{{ ocp_4_20_ai_maas_tiers | selectattr('priority', 'greaterthan', 0) | first }}"
-    _free_tier: "{{ ocp_4_20_ai_maas_tiers | selectattr('priority', 'equalto', 0) | first }}"
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+    _premium_tier: "{{ ocp_4_20_ai_maas_tiers | selectattr('priority', 'greaterthan', 0) | first | default({}) }}"
+    _free_tier: "{{ ocp_4_20_ai_maas_tiers | selectattr('priority', 'equalto', 0) | first | default({}) }}"
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
+
+# EE containers may have empty /etc/resolv.conf — populate with CoreDNS + public fallbacks.
+# Falls back to 8.8.8.8 / 1.1.1.1 if CoreDNS IP is non-standard.
+- name: Fix external/internal DNS resolution for EE containers
+  environment:
+    GW_HOSTNAME: "{{ ocp_4_20_ai_maas_gateway_hostname }}.{{ _cluster_domain }}"
+  ansible.builtin.shell: |
+    python3 -c "import os,socket; socket.getaddrinfo(os.environ['GW_HOSTNAME'], 443)" 2>/dev/null && exit 0
+    if [ ! -s /etc/resolv.conf ] || ! grep -q nameserver /etc/resolv.conf 2>/dev/null; then
+      {
+        echo "nameserver 172.30.0.10"
+        echo "nameserver 8.8.8.8"
+        echo "nameserver 1.1.1.1"
+      } > /etc/resolv.conf 2>/dev/null || true
+    fi
+  args:
+    executable: /bin/bash
+  changed_when: false
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_enable_maas | bool
 
 # --- Test 1: Unauthenticated inference must return 401 ---
 
@@ -44,10 +64,15 @@
       - 403
     validate_certs: false
   register: _unauth_test
+  retries: 6
+  delay: 10
+  until: _unauth_test.status in [401, 403]
+  when: ocp_4_20_ai_maas_enable_maas | bool
 
 - name: Report auth enforcement
   ansible.builtin.debug:
     msg: "Auth enforcement: HTTP {{ _unauth_test.status }} (401=auth rejected, 403=OPA denied — both confirm enforcement)"
+  when: ocp_4_20_ai_maas_enable_maas | bool
 
 # --- Test 2: API key creation with Keycloak JWT ---
 
@@ -65,7 +90,7 @@
     validate_certs: false
   no_log: true
   register: _jwt_response
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 - name: Create API key
   ansible.builtin.uri:
@@ -81,12 +106,12 @@
     validate_certs: false
   no_log: true
   register: _api_key_response
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 - name: Report API key creation
   ansible.builtin.debug:
-    msg: "API key created: {{ _api_key_response.json.keyPrefix | default('N/A') }} subscription={{ _api_key_response.json.subscription | default('N/A') }}"
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+    msg: "API key created successfully, subscription={{ _api_key_response.json.subscription | default('N/A') }}"
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 # --- Test 3: Inference with API key ---
 
@@ -112,19 +137,20 @@
   retries: 6
   delay: 10
   until: _inference_test.status == 200
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 - name: Fail if inference never succeeded
   ansible.builtin.fail:
     msg: "Inference test failed — last status {{ _inference_test.status }}. Auth pipeline may not be ready."
   when:
-    - ocp_4_20_ai_maas_enable_keycloak | default(true)
+    - ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
+    - _inference_test is defined
     - _inference_test.status != 200
 
 - name: Report inference
   ansible.builtin.debug:
     msg: "Inference: HTTP {{ _inference_test.status }} tokens={{ _inference_test.json.usage.total_tokens | default('?') }}"
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 # --- Test 4: Version pinning ---
 
@@ -138,12 +164,72 @@
 
 # TEMPORARY WORKAROUND: Remove this assertion once RHCL v1.4.0 compatibility
 # with SM is resolved and version pinning is no longer needed.
-- name: Assert no v1.4.0 CSVs installed
+- name: Assert no RHCL v1.4.0 CSVs installed
   ansible.builtin.assert:
     that:
-      - _all_csvs.resources | selectattr('metadata.name', 'search', 'v1.4.0') | list | length == 0
+      - >-
+        _all_csvs.resources
+        | selectattr('metadata.name', 'match', '(rhcl|authorino|limitador|dns)-operator')
+        | selectattr('metadata.name', 'search', 'v1\\.4\\.0')
+        | list | length == 0
     fail_msg: "RHCL v1.4.0 detected — version pinning failed"
     success_msg: "All RHCL operators at v1.3.x — version pinning held"
+  when: ocp_4_20_ai_maas_enable_maas | bool
+
+# --- Test 4b: Observability stack ---
+
+- name: Get COO CSV status
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ ocp_4_20_ai_maas_coo_starting_csv }}"
+    namespace: openshift-cluster-observability-operator
+  register: _coo_csv
+  when: ocp_4_20_ai_maas_enable_observability | default(true) | bool
+
+- name: Get OTel Subscription status
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: "{{ ocp_4_20_ai_maas_otel_package }}"
+    namespace: openshift-opentelemetry-operator
+  register: _otel_csv
+  when: ocp_4_20_ai_maas_enable_observability | default(true) | bool
+
+- name: Wait for Perses pod running
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: v1
+    kind: Pod
+    namespace: redhat-ods-monitoring
+    label_selectors:
+      - app.kubernetes.io/name=data-science-perses
+  register: _perses_verify
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  ignore_errors: true
+  until:
+    - _perses_verify.resources is defined
+    - _perses_verify.resources | length > 0
+    - _perses_verify.resources[0].status.phase | default('') == 'Running'
+  when: ocp_4_20_ai_maas_enable_observability | default(true) | bool
+
+- name: Verify observability stack
+  ansible.builtin.assert:
+    that:
+      - _coo_csv.resources | length > 0
+      - _coo_csv.resources[0].status.phase | default('') == 'Succeeded'
+      - _otel_csv.resources | length > 0
+      - _otel_csv.resources[0].status.installedCSV is defined
+      - _perses_verify.resources | length > 0
+      - _perses_verify.resources[0].status.phase | default('') == 'Running'
+    fail_msg: "Observability stack not fully operational"
+    success_msg: >-
+      Observability: COO={{ ocp_4_20_ai_maas_coo_starting_csv }},
+      Perses=Running
+  when: ocp_4_20_ai_maas_enable_observability | default(true) | bool
 
 # --- Test 5: Token rate limiting (free tier) ---
 
@@ -161,7 +247,7 @@
     validate_certs: false
   no_log: true
   register: _free_jwt
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 - name: Create free-tier API key
   ansible.builtin.uri:
@@ -177,7 +263,7 @@
     validate_certs: false
   no_log: true
   register: _free_key_response
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 - name: Send requests to exhaust free tier (100 tokens/min)
   ansible.builtin.uri:
@@ -201,7 +287,7 @@
   loop: "{{ range(1, 11) | list }}"
   loop_control:
     label: "request {{ item }}"
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 - name: Assert rate limiting was enforced
   ansible.builtin.assert:
@@ -211,11 +297,13 @@
     success_msg: >-
       Rate limiting enforced — {{ _rate_limit_results.results
       | selectattr('status', 'equalto', 429) | list | length }} of 10 requests returned 429
-  when: ocp_4_20_ai_maas_enable_keycloak | default(true)
+  when: ocp_4_20_ai_maas_enable_keycloak | default(true) | bool
 
 - name: Report verification complete
   ansible.builtin.debug:
     msg: >-
       All verification tests passed —
-      Auth: {{ _unauth_test.status }},
-      {{ 'API key: created, Inference: 200, Rate limiting: 429, ' if (ocp_4_20_ai_maas_enable_keycloak | default(true)) else '' }}Versions: all v1.3.x pinned
+      MaaS: {{ ocp_4_20_ai_maas_enable_maas | bool }},
+      Keycloak: {{ ocp_4_20_ai_maas_enable_keycloak | bool }},
+      Dashboard: {{ ocp_4_20_ai_maas_enable_dashboard | bool }},
+      {{ 'API key: created, Inference: 200, Rate limiting: 429, ' if (ocp_4_20_ai_maas_enable_keycloak | bool) else '' }}{{ 'Versions: all v1.3.x pinned, ' if (ocp_4_20_ai_maas_enable_maas | bool) else '' }}{{ 'Observability: COO+OTel+Perses' if (ocp_4_20_ai_maas_enable_observability | bool) else '' }}

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/openshift-ai-inference-gateway.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/openshift-ai-inference-gateway.yaml.j2
@@ -1,0 +1,23 @@
+# TEMPORARY WORKAROUND: RHOAI operator does not create openshift-ai-inference
+# gateway. The inferenceservice-config ConfigMap references it but GatewayConfig
+# only creates data-science-gateway. See: RHOAIENG-38214
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: openshift-ai-inference
+  namespace: openshift-ingress
+  labels:
+    istio.io/rev: openshift-gateway
+spec:
+  gatewayClassName: data-science-gateway-class
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: data-science-gateway-service-tls

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/postgres-maas.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/postgres-maas.yaml.j2
@@ -1,21 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: maas-db
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: maas-postgres-pvc
-  namespace: maas-db
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: {{ ocp_4_20_ai_maas_db_storage }}
----
-apiVersion: v1
 kind: Secret
 metadata:
   name: maas-postgres-credentials

--- a/playbook_osac_create_maas_deployment.yml
+++ b/playbook_osac_create_maas_deployment.yml
@@ -18,6 +18,12 @@
     # Simulate admin_kubeconfig (normally set by ocp_4_17_small pipeline)
     admin_kubeconfig: "{{ lookup('env', 'KUBECONFIG') | default('~/.kube/config', true) }}"
 
+  pre_tasks:
+    - name: Force enable_keycloak=false when enable_maas=false
+      ansible.builtin.set_fact:
+        ocp_4_20_ai_maas_enable_keycloak: false
+      when: not (ocp_4_20_ai_maas_enable_maas | default(true) | bool)
+
   tasks:
     # --- Install Operators (BOM Phase 2 + 3) ---
     - name: Install platform operators
@@ -32,6 +38,21 @@
         - operators
         - all
 
+    # --- Configure cluster (gateway, observability) ---
+    - name: Configure cluster
+      ansible.builtin.include_role:
+        name: osac.templates.ocp_4_20_ai_maas
+        tasks_from: configure_cluster.yaml
+        apply:
+          tags:
+            - cluster
+            - maas
+            - all
+      tags:
+        - cluster
+        - maas
+        - all
+
     # --- Configure MaaS (Phases 1-5) ---
     - name: Configure MaaS platform
       ansible.builtin.include_role:
@@ -44,6 +65,7 @@
       tags:
         - maas
         - all
+      when: ocp_4_20_ai_maas_enable_maas | default(true) | bool
 
     # --- Verification ---
     - name: Run verification tests


### PR DESCRIPTION
## Summary

[OSAC-1816](https://redhat.atlassian.net/browse/OSAC-1816) — Post-PR #351 enhancements for the `ocp_4_20_ai_maas` template role:

- **Observability stack**: COO v1.4.0 + OTel in isolated namespaces (prevents OLM bundling with RHCL), DSCI metrics configuration (replicas, retention, storage), User Workload Monitoring ConfigMap for vLLM metrics, captureUser for Usage tab
- **OpenShift AI Dashboard**: 6 dashboard feature flags for MaaS UI (modelAsService, maasAuthPolicies, vLLMDeploymentOnMaaS, observabilityDashboard, deploymentWizardYAMLViewer, llmGatewayField), model deployment via dashboard wizard, Observe tab with Perses dashboards (Cluster/Model/Usage tabs)
- **Multi-flavor deployment**: 7 parameters (enable_maas, enable_keycloak, enable_observability, enable_dashboard, oidc_issuer, oidc_client_id, run_verify), BYOIDP support with external OIDC configuration, standalone playbook for direct deployment
- **Version pinning resilience** (temporary — addresses RHCL v1.4.0 auto-install incompatibility with MaaS auth enforcement): SM atomic task with CSV cleanup guard, stale installedCSV detection, version-range checks (v1.3 pattern — survives OLM auto-upgrades within v1.3.x), SM auto-approve for inference-only clusters with CRD loss recovery, stale CRD guard. Will be removed once RHCL v1.4.0 compatibility with SM is resolved upstream.
- **Infrastructure**: EE container DNS fix (/etc/resolv.conf with CoreDNS + public fallbacks), maas-controller restart after subscription creation, TRLP enforcement wait, DSC creation retry for webhook startup race
- **CodeRabbit review fixes**: DEV ONLY credential warnings, follow-up fail tasks after readiness waits, escaped dots in v1.4.0 regex, _inference_test guard, default on tier filter
- **Defaults bumped**: authorino v1.3.2, RHCL v1.3.5 (current channel heads)

## Test Plan

- [x] `ansible-lint` — 0 failures, 0 warnings, production profile
- [x] `pre-commit run --all-files` — passes (yamllint, whitespace, private keys)
- [x] `ansible-playbook --syntax-check` — passes
- [x] Full MaaS + Keycloak (`--tags all`) — auth 401, JWT, API key 201, inference 200, rate limiting 429, version pinning (no v1.4.0)
- [x] BYOIDP — Tenant CR with externalOIDC, Keycloak tests correctly skipped
- [x] Inference + Dashboard + Monitoring — COO + OTel + Perses running, no MaaS operators
- [x] Headless Inference — observability only, no dashboard
- [x] Bare Inference — minimal install, operators + DSC only
- [x] Version pinning held across OLM auto-upgrades (v1.3.4→v1.3.5, v1.3.1→v1.3.2)
- [x] Self-healing retry — SM CRD recovery, stale CSV handling validated

## Also Modified

- `.gitignore`: Added `.idea/` and `*.iml` (JetBrains IDE files)
- `playbook_osac_create_maas_deployment.yml`: Standalone deployment playbook for direct invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added feature flags for observability and the dashboard, including metrics configuration and tenant telemetry label controls.
  * Added optional external OIDC inputs for authentication when managed Keycloak is disabled.
  * Introduced gateway-based cluster configuration to support inference access.
* **Bug Fixes**
  * Improved installation/upgrade reliability with stronger readiness checks, retries, and explicit failure handling.
  * Hardened MaaS/Keycloak/Tenant sequencing and ensured required namespaces/PVCs are created deterministically.
  * Updated default operator version pins and node resource class for new deployments.
* **Documentation**
  * Clarified “DEV ONLY” guidance for credential defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->