### PR TITLE
OSAC-2036: Add Netris ExternalIPAttachment template role

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -243,6 +243,30 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-create-external-ip-attachment"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_create_external_ip_attachment.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+  - name: "{{ aap_prefix }}-delete-external-ip-attachment"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_delete_external_ip_attachment.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
   - name: "{{ aap_prefix }}-create-security-group"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"

--- a/collections/ansible_collections/osac/templates/roles/netris/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/meta/argument_specs.yaml
@@ -94,3 +94,22 @@ argument_specs:
         type: dict
         required: true
         description: PublicIP CR from fulfillment-api via EDA payload
+
+  create_external_ip_attachment:
+    options:
+      external_ip_attachment:
+        type: dict
+        required: true
+        description: ExternalIPAttachment CR from fulfillment-api via EDA payload
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}
+
+  delete_external_ip_attachment:
+    options:
+      external_ip_attachment:
+        type: dict
+        required: true
+        description: ExternalIPAttachment CR from fulfillment-api via EDA payload

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip_attachment.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip_attachment.yaml
@@ -1,33 +1,58 @@
 ---
 # ExternalIPAttachment maps to a Netris DNAT rule
 # Creates a DNAT rule on the SoftGate: external IP -> internal target IP
-# The operator resolves the target IP before dispatching to AAP
+# Resolves the external IP address from the ExternalIP CR (same model as
+# ExternalIP resolving from ExternalIPPool)
 
 - name: Validate ExternalIPAttachment annotations
   ansible.builtin.assert:
     that:
       - external_ip_attachment.metadata is defined
       - external_ip_attachment.metadata.annotations is defined
-      - "'osac.openshift.io/external-ip-address' in external_ip_attachment.metadata.annotations"
+      - "'osac.openshift.io/externalip-name' in external_ip_attachment.metadata.annotations"
       - "'osac.openshift.io/target-ip' in external_ip_attachment.metadata.annotations"
     fail_msg: >-
       ExternalIPAttachment requires annotations
-      'osac.openshift.io/external-ip-address' and 'osac.openshift.io/target-ip'.
-      The operator must resolve these before dispatching to AAP.
+      'osac.openshift.io/externalip-name' (ExternalIP CR name) and
+      'osac.openshift.io/target-ip' (resolved internal IP).
 
 - name: Extract ExternalIPAttachment configuration
   ansible.builtin.set_fact:
     attachment_name: "{{ external_ip_attachment.metadata.name }}"
-    attachment_external_ip: >-
-      {{ external_ip_attachment.metadata.annotations['osac.openshift.io/external-ip-address'] }}
+    attachment_namespace: "{{ external_ip_attachment.metadata.namespace }}"
+    attachment_externalip_name: >-
+      {{ external_ip_attachment.metadata.annotations['osac.openshift.io/externalip-name'] }}
     attachment_target_ip: >-
       {{ external_ip_attachment.metadata.annotations['osac.openshift.io/target-ip'] }}
+
+- name: Look up ExternalIP CR to get allocated address
+  kubernetes.core.k8s_info:
+    api_version: osac.openshift.io/v1alpha1
+    kind: ExternalIP
+    name: "{{ attachment_externalip_name }}"
+    namespace: "{{ attachment_namespace }}"
+  register: _eip_lookup
+
+- name: Validate ExternalIP CR found with allocated address
+  ansible.builtin.assert:
+    that:
+      - _eip_lookup.resources | length > 0
+      - _eip_lookup.resources[0].metadata.annotations['osac.openshift.io/allocated-address'] is defined
+    fail_msg: >-
+      ExternalIP '{{ attachment_externalip_name }}' not found or missing
+      'osac.openshift.io/allocated-address' annotation. The ExternalIP must
+      be allocated before creating an attachment.
+
+- name: Extract allocated external IP address
+  ansible.builtin.set_fact:
+    attachment_external_ip: >-
+      {{ _eip_lookup.resources[0].metadata.annotations['osac.openshift.io/allocated-address'] }}
 
 - name: Display ExternalIPAttachment information
   ansible.builtin.debug:
     msg:
       - "Creating Netris DNAT rule for ExternalIPAttachment '{{ attachment_name }}'"
-      - "External IP: {{ attachment_external_ip }}"
+      - "External IP: {{ attachment_external_ip }} (from ExternalIP '{{ attachment_externalip_name }}')"
       - "Target IP: {{ attachment_target_ip }}"
 
 - name: Ensure Netris auth

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip_attachment.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip_attachment.yaml
@@ -1,0 +1,59 @@
+---
+# ExternalIPAttachment maps to a Netris DNAT rule
+# Creates a DNAT rule on the SoftGate: external IP -> internal target IP
+# The operator resolves the target IP before dispatching to AAP
+
+- name: Validate ExternalIPAttachment annotations
+  ansible.builtin.assert:
+    that:
+      - external_ip_attachment.metadata is defined
+      - external_ip_attachment.metadata.annotations is defined
+      - "'osac.openshift.io/external-ip-address' in external_ip_attachment.metadata.annotations"
+      - "'osac.openshift.io/target-ip' in external_ip_attachment.metadata.annotations"
+    fail_msg: >-
+      ExternalIPAttachment requires annotations
+      'osac.openshift.io/external-ip-address' and 'osac.openshift.io/target-ip'.
+      The operator must resolve these before dispatching to AAP.
+
+- name: Extract ExternalIPAttachment configuration
+  ansible.builtin.set_fact:
+    attachment_name: "{{ external_ip_attachment.metadata.name }}"
+    attachment_external_ip: >-
+      {{ external_ip_attachment.metadata.annotations['osac.openshift.io/external-ip-address'] }}
+    attachment_target_ip: >-
+      {{ external_ip_attachment.metadata.annotations['osac.openshift.io/target-ip'] }}
+
+- name: Display ExternalIPAttachment information
+  ansible.builtin.debug:
+    msg:
+      - "Creating Netris DNAT rule for ExternalIPAttachment '{{ attachment_name }}'"
+      - "External IP: {{ attachment_external_ip }}"
+      - "Target IP: {{ attachment_target_ip }}"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Create DNAT rule for ExternalIPAttachment
+  ansible.builtin.include_role:
+    name: netris.controller.nat
+    tasks_from: create
+  vars:
+    nat_name: "{{ attachment_name }}-dnat"
+    nat_site_id: "{{ netris_site_id }}"
+    nat_vpc_id: "{{ netris_mgmt_vpc_id }}"
+    nat_vpc_name: "{{ netris_mgmt_vpc_name | default('') }}"
+    nat_action: dnat
+    nat_protocol: all
+    nat_destination_address: "{{ attachment_external_ip }}/32"
+    nat_dnat_to_ip: "{{ attachment_target_ip }}/32"
+    nat_comment: "OSAC ExternalIPAttachment {{ attachment_name }}"
+
+- name: Display DNAT rule creation result
+  ansible.builtin.debug:
+    msg: >-
+      DNAT rule '{{ attachment_name }}-dnat'
+      {{ (nat_already_existed | default(false)) | ternary('already exists', 'created successfully') }}
+      (ID: {{ nat_id | default('unknown') }})
+      — {{ attachment_external_ip }} -> {{ attachment_target_ip }}

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip_attachment.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_external_ip_attachment.yaml
@@ -1,0 +1,27 @@
+---
+# ExternalIPAttachment deletion — removes the DNAT rule from Netris
+
+- name: Extract ExternalIPAttachment name
+  ansible.builtin.set_fact:
+    attachment_name: "{{ external_ip_attachment.metadata.name }}"
+
+- name: Display ExternalIPAttachment deletion info
+  ansible.builtin.debug:
+    msg: "Deleting Netris DNAT rule for ExternalIPAttachment '{{ attachment_name }}'"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Delete DNAT rule for ExternalIPAttachment
+  ansible.builtin.include_role:
+    name: netris.controller.nat
+    tasks_from: delete
+  vars:
+    nat_name: "{{ attachment_name }}-dnat"
+    nat_site_id: "{{ netris_site_id }}"
+
+- name: Display deletion result
+  ansible.builtin.debug:
+    msg: "DNAT rule '{{ attachment_name }}-dnat' deletion completed"

--- a/playbook_osac_create_external_ip_attachment.yml
+++ b/playbook_osac_create_external_ip_attachment.yml
@@ -1,0 +1,27 @@
+---
+- name: Create an ExternalIPAttachment resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    external_ip_attachment: "{{ ansible_eda.event.payload }}"
+    external_ip_attachment_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display ExternalIPAttachment information
+      ansible.builtin.debug:
+        msg:
+          - "ExternalIPAttachment name: {{ external_ip_attachment_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected ExternalIPAttachment role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: create_external_ip_attachment

--- a/playbook_osac_delete_external_ip_attachment.yml
+++ b/playbook_osac_delete_external_ip_attachment.yml
@@ -1,0 +1,27 @@
+---
+- name: Delete an ExternalIPAttachment resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    external_ip_attachment: "{{ ansible_eda.event.payload }}"
+    external_ip_attachment_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display ExternalIPAttachment information
+      ansible.builtin.debug:
+        msg:
+          - "Deleting ExternalIPAttachment: {{ external_ip_attachment_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected ExternalIPAttachment role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: delete_external_ip_attachment


### PR DESCRIPTION
## Summary

- Add `create_external_ip_attachment.yaml` and `delete_external_ip_attachment.yaml` to the `osac.templates.netris` role
- Create task resolves external IP from the ExternalIP CR (`allocated-address` annotation), reads the target IP from the operator-provided `target-ip` annotation, and creates a generic DNAT rule (protocol: all) via `netris.controller.nat`
- Delete task removes the DNAT rule by deterministic name (`{attachment}-dnat`)
- Add top-level playbooks and `argument_specs.yaml` entries

## IPAM hierarchy

Follows the agreed model where each layer resolves from the one below:

| Layer | Netris resource | Resolves from |
|-------|----------------|---------------|
| ExternalIPPool | IPAM allocation (CIDR container) | — |
| ExternalIP | /32 IPAM subnet (purpose=nat) | Pool allocation |
| **ExternalIPAttachment** | **NAT rule (DNAT)** | **ExternalIP CR** |

## Cross-repo dependencies

- **osac-operator**: ExternalIPAttachment controller must set `osac.openshift.io/target-ip` annotation (resolved internal IP) before dispatching to AAP. The `osac.openshift.io/externalip-name` annotation is already set.
- **OSAC-2035** (ExternalIP role): writes `osac.openshift.io/allocated-address` to the ExternalIP CR — this role reads it.

## Test plan

- [x] `ansible-lint` passes (production profile, 0 failures, 0 warnings)
- [x] `ansible-playbook --syntax-check` passes for both playbooks
- [ ] E2E: operator → AAP → Netris DNAT rule creation (requires operator `target-ip` annotation support)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and deleting `ExternalIPAttachment` resources through new automation flows.
  * Introduced end-to-end handling for incoming event payloads to route each request to the appropriate implementation.

* **Bug Fixes**
  * Improved validation and logging around attachment details to make creation and deletion outcomes clearer.
  * Added checks to ensure required connection details are available before running network changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->