### PR TITLE
OSAC-1699: Revert QoS policies created with wrong type for block storage tiers

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_qos_policy.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_qos_policy.yaml
@@ -1,7 +1,10 @@
 ---
 # Creates per-tier QoS policies on VAST via REST API for tiers that define qos_policy.
 # Uses ansible.builtin.uri because the vendored collection has no QoS module.
-# Sets policy_type based on tier protocol: VIEW for NFS, VOLUME for block.
+# NOTE: VAST 5.4.x only supports policy_type VIEW and USER — no VOLUME type.
+# Block StorageClasses must NOT reference qos_policy (the CSI driver rejects
+# VIEW-type policies on volumes). QoS for block is deferred until VAST adds
+# VOLUME-type QoS support.
 #
 # Requires in scope:
 #   _vast_vms_conn      — VAST VMS connection dict (admin or tenant manager)
@@ -11,9 +14,9 @@
 # Sets output fact:
 #   _vast_qos_policy_names — list of created QoS policy names
 
-- name: Filter tiers with qos_policy defined
+- name: Filter NFS tiers with qos_policy defined (block QoS not supported on VAST 5.4.x)
   ansible.builtin.set_fact:
-    _vast_qos_tiers: "{{ _provider_tiers | selectattr('qos_policy', 'defined') | list }}"
+    _vast_qos_tiers: "{{ _provider_tiers | selectattr('qos_policy', 'defined') | rejectattr('protocol', 'equalto', 'block') | list }}"
 
 - name: Skip QoS policy creation when no tiers define qos_policy
   when: _vast_qos_tiers | length == 0
@@ -66,8 +69,7 @@
         body: >-
           {{ {'name': item.item.qos_policy,
               'tenant_id': _vast_tenant_id | int,
-              'mode': 'STATIC',
-              'policy_type': ('VOLUME' if item.item.protocol == 'block' else 'VIEW')}
+              'mode': 'STATIC'}
              | combine(item.item.qos_limits | default({})) }}
         headers:
           Authorization: "Bearer {{ _vast_qos_auth.json.access }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -264,8 +264,7 @@
                           'tenant_name': tenant_name})
                | combine({'csi.storage.k8s.io/node-stage-secret-name': _vast_csi_secret_ref.name})
                | combine({'csi.storage.k8s.io/node-stage-secret-namespace': _vast_csi_secret_ref.namespace})
-               | combine(_vast_sc_block_encryption_params | default({}))
-               | combine(({'qos_policy': item.qos_policy} if item.qos_policy is defined else {})) }}
+               | combine(_vast_sc_block_encryption_params | default({})) }}
           reclaimPolicy: Delete
           volumeBindingMode: WaitForFirstConsumer
       loop: "{{ _vast_block_tiers }}"

--- a/tests/integration/fixtures/storage/secret-vast-tenant-config-test.yaml
+++ b/tests/integration/fixtures/storage/secret-vast-tenant-config-test.yaml
@@ -12,7 +12,7 @@ stringData:
   vast_local_provider_id: "PLACEHOLDER_DO_NOT_USE_1"
   vip_pool_name: "PLACEHOLDER_DO_NOT_USE_vippool-test-tenant"
   vast_endpoint: "PLACEHOLDER_DO_NOT_USE_https://vast-vms.example.com"
-  storage_tiers: '[{"name":"default","protocol":"nfs","provider":"vast","qos_policy":"test-qos"},{"name":"block-perf","protocol":"block","provider":"vast","qos_policy":"test-qos-block"}]'
+  storage_tiers: '[{"name":"default","protocol":"nfs","provider":"vast","qos_policy":"test-qos"}]'
   storage_provider_type: "vast"
   tenant_manager_name: "PLACEHOLDER_DO_NOT_USE_osac-test-tenant"
   tenant_manager_username: "PLACEHOLDER_DO_NOT_USE_osac-test-tenant"

--- a/tests/integration/mock_vms_server.py
+++ b/tests/integration/mock_vms_server.py
@@ -37,7 +37,7 @@ CANNED_DEFAULTS = {
     "views": {"name": "", "path": "/", "policy_id": 1, "tenant_id": 1},
     "viewpolicies": {"name": "", "flavor": "NFS", "protocols": ["NFS"], "tenant_id": 1},
     "quotas": {"name": "", "hard_limit": 0, "soft_limit": 0, "tenant_id": 1},
-    "qospolicies": {"name": "", "tenant_id": 1, "mode": "STATIC", "policy_type": "VIEW"},
+    "qospolicies": {"name": "", "tenant_id": 1, "mode": "STATIC"},
     "users": {"name": "", "local_provider_id": 1},
     "roles": {"name": "", "tenant_id": 1, "tenant_ids": [], "permissions_list": []},
     "managers": {"username": "", "user_type": "TENANT_ADMIN", "tenant_id": 1, "roles": []},

--- a/tests/integration/setup_test_env.sh
+++ b/tests/integration/setup_test_env.sh
@@ -173,7 +173,7 @@ export VAST_VIP_POOL_NAME="osac-test-pool"
 export VAST_VIP_POOL_IP_RANGES='[["10.0.0.10","10.0.0.50"]]'
 export VAST_VIP_POOL_SUBNET_CIDR="24"
 export VAST_VALIDATE_CERTS="false"
-export STORAGE_TIERS='[{"name":"default","protocol":"nfs","provider":"vast","qos_policy":"test-qos","qos_limits":{"static_limits":{"max_reads_bw_mbps":100,"max_writes_bw_mbps":100}}},{"name":"block-perf","protocol":"block","provider":"vast","qos_policy":"test-qos-block","qos_limits":{"static_limits":{"max_reads_bw_mbps":200,"max_writes_bw_mbps":200}}}]'
+export STORAGE_TIERS='[{"name":"default","protocol":"nfs","provider":"vast","qos_policy":"test-qos","qos_limits":{"static_limits":{"max_reads_bw_mbps":100,"max_writes_bw_mbps":100}}}]'
 ENVEOF
 fi
 

--- a/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -72,7 +72,7 @@
             vast_local_provider_id: "1"
             vip_pool_name: "osac-test-pool"
             vast_endpoint: "127.0.0.1:18443"
-            storage_tiers: '[{"name":"default","protocol":"nfs","provider":"vast","qos_policy":"test-qos"},{"name":"block-tier","protocol":"block","provider":"vast","qos_policy":"test-qos-block"}]'
+            storage_tiers: '[{"name":"default","protocol":"nfs","provider":"vast","qos_policy":"test-qos"},{"name":"block-tier","protocol":"block","provider":"vast"}]'
             storage_provider_type: "vast"
             tenant_manager_name: "osac-test-ensuresc"
             tenant_manager_username: "osac-test-ensuresc"
@@ -101,19 +101,9 @@
       - name: default
         protocol: nfs
         provider: vast
-        qos_policy: test-qos
-        qos_limits:
-          static_limits:
-            max_reads_bw_mbps: 100
-            max_writes_bw_mbps: 100
       - name: block-tier
         protocol: block
         provider: vast
-        qos_policy: test-qos-block
-        qos_limits:
-          static_limits:
-            max_reads_bw_mbps: 200
-            max_writes_bw_mbps: 200
     storage_provider_action: ensure_storage_class
     storage_provider_provisioning_target: vmaas
     storage_provider_snapshots_enabled: true
@@ -240,7 +230,6 @@
           - _block_sc_result.resources[0].parameters.storagePath is not defined
           - _block_sc_result.resources[0].parameters.viewPolicy is not defined
           - _block_sc_result.resources[0].parameters.secretName is not defined
-          - _block_sc_result.resources[0].parameters.qos_policy == "test-qos-block"
         fail_msg: "Block StorageClass parameters incorrect: {{ _block_sc_result.resources[0].parameters }}"
         success_msg: "Block StorageClass parameters correct"
 
@@ -363,19 +352,9 @@
       - name: default
         protocol: nfs
         provider: vast
-        qos_policy: test-qos
-        qos_limits:
-          static_limits:
-            max_reads_bw_mbps: 100
-            max_writes_bw_mbps: 100
       - name: block-tier
         protocol: block
         provider: vast
-        qos_policy: test-qos-block
-        qos_limits:
-          static_limits:
-            max_reads_bw_mbps: 200
-            max_writes_bw_mbps: 200
     storage_provider_action: ensure_storage_class
     storage_provider_provisioning_target: vmaas
     storage_provider_snapshots_enabled: true
@@ -429,22 +408,6 @@
           - _call_log | selectattr('path', 'search', 'viewpolicies') | list | length > 0
         fail_msg: "No view policy API calls found — ensure_storage_class should create view policies"
         success_msg: "View policy API calls detected"
-
-    - name: Extract QoS policy creation calls
-      ansible.builtin.set_fact:
-        _qos_create_calls: >-
-          {{ _call_log
-             | selectattr('path', 'search', 'qospolicies')
-             | selectattr('method', 'equalto', 'POST')
-             | list }}
-
-    - name: Assert QoS policies were created with correct policy_type
-      ansible.builtin.assert:
-        that:
-          - _qos_create_calls | selectattr('body.name', 'equalto', 'test-qos') | map(attribute='body.policy_type') | first == 'VIEW'
-          - _qos_create_calls | selectattr('body.name', 'equalto', 'test-qos-block') | map(attribute='body.policy_type') | first == 'VOLUME'
-        fail_msg: "QoS policy_type incorrect — NFS should be VIEW, block should be VOLUME"
-        success_msg: "QoS policies created with correct policy_type per protocol"
 
 # ── Cleanup ──
 - name: "Storage Provider Ensure SC - Cleanup"

--- a/tests/integration/targets/storage_provider_setup/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_setup/tasks/main.yml
@@ -30,14 +30,6 @@
           static_limits:
             max_reads_bw_mbps: 100
             max_writes_bw_mbps: 100
-      - name: block-perf
-        protocol: block
-        provider: vast
-        qos_policy: test-qos-block
-        qos_limits:
-          static_limits:
-            max_reads_bw_mbps: 200
-            max_writes_bw_mbps: 200
     storage_provider_action: setup
     storage_provider_provisioning_target: vmaas
     storage_provider_snapshots_enabled: false


### PR DESCRIPTION
Reverts osac-project/osac-aap#393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated QoS policy creation to support VAST 5.4.x constraints by only using supported policy types and excluding block-based QoS options.
  * Block storage class setup no longer adds QoS policy settings, reducing invalid configuration for block tiers.

* **Tests**
  * Adjusted integration test data and expectations to match the updated storage tier and QoS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->