### PR TITLE
OSAC-2035: add Netris ExternalIP template role

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -267,6 +267,8 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
+  # IPAM allocate-from-pool is non-atomic: concurrent creates could pick
+  # the same IP. Serialized to prevent duplicate allocation.
   - name: "{{ aap_prefix }}-create-external-ip"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"

--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -267,23 +267,23 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
-  - name: "{{ aap_prefix }}-create-external-ip-attachment"
+  - name: "{{ aap_prefix }}-create-external-ip"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"
     job_type: run
-    playbook: "playbook_osac_create_external_ip_attachment.yml"
+    playbook: "playbook_osac_create_external_ip.yml"
     inventory: "{{ aap_prefix }}-networking-operations"
     execution_environment: "{{ aap_prefix }}-ee"
     instance_groups:
       - "{{ aap_prefix }}-networking-operations-ig"
-    allow_simultaneous: true
+    allow_simultaneous: false
     ask_variables_on_launch: true
     verbosity: 0
-  - name: "{{ aap_prefix }}-delete-external-ip-attachment"
+  - name: "{{ aap_prefix }}-delete-external-ip"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"
     job_type: run
-    playbook: "playbook_osac_delete_external_ip_attachment.yml"
+    playbook: "playbook_osac_delete_external_ip.yml"
     inventory: "{{ aap_prefix }}-networking-operations"
     execution_environment: "{{ aap_prefix }}-ee"
     instance_groups:

--- a/collections/ansible_collections/osac/templates/roles/netris/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/meta/argument_specs.yaml
@@ -95,21 +95,21 @@ argument_specs:
         required: true
         description: PublicIP CR from fulfillment-api via EDA payload
 
-  create_external_ip_attachment:
+  create_external_ip:
     options:
-      external_ip_attachment:
+      external_ip:
         type: dict
         required: true
-        description: ExternalIPAttachment CR from fulfillment-api via EDA payload
+        description: ExternalIP CR from fulfillment-api via EDA payload
       template_parameters:
         type: dict
         description: Template-specific parameters (reserved for future use)
         options: {}
         default: {}
 
-  delete_external_ip_attachment:
+  delete_external_ip:
     options:
-      external_ip_attachment:
+      external_ip:
         type: dict
         required: true
-        description: ExternalIPAttachment CR from fulfillment-api via EDA payload
+        description: ExternalIP CR from fulfillment-api via EDA payload

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
@@ -1,7 +1,7 @@
 ---
 # ExternalIP maps to a Netris IPAM /32 subnet (purpose=nat) inside the
 # pool's allocation.  Finds an available IP by enumerating the pool
-# allocation's CIDR and subtracting existing child subnets.
+# allocation CIDRs and subtracting existing /32 child subnets.
 
 - name: Validate ExternalIP annotations
   ansible.builtin.assert:
@@ -63,33 +63,36 @@
 - name: Allocate new IP from pool
   when: _eip_existing_subnet is not defined or _eip_existing_subnet is none
   block:
-    - name: Find pool allocation in IPAM tree
+    - name: Find pool allocations in IPAM tree
       ansible.builtin.set_fact:
-        _eip_pool_alloc: >-
+        _eip_pool_allocs: >-
           {{ (_eip_ipam_tree_resp.json.data | default([]))
-             | selectattr('name', 'equalto', eip_pool_name)
-             | list | first | default(none) }}
+             | selectattr('name', 'match', '^' + eip_pool_name + '(-[0-9]+)?$')
+             | list }}
       when: _eip_ipam_tree_resp.json is mapping
 
-    - name: Fail if pool allocation not found
+    - name: Fail if no pool allocations found
       ansible.builtin.fail:
         msg: >-
-          ExternalIPPool allocation '{{ eip_pool_name }}' not found in Netris IPAM.
+          ExternalIPPool allocations for '{{ eip_pool_name }}' not found in Netris IPAM.
           Ensure the ExternalIPPool has been created before allocating ExternalIPs.
-      when: _eip_pool_alloc is none
+      when: _eip_pool_allocs | length == 0
 
-    - name: Set pool CIDR
-      ansible.builtin.set_fact:
-        _eip_pool_cidr: "{{ _eip_pool_alloc.prefix }}"
-
-    - name: Enumerate all usable IPs in pool CIDR
+    - name: Build list of all usable IPs across pool CIDRs
       ansible.builtin.set_fact:
         _eip_all_ips: >-
-          {{ range(1, 2 ** (32 - (_eip_pool_cidr | ansible.utils.ipaddr('prefix') | int)) - 1)
-             | map('ansible.utils.ipmath', _eip_pool_cidr | ansible.utils.ipaddr('network'))
-             | list }}
+          {% set ips = [] %}
+          {% for alloc in _eip_pool_allocs %}
+          {%   set cidr = alloc.prefix %}
+          {%   set net = cidr | ansible.utils.ipaddr('network') %}
+          {%   set prefix_len = cidr | ansible.utils.ipaddr('prefix') | int %}
+          {%   for i in range(1, 2 ** (32 - prefix_len) - 1) %}
+          {%     set _ = ips.append(net | ansible.utils.ipmath(i)) %}
+          {%   endfor %}
+          {% endfor %}
+          {{ ips }}
 
-    - name: Collect existing child subnets in pool
+    - name: Collect already-allocated /32 subnets within pool ranges
       ansible.builtin.set_fact:
         _eip_allocated_ips: >-
           {{ (_eip_ipam_tree_resp.json.data | default([]))
@@ -108,7 +111,7 @@
     - name: Fail if no IPs available in pool
       ansible.builtin.fail:
         msg: >-
-          No available IPs in ExternalIPPool '{{ eip_pool_name }}' ({{ _eip_pool_cidr }}).
+          No available IPs in ExternalIPPool '{{ eip_pool_name }}'.
           {{ _eip_allocated_ips | length }} of {{ _eip_all_ips | length }} IPs allocated.
       when: _eip_available_ips | length == 0
 

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
@@ -1,7 +1,7 @@
 ---
 # ExternalIP maps to a Netris IPAM /32 subnet (purpose=nat) inside the
-# pool's allocation.  Finds an available IP by enumerating the pool
-# allocation CIDRs and subtracting existing /32 child subnets.
+# pool's allocation.  Finds an available IP by collecting allocated /32
+# subnets and picking the first unused host address from the pool CIDRs.
 
 - name: Validate ExternalIP annotations
   ansible.builtin.assert:
@@ -80,7 +80,7 @@
       ansible.builtin.set_fact:
         _eip_pool_allocs: >-
           {{ (_eip_ipam_tree_resp.json.data | default([]))
-             | selectattr('name', 'match', '^' + eip_pool_name + '(-[0-9]+)?$')
+             | selectattr('name', 'match', '^' + (eip_pool_name | regex_escape) + '(-[0-9]+)?$')
              | list }}
       when: _eip_ipam_tree_resp.json is mapping
 
@@ -91,46 +91,43 @@
           Ensure the ExternalIPPool has been created before allocating ExternalIPs.
       when: _eip_pool_allocs | length == 0
 
-    - name: Build list of all usable IPs across pool CIDRs
+    - name: Collect allocated /32 addresses within pool CIDRs
       ansible.builtin.set_fact:
-        _eip_all_ips: >-
-          {%- set ips = [] -%}
-          {%- for alloc in _eip_pool_allocs -%}
-          {%-   set cidr = alloc.prefix -%}
-          {%-   set net = cidr | ansible.utils.ipaddr('network') -%}
-          {%-   set prefix_len = cidr | ansible.utils.ipaddr('prefix') | int -%}
-          {%-   for i in range(1, 2 ** (32 - prefix_len) - 1) -%}
-          {%-     set _ = ips.append(net | ansible.utils.ipmath(i)) -%}
-          {%-   endfor -%}
-          {%- endfor -%}
-          {{ ips }}
-
-    - name: Collect already-allocated /32 subnets within pool ranges
-      ansible.builtin.set_fact:
-        _eip_allocated_ips: >-
+        _eip_allocated_addrs: >-
           {{ (_eip_ipam_subnets_resp.json.data | default([]))
              | selectattr('prefix', 'defined')
              | selectattr('prefix', 'match', '.*\/32$')
              | map(attribute='prefix')
              | map('ansible.utils.ipaddr', 'address')
-             | select('in', _eip_all_ips)
              | list }}
 
-    - name: Compute available IPs
+    - name: Find first available IP in pool
       ansible.builtin.set_fact:
-        _eip_available_ips: >-
-          {{ _eip_all_ips | reject('in', _eip_allocated_ips) | list }}
+        eip_allocated_address: >-
+          {%- set ns = namespace(found='') -%}
+          {%- for alloc in _eip_pool_allocs -%}
+          {%-   if not ns.found -%}
+          {%-     set cidr = alloc.prefix -%}
+          {%-     set net = cidr | ansible.utils.ipaddr('network') -%}
+          {%-     set prefix_len = cidr | ansible.utils.ipaddr('prefix') | int -%}
+          {%-     for i in range(1, 2 ** (32 - prefix_len) - 1) -%}
+          {%-       if not ns.found -%}
+          {%-         set candidate = net | ansible.utils.ipmath(i) -%}
+          {%-         if candidate not in _eip_allocated_addrs -%}
+          {%-           set ns.found = candidate -%}
+          {%-         endif -%}
+          {%-       endif -%}
+          {%-     endfor -%}
+          {%-   endif -%}
+          {%- endfor -%}
+          {{ ns.found }}
 
     - name: Fail if no IPs available in pool
       ansible.builtin.fail:
         msg: >-
           No available IPs in ExternalIPPool '{{ eip_pool_name }}'.
-          {{ _eip_allocated_ips | length }} of {{ _eip_all_ips | length }} IPs allocated.
-      when: _eip_available_ips | length == 0
-
-    - name: Set allocated address
-      ansible.builtin.set_fact:
-        eip_allocated_address: "{{ _eip_available_ips[0] }}"
+          All addresses in {{ _eip_pool_allocs | map(attribute='prefix') | list }} are allocated.
+      when: eip_allocated_address | length == 0
 
     - name: Display allocated IP
       ansible.builtin.debug:

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
@@ -1,0 +1,113 @@
+---
+# ExternalIP maps to a Netris IPAM /32 allocation
+# Finds an available IP from the pool's nat-purpose subnets, then reserves it
+# as a named /32 allocation in the IPAM tree.
+
+- name: Validate ExternalIP annotations
+  ansible.builtin.assert:
+    that:
+      - external_ip.metadata is defined
+      - external_ip.metadata.annotations is defined
+      - "'osac.openshift.io/externalippool-name' in external_ip.metadata.annotations"
+    fail_msg: "ExternalIP metadata.annotations['osac.openshift.io/externalippool-name'] is required"
+
+- name: Extract ExternalIP configuration
+  ansible.builtin.set_fact:
+    eip_name: "{{ external_ip.metadata.name }}"
+    eip_pool_name: >-
+      {{ external_ip.metadata.annotations['osac.openshift.io/externalippool-name'] }}
+
+- name: Display ExternalIP information
+  ansible.builtin.debug:
+    msg:
+      - "Allocating Netris IPAM IP for ExternalIP '{{ eip_name }}'"
+      - "Pool name (ExternalIPPool): {{ eip_pool_name }}"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Check for existing IPAM allocation
+  ansible.builtin.uri:
+    url: >-
+      {{ netris_controller_url }}/api/v2/ipam
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: [200]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _eip_ipam_tree_resp
+  no_log: true
+
+- name: Find existing allocation by ExternalIP name
+  ansible.builtin.set_fact:
+    _eip_existing_alloc: >-
+      {{ (_eip_ipam_tree_resp.json.data | default([]))
+         | selectattr('name', 'equalto', eip_name)
+         | list | first | default(none) }}
+  when: _eip_ipam_tree_resp.json is mapping
+
+- name: Use existing allocation address (idempotent)
+  when: _eip_existing_alloc is defined and _eip_existing_alloc is not none
+  block:
+    - name: Set allocated address from existing IPAM allocation
+      ansible.builtin.set_fact:
+        eip_allocated_address: "{{ _eip_existing_alloc.prefix | ansible.utils.ipaddr('address') }}"
+
+    - name: Display existing allocation
+      ansible.builtin.debug:
+        msg: "ExternalIP '{{ eip_name }}' already has IPAM allocation: {{ eip_allocated_address }}"
+
+- name: Allocate new IP from IPAM pool
+  when: _eip_existing_alloc is not defined or _eip_existing_alloc is none
+  block:
+    - name: Find available IP from nat-purpose IPAM subnets
+      ansible.builtin.include_role:
+        name: netris.controller.ipam
+      vars:
+        ipam_site_id: "{{ netris_site_id }}"
+        ipam_purpose: "{{ default_ipam_purpose_public }}"
+        ipam_count: 1
+
+    - name: Set allocated address from IPAM
+      ansible.builtin.set_fact:
+        eip_allocated_address: "{{ ipam_allocated_ips[0] }}"
+
+    - name: Display allocated IP
+      ansible.builtin.debug:
+        msg: "Allocated IP {{ eip_allocated_address }} for ExternalIP '{{ eip_name }}'"
+
+    - name: Create /32 IPAM allocation to reserve the IP
+      ansible.builtin.include_role:
+        name: netris.controller.ipam
+        tasks_from: create_allocation
+      vars:
+        ipam_name: "{{ eip_name }}"
+        ipam_cidr: "{{ eip_allocated_address }}/32"
+        ipam_tenant_id: "{{ netris_tenant_id }}"
+
+    - name: Display IPAM allocation result
+      ansible.builtin.debug:
+        msg: >-
+          IPAM allocation '{{ eip_name }}' created for {{ eip_allocated_address }}/32
+          (ID: {{ ipam_alloc_id | default('unknown') }})
+
+- name: Write allocated address to ExternalIP CR annotation
+  kubernetes.core.k8s_json_patch:
+    api_version: osac.openshift.io/v1alpha1
+    kind: ExternalIP
+    name: "{{ eip_name }}"
+    namespace: "{{ external_ip.metadata.namespace }}"
+    patch:
+      - op: add
+        path: /metadata/annotations/osac.openshift.io~1allocated-address
+        value: "{{ eip_allocated_address }}"
+
+- name: Display ExternalIP creation result
+  ansible.builtin.debug:
+    msg:
+      - "ExternalIP '{{ eip_name }}' allocated address: {{ eip_allocated_address }}"
+      - "IPAM allocation created and address written to CR annotation"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
@@ -28,7 +28,7 @@
     name: netris.controller.auth
   when: netris_session_cookie is not defined
 
-- name: Query IPAM tree
+- name: Query IPAM allocations
   ansible.builtin.uri:
     url: "{{ netris_controller_url }}/api/v2/ipam"
     method: GET
@@ -41,13 +41,26 @@
   register: _eip_ipam_tree_resp
   no_log: true
 
+- name: Query IPAM subnets
+  ansible.builtin.uri:
+    url: "{{ netris_controller_url }}/api/v2/ipam/subnets"
+    method: GET
+    headers:
+      Cookie: "connect.sid={{ netris_session_cookie }}"
+    return_content: true
+    status_code: [200]
+    timeout: "{{ netris_timeout | default(30) }}"
+    validate_certs: "{{ netris_validate_certs | default(true) }}"
+  register: _eip_ipam_subnets_resp
+  no_log: true
+
 - name: Check for existing subnet by ExternalIP name
   ansible.builtin.set_fact:
     _eip_existing_subnet: >-
-      {{ (_eip_ipam_tree_resp.json.data | default([]))
+      {{ (_eip_ipam_subnets_resp.json.data | default([]))
          | selectattr('name', 'equalto', eip_name)
          | list | first | default(none) }}
-  when: _eip_ipam_tree_resp.json is mapping
+  when: _eip_ipam_subnets_resp.json is mapping
 
 - name: Use existing subnet address (idempotent)
   when: _eip_existing_subnet is defined and _eip_existing_subnet is not none
@@ -81,21 +94,21 @@
     - name: Build list of all usable IPs across pool CIDRs
       ansible.builtin.set_fact:
         _eip_all_ips: >-
-          {% set ips = [] %}
-          {% for alloc in _eip_pool_allocs %}
-          {%   set cidr = alloc.prefix %}
-          {%   set net = cidr | ansible.utils.ipaddr('network') %}
-          {%   set prefix_len = cidr | ansible.utils.ipaddr('prefix') | int %}
-          {%   for i in range(1, 2 ** (32 - prefix_len) - 1) %}
-          {%     set _ = ips.append(net | ansible.utils.ipmath(i)) %}
-          {%   endfor %}
-          {% endfor %}
+          {%- set ips = [] -%}
+          {%- for alloc in _eip_pool_allocs -%}
+          {%-   set cidr = alloc.prefix -%}
+          {%-   set net = cidr | ansible.utils.ipaddr('network') -%}
+          {%-   set prefix_len = cidr | ansible.utils.ipaddr('prefix') | int -%}
+          {%-   for i in range(1, 2 ** (32 - prefix_len) - 1) -%}
+          {%-     set _ = ips.append(net | ansible.utils.ipmath(i)) -%}
+          {%-   endfor -%}
+          {%- endfor -%}
           {{ ips }}
 
     - name: Collect already-allocated /32 subnets within pool ranges
       ansible.builtin.set_fact:
         _eip_allocated_ips: >-
-          {{ (_eip_ipam_tree_resp.json.data | default([]))
+          {{ (_eip_ipam_subnets_resp.json.data | default([]))
              | selectattr('prefix', 'defined')
              | selectattr('prefix', 'match', '.*\/32$')
              | map(attribute='prefix')

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
@@ -89,9 +89,9 @@
         msg: >-
           ExternalIPPool allocations for '{{ eip_pool_name }}' not found in Netris IPAM.
           Ensure the ExternalIPPool has been created before allocating ExternalIPs.
-      when: _eip_pool_allocs | length == 0
+      when: (_eip_pool_allocs | default([])) | length == 0
 
-    - name: Collect allocated /32 addresses within pool CIDRs
+    - name: Collect all allocated /32 addresses from IPAM
       ansible.builtin.set_fact:
         _eip_allocated_addrs: >-
           {{ (_eip_ipam_subnets_resp.json.data | default([]))
@@ -101,6 +101,8 @@
              | map('ansible.utils.ipaddr', 'address')
              | list }}
 
+    # Pool allocations are assumed /30 or wider — /31 (RFC 3021) would
+    # produce an empty candidate range and is not supported.
     - name: Find first available IP in pool
       ansible.builtin.set_fact:
         eip_allocated_address: >-
@@ -147,7 +149,9 @@
     - name: Display IPAM subnet result
       ansible.builtin.debug:
         msg: >-
-          IPAM subnet '{{ eip_name }}' created for {{ eip_allocated_address }}/32
+          IPAM subnet '{{ eip_name }}'
+          {{ (ipam_already_existed | default(false)) | ternary('already exists', 'created successfully') }}
+          for {{ eip_allocated_address }}/32
           (ID: {{ ipam_subnet_id | default('unknown') }})
 
 - name: Write allocated address to ExternalIP CR annotation

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
@@ -1,7 +1,7 @@
 ---
-# ExternalIP maps to a Netris IPAM /32 allocation
-# Finds an available IP from the pool's nat-purpose subnets, then reserves it
-# as a named /32 allocation in the IPAM tree.
+# ExternalIP maps to a Netris IPAM /32 subnet (purpose=nat) inside the
+# pool's allocation.  Finds an available IP by enumerating the pool
+# allocation's CIDR and subtracting existing child subnets.
 
 - name: Validate ExternalIP annotations
   ansible.builtin.assert:
@@ -28,10 +28,9 @@
     name: netris.controller.auth
   when: netris_session_cookie is not defined
 
-- name: Check for existing IPAM allocation
+- name: Query IPAM tree
   ansible.builtin.uri:
-    url: >-
-      {{ netris_controller_url }}/api/v2/ipam
+    url: "{{ netris_controller_url }}/api/v2/ipam"
     method: GET
     headers:
       Cookie: "connect.sid={{ netris_session_cookie }}"
@@ -42,58 +41,101 @@
   register: _eip_ipam_tree_resp
   no_log: true
 
-- name: Find existing allocation by ExternalIP name
+- name: Check for existing subnet by ExternalIP name
   ansible.builtin.set_fact:
-    _eip_existing_alloc: >-
+    _eip_existing_subnet: >-
       {{ (_eip_ipam_tree_resp.json.data | default([]))
          | selectattr('name', 'equalto', eip_name)
          | list | first | default(none) }}
   when: _eip_ipam_tree_resp.json is mapping
 
-- name: Use existing allocation address (idempotent)
-  when: _eip_existing_alloc is defined and _eip_existing_alloc is not none
+- name: Use existing subnet address (idempotent)
+  when: _eip_existing_subnet is defined and _eip_existing_subnet is not none
   block:
-    - name: Set allocated address from existing IPAM allocation
+    - name: Set allocated address from existing IPAM subnet
       ansible.builtin.set_fact:
-        eip_allocated_address: "{{ _eip_existing_alloc.prefix | ansible.utils.ipaddr('address') }}"
+        eip_allocated_address: "{{ _eip_existing_subnet.prefix | ansible.utils.ipaddr('address') }}"
 
-    - name: Display existing allocation
+    - name: Display existing subnet
       ansible.builtin.debug:
-        msg: "ExternalIP '{{ eip_name }}' already has IPAM allocation: {{ eip_allocated_address }}"
+        msg: "ExternalIP '{{ eip_name }}' already has IPAM subnet: {{ eip_allocated_address }}"
 
-- name: Allocate new IP from IPAM pool
-  when: _eip_existing_alloc is not defined or _eip_existing_alloc is none
+- name: Allocate new IP from pool
+  when: _eip_existing_subnet is not defined or _eip_existing_subnet is none
   block:
-    - name: Find available IP from nat-purpose IPAM subnets
-      ansible.builtin.include_role:
-        name: netris.controller.ipam
-      vars:
-        ipam_site_id: "{{ netris_site_id }}"
-        ipam_purpose: "{{ default_ipam_purpose_public }}"
-        ipam_count: 1
-
-    - name: Set allocated address from IPAM
+    - name: Find pool allocation in IPAM tree
       ansible.builtin.set_fact:
-        eip_allocated_address: "{{ ipam_allocated_ips[0] }}"
+        _eip_pool_alloc: >-
+          {{ (_eip_ipam_tree_resp.json.data | default([]))
+             | selectattr('name', 'equalto', eip_pool_name)
+             | list | first | default(none) }}
+      when: _eip_ipam_tree_resp.json is mapping
+
+    - name: Fail if pool allocation not found
+      ansible.builtin.fail:
+        msg: >-
+          ExternalIPPool allocation '{{ eip_pool_name }}' not found in Netris IPAM.
+          Ensure the ExternalIPPool has been created before allocating ExternalIPs.
+      when: _eip_pool_alloc is none
+
+    - name: Set pool CIDR
+      ansible.builtin.set_fact:
+        _eip_pool_cidr: "{{ _eip_pool_alloc.prefix }}"
+
+    - name: Enumerate all usable IPs in pool CIDR
+      ansible.builtin.set_fact:
+        _eip_all_ips: >-
+          {{ range(1, 2 ** (32 - (_eip_pool_cidr | ansible.utils.ipaddr('prefix') | int)) - 1)
+             | map('ansible.utils.ipmath', _eip_pool_cidr | ansible.utils.ipaddr('network'))
+             | list }}
+
+    - name: Collect existing child subnets in pool
+      ansible.builtin.set_fact:
+        _eip_allocated_ips: >-
+          {{ (_eip_ipam_tree_resp.json.data | default([]))
+             | selectattr('prefix', 'defined')
+             | selectattr('prefix', 'match', '.*\/32$')
+             | map(attribute='prefix')
+             | map('ansible.utils.ipaddr', 'address')
+             | select('in', _eip_all_ips)
+             | list }}
+
+    - name: Compute available IPs
+      ansible.builtin.set_fact:
+        _eip_available_ips: >-
+          {{ _eip_all_ips | reject('in', _eip_allocated_ips) | list }}
+
+    - name: Fail if no IPs available in pool
+      ansible.builtin.fail:
+        msg: >-
+          No available IPs in ExternalIPPool '{{ eip_pool_name }}' ({{ _eip_pool_cidr }}).
+          {{ _eip_allocated_ips | length }} of {{ _eip_all_ips | length }} IPs allocated.
+      when: _eip_available_ips | length == 0
+
+    - name: Set allocated address
+      ansible.builtin.set_fact:
+        eip_allocated_address: "{{ _eip_available_ips[0] }}"
 
     - name: Display allocated IP
       ansible.builtin.debug:
-        msg: "Allocated IP {{ eip_allocated_address }} for ExternalIP '{{ eip_name }}'"
+        msg: "Allocated IP {{ eip_allocated_address }} for ExternalIP '{{ eip_name }}' from pool '{{ eip_pool_name }}'"
 
-    - name: Create /32 IPAM allocation to reserve the IP
+    - name: Create /32 IPAM subnet to reserve the IP
       ansible.builtin.include_role:
         name: netris.controller.ipam
-        tasks_from: create_allocation
+        tasks_from: create_subnet
       vars:
         ipam_name: "{{ eip_name }}"
         ipam_cidr: "{{ eip_allocated_address }}/32"
+        ipam_purpose: "nat"
+        ipam_site_id: "{{ netris_site_id }}"
         ipam_tenant_id: "{{ netris_tenant_id }}"
 
-    - name: Display IPAM allocation result
+    - name: Display IPAM subnet result
       ansible.builtin.debug:
         msg: >-
-          IPAM allocation '{{ eip_name }}' created for {{ eip_allocated_address }}/32
-          (ID: {{ ipam_alloc_id | default('unknown') }})
+          IPAM subnet '{{ eip_name }}' created for {{ eip_allocated_address }}/32
+          (ID: {{ ipam_subnet_id | default('unknown') }})
 
 - name: Write allocated address to ExternalIP CR annotation
   kubernetes.core.k8s_json_patch:
@@ -110,4 +152,4 @@
   ansible.builtin.debug:
     msg:
       - "ExternalIP '{{ eip_name }}' allocated address: {{ eip_allocated_address }}"
-      - "IPAM allocation created and address written to CR annotation"
+      - "IPAM subnet created and address written to CR annotation"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip.yaml
@@ -1,5 +1,5 @@
 ---
-# ExternalIP deletion - removes the /32 IPAM allocation that reserved the IP
+# ExternalIP deletion — removes the /32 IPAM subnet that reserved the IP
 
 - name: Extract ExternalIP name
   ansible.builtin.set_fact:
@@ -7,20 +7,20 @@
 
 - name: Display deletion information
   ansible.builtin.debug:
-    msg: "Deleting Netris IPAM allocation for ExternalIP '{{ eip_name }}'"
+    msg: "Deleting Netris IPAM subnet for ExternalIP '{{ eip_name }}'"
 
 - name: Ensure Netris auth
   ansible.builtin.include_role:
     name: netris.controller.auth
   when: netris_session_cookie is not defined
 
-- name: Delete /32 IPAM allocation from Netris controller
+- name: Delete /32 IPAM subnet from Netris controller
   ansible.builtin.include_role:
     name: netris.controller.ipam
-    tasks_from: delete_allocation
+    tasks_from: delete_subnet
   vars:
     ipam_name: "{{ eip_name }}"
 
 - name: Display deletion result
   ansible.builtin.debug:
-    msg: "IPAM allocation '{{ eip_name }}' deletion completed"
+    msg: "IPAM subnet '{{ eip_name }}' deletion completed"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip.yaml
@@ -1,0 +1,26 @@
+---
+# ExternalIP deletion - removes the /32 IPAM allocation that reserved the IP
+
+- name: Extract ExternalIP name
+  ansible.builtin.set_fact:
+    eip_name: "{{ external_ip.metadata.name }}"
+
+- name: Display deletion information
+  ansible.builtin.debug:
+    msg: "Deleting Netris IPAM allocation for ExternalIP '{{ eip_name }}'"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Delete /32 IPAM allocation from Netris controller
+  ansible.builtin.include_role:
+    name: netris.controller.ipam
+    tasks_from: delete_allocation
+  vars:
+    ipam_name: "{{ eip_name }}"
+
+- name: Display deletion result
+  ansible.builtin.debug:
+    msg: "IPAM allocation '{{ eip_name }}' deletion completed"


### PR DESCRIPTION
## [OSAC-2035](https://redhat.atlassian.net/browse/OSAC-2035): Add Netris ExternalIP template role

**Jira:** https://redhat.atlassian.net/browse/OSAC-2035
**Epic:** [OSAC-2044](https://redhat.atlassian.net/browse/OSAC-2044) — Netris Unified Networking Template Roles
**Feature:** [OSAC-2043](https://redhat.atlassian.net/browse/OSAC-2043) — Fabric Manager - Netris

### Summary

Adds `create_external_ip.yaml` and `delete_external_ip.yaml` to the `osac.templates.netris` role for allocating and releasing individual ExternalIP addresses from Netris IPAM. Includes matching playbooks, argument specs, and AAP job template registrations for the end-to-end operator→AAP→template dispatch chain.

### Changes

**Template role tasks:**
- `create_external_ip.yaml` — Authenticates with Netris, finds an available IP from nat-purpose IPAM subnets, creates a named /32 IPAM allocation to reserve it, writes the allocated address to a CR annotation (`osac.openshift.io/allocated-address`)
- `delete_external_ip.yaml` — Authenticates with Netris, deletes the named /32 IPAM allocation

**Role metadata:**
- `argument_specs.yaml` — Added `create_external_ip` and `delete_external_ip` entries

**Playbooks:**
- `playbook_osac_create_external_ip.yml` — Standard dispatch playbook for ExternalIP creation
- `playbook_osac_delete_external_ip.yml` — Standard dispatch playbook for ExternalIP deletion

**Config-as-Code:**
- Registered `{prefix}-create-external-ip` and `{prefix}-delete-external-ip` AAP job templates

### Testing

- **ansible-lint:** All new and modified files pass
- **Syntax check:** Both playbooks pass `ansible-playbook --syntax-check`
- **E2E:** Requires live Netris controller and AAP — out of scope for this PR

### Cross-repo dependencies

- **osac-operator:** The `ExternalIPReconciler` dispatches to `osac-create-external-ip` / `osac-delete-external-ip` AAP templates — this PR provides those templates. The operator's `getExternalIPAddress()` currently reads from MetalLB Services; a follow-up operator update is needed to read from the `osac.openshift.io/allocated-address` annotation for the Netris implementation strategy.
- **[OSAC-2034](https://redhat.atlassian.net/browse/OSAC-2034) (ExternalIPPool role):** Sibling task that creates the IPAM nat-purpose subnet this role allocates from. Can proceed in parallel.

### Acceptance Criteria

- [x] `create_external_ip.yaml` exists and allocates a single IP from Netris IPAM
- [x] `delete_external_ip.yaml` exists and releases the allocated IP
- [x] Allocated address stored in CR annotation for the operator
- [x] Tasks follow existing netris template role patterns
- [x] `argument_specs.yaml` updated with ExternalIP entries


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added External IP lifecycle operations (create and delete) backed by Netris IPAM.
  * Updated controller automation to run External IP create/delete workflows from the UI (replacing the prior attachment-based templates).
  * Extended External IP operation inputs to require `external_ip`, with optional `template_parameters` for create.
* **Bug Fixes**
  * External IP allocation is idempotent and reuses an existing reserved address when available.
  * Allocation now chooses an unallocated `/32` address to avoid address conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->