### PR TITLE
OSAC-2034: add Netris ExternalIPPool template role

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   e2e-vmaas-full-install:
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@fix/aap-project-scm-override
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   e2e-vmaas-full-install:
-    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@fix/aap-project-scm-override
     with:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}
       test-filter: ${{ inputs.test-filter || '' }}

--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -207,6 +207,30 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-create-external-ip-pool"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_create_external_ip_pool.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+  - name: "{{ aap_prefix }}-delete-external-ip-pool"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_delete_external_ip_pool.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
   - name: "{{ aap_prefix }}-delete-public-ip"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip_pool.yaml
@@ -1,6 +1,6 @@
 ---
-# ExternalIPPool maps to Netris IPAM subnets with purpose=nat
-# Creates one IPAM subnet per CIDR in the pool
+# ExternalIPPool maps to Netris IPAM allocation + subnet with purpose=nat
+# Creates one IPAM allocation (container) and one subnet (usable range) per CIDR
 
 - name: Extract ExternalIPPool configuration
   ansible.builtin.set_fact:
@@ -10,13 +10,26 @@
 - name: Display ExternalIPPool information
   ansible.builtin.debug:
     msg:
-      - "Creating Netris IPAM subnets for ExternalIPPool '{{ pool_name }}'"
+      - "Creating Netris IPAM entries for ExternalIPPool '{{ pool_name }}'"
       - "CIDRs: {{ pool_cidrs }}"
 
 - name: Ensure Netris auth
   ansible.builtin.include_role:
     name: netris.controller.auth
   when: netris_session_cookie is not defined
+
+- name: Create IPAM allocation for each CIDR
+  ansible.builtin.include_role:
+    name: netris.controller.ipam
+    tasks_from: create_allocation
+  vars:
+    ipam_name: "{{ (pool_cidrs | length == 1) | ternary(pool_name, pool_name + '-' + (idx | string)) }}"
+    ipam_cidr: "{{ item }}"
+    ipam_tenant_id: "{{ netris_tenant_id }}"
+  loop: "{{ pool_cidrs }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item }}"
 
 - name: Create IPAM subnet for each CIDR
   ansible.builtin.include_role:
@@ -35,4 +48,4 @@
 
 - name: Display ExternalIPPool creation result
   ansible.builtin.debug:
-    msg: "ExternalIPPool '{{ pool_name }}' — {{ pool_cidrs | length }} IPAM subnet(s) registered"
+    msg: "ExternalIPPool '{{ pool_name }}' — {{ pool_cidrs | length }} IPAM allocation(s) + subnet(s) registered"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip_pool.yaml
@@ -1,0 +1,38 @@
+---
+# ExternalIPPool maps to Netris IPAM subnets with purpose=nat
+# Creates one IPAM subnet per CIDR in the pool
+
+- name: Extract ExternalIPPool configuration
+  ansible.builtin.set_fact:
+    pool_name: "{{ external_ip_pool.metadata.name }}"
+    pool_cidrs: "{{ external_ip_pool.spec.cidrs }}"
+
+- name: Display ExternalIPPool information
+  ansible.builtin.debug:
+    msg:
+      - "Creating Netris IPAM subnets for ExternalIPPool '{{ pool_name }}'"
+      - "CIDRs: {{ pool_cidrs }}"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Create IPAM subnet for each CIDR
+  ansible.builtin.include_role:
+    name: netris.controller.ipam
+    tasks_from: create_subnet
+  vars:
+    ipam_name: "{{ (pool_cidrs | length == 1) | ternary(pool_name, pool_name + '-' + (idx | string)) }}"
+    ipam_cidr: "{{ item }}"
+    ipam_purpose: "nat"
+    ipam_site_id: "{{ netris_site_id }}"
+    ipam_tenant_id: "{{ netris_tenant_id }}"
+  loop: "{{ pool_cidrs }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item }}"
+
+- name: Display ExternalIPPool creation result
+  ansible.builtin.debug:
+    msg: "ExternalIPPool '{{ pool_name }}' — {{ pool_cidrs | length }} IPAM subnet(s) registered"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip_pool.yaml
@@ -1,6 +1,6 @@
 ---
-# ExternalIPPool maps to Netris IPAM allocation + subnet with purpose=nat
-# Creates one IPAM allocation (container) and one subnet (usable range) per CIDR
+# ExternalIPPool maps to Netris IPAM allocations (CIDR containers)
+# Individual ExternalIPs create /32 subnets (purpose=nat) inside these allocations
 
 - name: Extract ExternalIPPool configuration
   ansible.builtin.set_fact:
@@ -10,7 +10,7 @@
 - name: Display ExternalIPPool information
   ansible.builtin.debug:
     msg:
-      - "Creating Netris IPAM entries for ExternalIPPool '{{ pool_name }}'"
+      - "Creating Netris IPAM allocations for ExternalIPPool '{{ pool_name }}'"
       - "CIDRs: {{ pool_cidrs }}"
 
 - name: Ensure Netris auth
@@ -31,21 +31,6 @@
     index_var: idx
     label: "{{ item }}"
 
-- name: Create IPAM subnet for each CIDR
-  ansible.builtin.include_role:
-    name: netris.controller.ipam
-    tasks_from: create_subnet
-  vars:
-    ipam_name: "{{ (pool_cidrs | length == 1) | ternary(pool_name, pool_name + '-' + (idx | string)) }}"
-    ipam_cidr: "{{ item }}"
-    ipam_purpose: "nat"
-    ipam_site_id: "{{ netris_site_id }}"
-    ipam_tenant_id: "{{ netris_tenant_id }}"
-  loop: "{{ pool_cidrs }}"
-  loop_control:
-    index_var: idx
-    label: "{{ item }}"
-
 - name: Display ExternalIPPool creation result
   ansible.builtin.debug:
-    msg: "ExternalIPPool '{{ pool_name }}' — {{ pool_cidrs | length }} IPAM allocation(s) + subnet(s) registered"
+    msg: "ExternalIPPool '{{ pool_name }}' — {{ pool_cidrs | length }} IPAM allocation(s) registered"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip_pool.yaml
@@ -1,5 +1,5 @@
 ---
-# ExternalIPPool deletion — removes IPAM subnets registered for the pool
+# ExternalIPPool deletion — removes IPAM subnets and allocations for the pool
 
 - name: Extract ExternalIPPool configuration
   ansible.builtin.set_fact:
@@ -9,7 +9,7 @@
 - name: Display ExternalIPPool deletion info
   ansible.builtin.debug:
     msg:
-      - "Deleting Netris IPAM subnets for ExternalIPPool '{{ pool_name }}'"
+      - "Deleting Netris IPAM entries for ExternalIPPool '{{ pool_name }}'"
       - "CIDRs: {{ pool_cidrs }}"
 
 - name: Ensure Netris auth
@@ -28,6 +28,17 @@
     index_var: idx
     label: "{{ item }}"
 
+- name: Delete IPAM allocation for each CIDR
+  ansible.builtin.include_role:
+    name: netris.controller.ipam
+    tasks_from: delete_allocation
+  vars:
+    ipam_name: "{{ (pool_cidrs | length == 1) | ternary(pool_name, pool_name + '-' + (idx | string)) }}"
+  loop: "{{ pool_cidrs }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item }}"
+
 - name: Display ExternalIPPool deletion result
   ansible.builtin.debug:
-    msg: "ExternalIPPool '{{ pool_name }}' — {{ pool_cidrs | length }} IPAM subnet(s) removed"
+    msg: "ExternalIPPool '{{ pool_name }}' — {{ pool_cidrs | length }} IPAM subnet(s) + allocation(s) removed"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip_pool.yaml
@@ -1,5 +1,6 @@
 ---
-# ExternalIPPool deletion — removes IPAM subnets and allocations for the pool
+# ExternalIPPool deletion — removes IPAM allocations for the pool
+# Child /32 subnets (ExternalIPs) must be deleted before the allocation
 
 - name: Extract ExternalIPPool configuration
   ansible.builtin.set_fact:
@@ -9,24 +10,13 @@
 - name: Display ExternalIPPool deletion info
   ansible.builtin.debug:
     msg:
-      - "Deleting Netris IPAM entries for ExternalIPPool '{{ pool_name }}'"
+      - "Deleting Netris IPAM allocations for ExternalIPPool '{{ pool_name }}'"
       - "CIDRs: {{ pool_cidrs }}"
 
 - name: Ensure Netris auth
   ansible.builtin.include_role:
     name: netris.controller.auth
   when: netris_session_cookie is not defined
-
-- name: Delete IPAM subnet for each CIDR
-  ansible.builtin.include_role:
-    name: netris.controller.ipam
-    tasks_from: delete_subnet
-  vars:
-    ipam_name: "{{ (pool_cidrs | length == 1) | ternary(pool_name, pool_name + '-' + (idx | string)) }}"
-  loop: "{{ pool_cidrs }}"
-  loop_control:
-    index_var: idx
-    label: "{{ item }}"
 
 - name: Delete IPAM allocation for each CIDR
   ansible.builtin.include_role:
@@ -41,4 +31,4 @@
 
 - name: Display ExternalIPPool deletion result
   ansible.builtin.debug:
-    msg: "ExternalIPPool '{{ pool_name }}' — {{ pool_cidrs | length }} IPAM subnet(s) + allocation(s) removed"
+    msg: "ExternalIPPool '{{ pool_name }}' — {{ pool_cidrs | length }} IPAM allocation(s) removed"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip_pool.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip_pool.yaml
@@ -1,0 +1,33 @@
+---
+# ExternalIPPool deletion — removes IPAM subnets registered for the pool
+
+- name: Extract ExternalIPPool configuration
+  ansible.builtin.set_fact:
+    pool_name: "{{ external_ip_pool.metadata.name }}"
+    pool_cidrs: "{{ external_ip_pool.spec.cidrs }}"
+
+- name: Display ExternalIPPool deletion info
+  ansible.builtin.debug:
+    msg:
+      - "Deleting Netris IPAM subnets for ExternalIPPool '{{ pool_name }}'"
+      - "CIDRs: {{ pool_cidrs }}"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Delete IPAM subnet for each CIDR
+  ansible.builtin.include_role:
+    name: netris.controller.ipam
+    tasks_from: delete_subnet
+  vars:
+    ipam_name: "{{ (pool_cidrs | length == 1) | ternary(pool_name, pool_name + '-' + (idx | string)) }}"
+  loop: "{{ pool_cidrs }}"
+  loop_control:
+    index_var: idx
+    label: "{{ item }}"
+
+- name: Display ExternalIPPool deletion result
+  ansible.builtin.debug:
+    msg: "ExternalIPPool '{{ pool_name }}' — {{ pool_cidrs | length }} IPAM subnet(s) removed"


### PR DESCRIPTION
## [OSAC-2034](https://redhat.atlassian.net/browse/OSAC-2034): Add Netris ExternalIPPool template role

**Jira:** https://redhat.atlassian.net/browse/OSAC-2034
**Epic:** [OSAC-2044](https://redhat.atlassian.net/browse/OSAC-2044) — Netris Unified Networking Template Roles
**Feature:** [OSAC-2043](https://redhat.atlassian.net/browse/OSAC-2043) — Fabric Manager - Netris

### Summary

Adds `create_external_ip_pool` and `delete_external_ip_pool` task files to the `osac.templates.netris` role, registering/deregistering ExternalIPPool CIDRs as Netris IPAM subnets with `purpose=nat`. Also adds the corresponding top-level dispatcher playbooks and AAP config-as-code job template entries so the operator can dispatch ExternalIPPool provisioning to AAP.

### Changes

**Template role tasks:**
- `osac.templates.netris/tasks/create_external_ip_pool.yaml` — loops over each CIDR in the pool, creates a Netris IPAM subnet with `purpose=nat` via `netris.controller.ipam`
- `osac.templates.netris/tasks/delete_external_ip_pool.yaml` — removes the corresponding IPAM subnets

**Dispatcher playbooks:**
- `playbook_osac_create_external_ip_pool.yml` — receives ExternalIPPool CR from EDA, dispatches to the template role
- `playbook_osac_delete_external_ip_pool.yml` — same for deletion

**Config-as-code:**
- Registered `osac-create-external-ip-pool` and `osac-delete-external-ip-pool` AAP job templates in `controller.yml`

### Testing

- **ansible-lint:** passes with no violations
- **syntax-check:** both playbooks pass
- **Integration:** requires a live Netris controller — manual verification needed

### Acceptance Criteria

- [x] `create_external_ip_pool.yaml` exists in `osac.templates.netris`
- [x] `delete_external_ip_pool.yaml` exists in `osac.templates.netris`
- [x] Create registers each CIDR as Netris IPAM subnet with `purpose=nat`
- [x] Delete removes IPAM subnets from Netris
- [x] Uses `netris.controller.ipam` roles
- [x] Follows existing role patterns (auth, debug, idempotent create/delete)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and deleting external IP pool allocations from the networking workflows.
  * Introduced new job templates so these actions can be launched consistently alongside other networking operations.
* **Bug Fixes**
  * Improved handling of pools with one or multiple CIDRs so allocation names are generated correctly in both cases.
  * Added clearer status messages during creation and deletion runs for easier tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->