### PR TITLE
OSAC-1749: Add BGP route advertisement for PublicIP external access

### DIFF
--- a/collections/ansible_collections/agentless_net/l3/roles/bgp/meta/argument_specs.yaml
+++ b/collections/ansible_collections/agentless_net/l3/roles/bgp/meta/argument_specs.yaml
@@ -1,0 +1,21 @@
+argument_specs:
+  announce:
+    options:
+      bgp_public_ip:
+        description: "PublicIP to announce as a /32 route (e.g., 192.168.100.10)."
+        type: "str"
+        required: true
+      bgp_next_hop:
+        description: "Next-hop IP for the route (namespace-side veth IP, e.g., 10.254.0.2)."
+        type: "str"
+        required: true
+  withdraw:
+    options:
+      bgp_public_ip:
+        description: "PublicIP to withdraw (e.g., 192.168.100.10)."
+        type: "str"
+        required: true
+      bgp_next_hop:
+        description: "Next-hop IP to match for withdrawal (namespace-side veth IP)."
+        type: "str"
+        required: true

--- a/collections/ansible_collections/agentless_net/l3/roles/bgp/tasks/announce.yaml
+++ b/collections/ansible_collections/agentless_net/l3/roles/bgp/tasks/announce.yaml
@@ -1,0 +1,23 @@
+---
+- name: Validate BGP announce input variables
+  ansible.builtin.assert:
+    that:
+      - bgp_public_ip | ansible.utils.ipv4 != false
+      - bgp_next_hop | ansible.utils.ipv4 != false
+    fail_msg: "BGP announce variable validation failed. Check IPs."
+
+- name: Check if static route already exists
+  ansible.builtin.raw: >-
+    vtysh -c "show ip route {{ bgp_public_ip }}/32" 2>/dev/null
+    | grep -qw "{{ bgp_next_hop }}"
+  register: bgp_route_check
+  changed_when: false
+  failed_when: false
+
+- name: Add static route for BGP announcement
+  ansible.builtin.raw: >-
+    vtysh -c "configure terminal"
+    -c "ip route {{ bgp_public_ip }}/32 {{ bgp_next_hop }}"
+    -c "end"
+  when: bgp_route_check.rc != 0
+  changed_when: true

--- a/collections/ansible_collections/agentless_net/l3/roles/bgp/tasks/withdraw.yaml
+++ b/collections/ansible_collections/agentless_net/l3/roles/bgp/tasks/withdraw.yaml
@@ -1,0 +1,23 @@
+---
+- name: Validate BGP withdraw input variables
+  ansible.builtin.assert:
+    that:
+      - bgp_public_ip | ansible.utils.ipv4 != false
+      - bgp_next_hop | ansible.utils.ipv4 != false
+    fail_msg: "BGP withdraw variable validation failed. Check IPs."
+
+- name: Check if static route exists
+  ansible.builtin.raw: >-
+    vtysh -c "show ip route {{ bgp_public_ip }}/32" 2>/dev/null
+    | grep -qw "{{ bgp_next_hop }}"
+  register: bgp_route_check
+  changed_when: false
+  failed_when: false
+
+- name: Remove static route to withdraw BGP announcement
+  ansible.builtin.raw: >-
+    vtysh -c "configure terminal"
+    -c "no ip route {{ bgp_public_ip }}/32 {{ bgp_next_hop }}"
+    -c "end"
+  when: bgp_route_check.rc == 0
+  changed_when: true

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/create.yaml
@@ -210,6 +210,29 @@
       - "Subnet: {{ agentless_net_subnet_cidr }}, Gateway: {{ cluster_infra_subnet_gateway }}"
       - "External link: {{ cluster_infra_external_router_ip }} <-> {{ cluster_infra_external_peer_ip }}"
 
+- name: Store veth IPs in network state  # noqa: no-changed-when
+  ansible.builtin.raw: |
+    python3 - '{{ agentless_net_net_node_ipam_state_file }}' \
+              '{{ cluster_infra_state_key }}' \
+              '{{ cluster_infra_external_peer_ip }}' \
+              '{{ cluster_infra_external_router_ip }}' <<'STATE_PY'
+    import fcntl, json, os, sys
+    state_file, cluster_name, host_ip, ns_ip = sys.argv[1:5]
+    with open(state_file, 'r+') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        state = json.load(f)
+        state.setdefault('veth_state', {})[cluster_name] = {
+            'host_ip': host_ip,
+            'ns_ip': ns_ip
+        }
+        f.seek(0)
+        f.write(json.dumps(state, indent=2))
+        f.truncate()
+        f.flush()
+        os.fsync(f.fileno())
+    STATE_PY
+  delegate_to: "{{ groups['net_nodes'][0] }}"
+
 - name: Create L3 router namespace  # noqa: no-changed-when
   environment:
     ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"

--- a/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/delete.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/cluster_infra/tasks/delete.yaml
@@ -16,15 +16,17 @@
       delegate_to: "{{ groups['net_nodes'][0] }}"
       register: cluster_infra_ipam_state_raw
 
-    - name: Parse VLAN ID and allocated hosts for this cluster
+    - name: Parse cluster state from state file
       ansible.builtin.set_fact:
         cluster_infra_vlan_id: "{{ (cluster_infra_ipam_state_raw.content | b64decode | from_json).vlans[cluster_infra_state_key] | default('') }}"
         cluster_infra_allocated_host_ids: "{{ (cluster_infra_ipam_state_raw.content | b64decode | from_json).host_allocations[cluster_infra_state_key] | default([]) }}"
+        cluster_infra_external_peer_ip: "{{ (cluster_infra_ipam_state_raw.content | b64decode | from_json).veth_state[cluster_infra_state_key].host_ip | default('') }}"
   rescue:
-    - name: Default to empty VLAN ID and host IDs on missing or corrupt state
+    - name: Default to empty state on missing or corrupt file
       ansible.builtin.set_fact:
         cluster_infra_vlan_id: ""
         cluster_infra_allocated_host_ids: []
+        cluster_infra_external_peer_ip: ""
 
 - name: Skip network cleanup if no VLAN allocated
   ansible.builtin.debug:
@@ -36,18 +38,6 @@
 - name: Compute veth namespace-side interface name
   ansible.builtin.set_fact:
     cluster_infra_snat_veth_ns: "v{{ cluster_infra_name | hash('md5') | truncate(11, True, '') }}i"
-  when: cluster_infra_vlan_id | string | length > 0
-
-- name: Compute veth addresses for SNAT cleanup
-  ansible.builtin.set_fact:
-    cluster_infra_veth_index: "{{ (cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4 }}"
-    cluster_infra_veth_octet3: "{{ ((cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4) // 256 }}"
-    cluster_infra_veth_octet4: "{{ ((cluster_infra_vlan_id | int - agentless_net_vlan_pool_start | int) * 4) % 256 }}"
-  when: cluster_infra_vlan_id | string | length > 0
-
-- name: Set external subnet for SNAT cleanup
-  ansible.builtin.set_fact:
-    cluster_infra_external_peer_ip: "10.254.{{ cluster_infra_veth_octet3 }}.{{ cluster_infra_veth_octet4 | int + 1 }}/30"
   when: cluster_infra_vlan_id | string | length > 0
 
 - name: Delete SNAT rules  # noqa: no-changed-when
@@ -150,9 +140,9 @@
       {{ role_path }}/playbooks/ipam_release_vlan.yaml
   when: cluster_infra_vlan_id | string | length > 0
 
-# --- Clean up host allocation state ---
+# --- Clean up cluster state ---
 
-- name: Remove host allocation from network state  # noqa: no-changed-when
+- name: Remove cluster state from network state  # noqa: no-changed-when
   ansible.builtin.raw: |
     python3 - '{{ agentless_net_net_node_ipam_state_file }}' \
               '{{ cluster_infra_state_key }}' <<'STATE_PY'
@@ -162,6 +152,7 @@
         fcntl.flock(f, fcntl.LOCK_EX)
         state = json.load(f)
         state.get('host_allocations', {}).pop(cluster_name, None)
+        state.get('veth_state', {}).pop(cluster_name, None)
         f.seek(0)
         f.write(json.dumps(state, indent=2))
         f.truncate()
@@ -169,4 +160,4 @@
         os.fsync(f.fileno())
     STATE_PY
   delegate_to: "{{ groups['net_nodes'][0] }}"
-  when: cluster_infra_allocated_host_ids | length > 0
+  when: cluster_infra_vlan_id | string | length > 0

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/bgp_announce.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/bgp_announce.yaml
@@ -1,0 +1,10 @@
+---
+- name: Announce PublicIP route via BGP
+  hosts: net_nodes[0]
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Announce route
+      ansible.builtin.include_role:
+        name: agentless_net.l3.bgp
+        tasks_from: announce

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/bgp_withdraw.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/playbooks/bgp_withdraw.yaml
@@ -1,0 +1,10 @@
+---
+- name: Withdraw PublicIP route from BGP
+  hosts: net_nodes[0]
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Withdraw route
+      ansible.builtin.include_role:
+        name: agentless_net.l3.bgp
+        tasks_from: withdraw

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/create.yaml
@@ -219,3 +219,33 @@
       -e dnat_internal_port=443
       -e dnat_protocol=tcp
       {{ role_path }}/playbooks/l3_create_dnat.yaml
+
+# --- agentless_net: announce PublicIP routes via BGP ---
+
+- name: Read veth namespace-side IP from state file
+  ansible.builtin.set_fact:
+    external_access_bgp_next_hop: "{{ (external_access_api_ipam_raw.content | b64decode | from_json).veth_state[external_access_state_key].ns_ip | ansible.utils.ipaddr('address') }}"
+
+- name: Announce API PublicIP route  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e bgp_public_ip={{ external_access_api_public_ip }}
+      -e bgp_next_hop={{ external_access_bgp_next_hop }}
+      {{ role_path }}/playbooks/bgp_announce.yaml
+
+- name: Announce ingress PublicIP route  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e bgp_public_ip={{ external_access_ingress_public_ip }}
+      -e bgp_next_hop={{ external_access_bgp_next_hop }}
+      {{ role_path }}/playbooks/bgp_announce.yaml

--- a/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/delete.yaml
+++ b/collections/ansible_collections/agentless_net/steps/roles/external_access/tasks/delete.yaml
@@ -44,6 +44,45 @@
     external_access_metallb_ingress_ip: "{{ agentless_net_subnet_cidr | ansible.utils.nthhost(-10) }}"
   when: external_access_ingress_public_ip | length > 0
 
+# --- agentless_net: withdraw BGP routes ---
+
+- name: Read veth namespace-side IP for BGP withdrawal
+  when: external_access_api_public_ip | length > 0 or external_access_ingress_public_ip | length > 0
+  block:
+    - name: Extract veth namespace-side IP from state file
+      ansible.builtin.set_fact:
+        external_access_bgp_next_hop: "{{ (external_access_ipam_state_raw.content | b64decode | from_json).veth_state[external_access_state_key].ns_ip | ansible.utils.ipaddr('address') }}"
+  rescue:
+    - name: Default to empty BGP next-hop
+      ansible.builtin.set_fact:
+        external_access_bgp_next_hop: ""
+
+- name: Withdraw API PublicIP route  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e bgp_public_ip={{ external_access_api_public_ip }}
+      -e bgp_next_hop={{ external_access_bgp_next_hop }}
+      {{ role_path }}/playbooks/bgp_withdraw.yaml
+  when: external_access_api_public_ip | length > 0 and external_access_bgp_next_hop | default('') | length > 0
+
+- name: Withdraw ingress PublicIP route  # noqa: no-changed-when
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ agentless_net_collections_path }}"
+    ANSIBLE_ROLES_PATH: "{{ agentless_net_roles_path }}"
+  ansible.builtin.command:
+    cmd: >
+      ansible-playbook
+      -i {{ agentless_net_inventory_file }}
+      -e bgp_public_ip={{ external_access_ingress_public_ip }}
+      -e bgp_next_hop={{ external_access_bgp_next_hop }}
+      {{ role_path }}/playbooks/bgp_withdraw.yaml
+  when: external_access_ingress_public_ip | length > 0 and external_access_bgp_next_hop | default('') | length > 0
+
 # --- agentless_net: delete DNAT rules ---
 
 - name: Delete DNAT for API endpoint  # noqa: no-changed-when


### PR DESCRIPTION
Adds BGP-based route advertisement so that PublicIP addresses allocated to tenants are reachable
from the upstream network. A new `agentless_net.l3.bgp` role manages static route injection into
FRR, which redistributes them via eBGP to the upstream router. The `external_access` step role
integrates announce/withdraw into the cluster lifecycle, and the `cluster_infra` step stores veth
state for cross-step coordination.

## Changes

- **`agentless_net.l3.bgp` role** — `announce` and `withdraw` task files that add/remove `/32`
  static routes via `vtysh`, with idempotency checks
- **`cluster_infra/tasks/create.yaml`** — stores both host-side and namespace-side veth IPs in
  the network state file (`veth_state`) for use by downstream steps
- **`external_access/tasks/create.yaml`** — allocates public IPs, creates DNAT rules, then
  announces routes via BGP using the namespace-side veth IP as next-hop
- **`external_access/tasks/delete.yaml`** — withdraws BGP routes before releasing public IPs,
  with graceful fallback if state is missing

 ---

## Test coverage

The containerlab-based integration test (`test-steps.sh`) validates the full lifecycle across
two tenants:

- Management network reachability to all lab nodes
- Intra-tenant L2 connectivity across switches
- Inter-tenant isolation (traffic must not cross VLAN boundaries)
- Router namespace connectivity to tenant hosts
- SNAT egress from tenant networks to external destinations
- BGP session establishment between net-node and upstream router
- PublicIP route presence on net-node after announce
- PublicIP route propagation to upstream router via eBGP
- PublicIP route withdrawal from upstream router after delete
- Idempotency of all create operations (re-run produces no errors)
- Full teardown of networking resources (VLANs, routers, SNAT, DNAT, IPAM)

/assign @danmanor 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BGP-based public IP route announcement and withdrawal to external access create/delete flows.
  * Introduced dedicated BGP announce/withdraw playbooks and validation schema for BGP route parameters.
  * Enhanced cluster network state handling to persist veth IPs for later teardown steps.
* **Bug Fixes**
  * Added IPv4 input validation for BGP next-hop and public IP values before route changes.
  * Made route announcements/withdrawals idempotent by checking for existing routes before applying/removing them.
  * Improved cleanup resilience by using safe defaults when IPAM state parsing fails and aligning route teardown with current allocation conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->