### PR TITLE
OSAC-2174: Trigger execution environment image build on version tag pushes

### DIFF
--- a/.github/workflows/execution-environment.yml
+++ b/.github/workflows/execution-environment.yml
@@ -3,12 +3,14 @@ name: "Build execution environment"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main
@@ -41,22 +43,26 @@ jobs:
                                             -f "./execution-environment/execution-environment.yaml"
 
       - name: Extract metadata (tags, labels)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
+            type=ref,event=tag
             type=sha
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Log against GHCR
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | podman login --username ${{ github.actor }} --password-stdin ghcr.io
 
       - name: Push execution environment image
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name != 'pull_request'
         run: |
           for tag in $(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ' '); do
             podman tag "osac-ee" "${tag}"


### PR DESCRIPTION
## Summary

- Add `tags: ['v*']` to the `execution-environment.yml` push trigger so version tag pushes produce container images with matching version tags
- Add `semver` tag patterns to `docker/metadata-action` so tag pushes generate `v0.0.X` image tags
- Change push step conditions from main-branch-only to non-PR (covers both main pushes and tag pushes)
- Change `cancel-in-progress` to only cancel PR runs, preventing tag push builds from being cancelled

Same root cause as osac-project/osac-operator#342 and osac-project/bare-metal-fulfillment-operator#64 — version tags never triggered image builds, so released versions had no matching container image tags.

## Test plan

- [ ] Merge and create a test tag to verify the workflow triggers and produces semver-tagged images
- [ ] Verify `docker/metadata-action` generates expected tags (e.g., `v0.0.7`, `v0`, `v0.0`)