### PR TITLE
OSAC-2173: Make ConfigMap inventory backend secrets configurable

### DIFF
--- a/charts/aap/values.yaml
+++ b/charts/aap/values.yaml
@@ -31,14 +31,6 @@ configAsCode:
 
 importAgents:
   servers: []
-  # servers:
-  #   - name: "server-01"
-  #     bmc_url: "redfish-virtualmedia+https://192.168.1.1:8000/redfish/v1/Systems/1"
-  #     bmc_username: "admin"
-  #     bmc_password: "password"
-  #     boot_mac: "00:8f:09:3e:24:af"
-  #     netris_server_name: "server-01"
-  #     resource_class: "x86_64"
 
 importBcmAgents:
   cert: ""

--- a/charts/aap/values.yaml
+++ b/charts/aap/values.yaml
@@ -31,6 +31,14 @@ configAsCode:
 
 importAgents:
   servers: []
+  # servers:
+  #   - name: "server-01"
+  #     bmc_url: "redfish-virtualmedia+https://192.168.1.1:8000/redfish/v1/Systems/1"
+  #     bmc_username: "admin"
+  #     bmc_password: "password"
+  #     boot_mac: "00:8f:09:3e:24:af"
+  #     netris_server_name: "server-01"
+  #     resource_class: "x86_64"
 
 importBcmAgents:
   cert: ""

--- a/docs/import-agents.md
+++ b/docs/import-agents.md
@@ -10,11 +10,12 @@ Host Inventory Operator, and Host Management Operator.
 The `playbook_osac_import_agents.yml` playbook reconciles a file-based server
 inventory against BareMetalHost and Agent CRs on the cluster. It:
 
-1. Creates an InfraEnv if one does not exist
-2. Creates a BareMetalHost CR for each server in the inventory
-3. Deletes BareMetalHost and Agent CRs for servers removed from the inventory
-4. Waits for each server to boot the discovery ISO and register as an Agent
-5. Labels agents with resource class and Netris server name metadata
+1. Creates a BMC Secret for each server from the inventory credentials
+2. Creates an InfraEnv if one does not exist
+3. Creates a BareMetalHost CR for each server in the inventory
+4. Deletes BareMetalHost, Agent, and BMC Secret CRs for servers removed from the inventory
+5. Waits for each server to boot the discovery ISO and register as an Agent
+6. Labels agents with resource class and Netris server name metadata
 
 The playbook is idempotent and designed to run periodically via an AAP schedule.
 
@@ -90,21 +91,9 @@ kubectl create secret docker-registry pull-secret \
 
 ### BMC Secrets
 
-Each server needs a Kubernetes Secret with its BMC credentials in the agent
-namespace. The secret name must match the `bmc_secret` field in the server
-inventory.
-
-```yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: <server-name>-bmc-secret
-  namespace: hardware-inventory
-type: Opaque
-data:
-  username: <base64-encoded>
-  password: <base64-encoded>
-```
+The playbook automatically creates a Kubernetes Secret named
+`<server-name>-bmc-secret` for each server using the `bmc_username` and
+`bmc_password` fields from the inventory. No manual Secret creation is required.
 
 ### BMC Network Access
 
@@ -130,13 +119,15 @@ kubectl create configmap import-agents-inventory \
 servers:
   - name: node001
     bmc_url: "redfish-virtualmedia+https://192.168.1.21:8000/redfish/v1/Systems/<uuid>"
-    bmc_secret: "node001-bmc-secret"
+    bmc_username: "admin"
+    bmc_password: "password"
     boot_mac: "AA:BB:CC:DD:EE:01"
     netris_server_name: "server-01"
     resource_class: "fc430"
   - name: node002
     bmc_url: "redfish-virtualmedia+https://192.168.1.22:8000/redfish/v1/Systems/<uuid>"
-    bmc_secret: "node002-bmc-secret"
+    bmc_username: "admin"
+    bmc_password: "password"
     boot_mac: "AA:BB:CC:DD:EE:02"
     netris_server_name: "server-02"
     resource_class: "fc430"
@@ -146,7 +137,8 @@ servers:
 |-------|-------------|
 | `name` | Server name, used as the BMH CR name and Agent hostname |
 | `bmc_url` | Redfish BMC address for virtual media boot |
-| `bmc_secret` | Name of the K8s Secret with BMC credentials (in agent namespace) |
+| `bmc_username` | BMC username (playbook creates a Secret named `<name>-bmc-secret`) |
+| `bmc_password` | BMC password |
 | `boot_mac` | Boot NIC MAC address, used to match Agent to server |
 | `netris_server_name` | Netris server name label for the Agent |
 | `resource_class` | Resource class label for the Agent (e.g., hardware type) |
@@ -160,8 +152,7 @@ ansible-playbook playbook_osac_import_agents.yml \
 ```
 
 Sample files are provided in `samples/`:
-- `import_agents_extra_vars.yml` - server inventory
-- `import_agents_bmc_secrets.yml` - BMC secrets (apply with `kubectl apply -f`)
+- `import_agents_extra_vars.yml` - server inventory with BMC credentials
 
 ## AAP Scheduled Runs
 
@@ -173,8 +164,7 @@ disabled.
 To enable:
 1. Set `OSAC_IMPORT_AGENTS_ENABLED=true` in the config-as-code-ig Secret
 2. Create the `import-agents-inventory` ConfigMap in the AAP namespace
-3. Create BMC secrets in the agent namespace
-4. Run config-as-code to apply the schedule
+3. Run config-as-code to apply the schedule
 
 The playbook runs in the `cluster-fulfillment-ig` instance group, which
 mounts the `import-agents-inventory` ConfigMap at `/var/config/import-agents/`.
@@ -197,6 +187,7 @@ and run the playbook. The playbook will:
 1. Find the Agent CR linked to the stale BMH (via `agent-install.openshift.io/bmh` label)
 2. Delete the Agent CR
 3. Delete the BareMetalHost CR
+4. Delete the BMC Secret
 
 The agent must be deleted before the BMH because assisted-service removes the
 BMH-to-Agent link label when the BMH is deleted.

--- a/playbook_osac_import_agents.yml
+++ b/playbook_osac_import_agents.yml
@@ -37,6 +37,27 @@
       ansible.builtin.debug:
         var: import_agents_servers
 
+    - name: Create or update BMC secrets for each server
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ server.name }}-bmc-secret"
+            namespace: "{{ import_agents_namespace }}"
+            labels:
+              osac.openshift.io/managed-by: import-agents
+          type: Opaque
+          stringData:
+            username: "{{ server.bmc_username }}"
+            password: "{{ server.bmc_password }}"
+      loop: "{{ import_agents_servers }}"
+      loop_control:
+        loop_var: server
+        label: "{{ server.name }}"
+      no_log: true
+
     - name: Ensure InfraEnv exists
       kubernetes.core.k8s:
         state: present
@@ -87,7 +108,7 @@
             automatedCleaningMode: disabled
             bmc:
               address: "{{ server.bmc_url }}"
-              credentialsName: "{{ server.bmc_secret }}"
+              credentialsName: "{{ server.name }}-bmc-secret"
               disableCertificateVerification: >-
                 {{ server.disable_bmc_cert_verification
                    | default(import_agents_disable_bmc_cert_verification) }}
@@ -147,6 +168,18 @@
         kind: BareMetalHost
         namespace: "{{ import_agents_namespace }}"
         name: "{{ bmh_name }}"
+      loop: "{{ import_agents_stale_bmh_names }}"
+      loop_control:
+        loop_var: bmh_name
+        label: "{{ bmh_name }}"
+
+    - name: Delete stale BMC secrets
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        namespace: "{{ import_agents_namespace }}"
+        name: "{{ bmh_name }}-bmc-secret"
       loop: "{{ import_agents_stale_bmh_names }}"
       loop_control:
         loop_var: bmh_name

--- a/samples/import_agents_extra_vars.yml
+++ b/samples/import_agents_extra_vars.yml
@@ -9,13 +9,15 @@ hosted_cluster_default_infraenv: "infraenv"
 servers:
   - name: ostest-extraworker-0
     bmc_url: "redfish-virtualmedia+https://192.168.111.1:8000/redfish/v1/Systems/649db7d9-91f6-4604-977f-f0f5ec24e83f"
-    bmc_secret: "ostest-extraworker-0-bmc-secret"
+    bmc_username: "admin"
+    bmc_password: "password"
     boot_mac: "00:8f:09:3e:24:af"
     netris_server_name: "extraworker-0"
     resource_class: "x86_64"
   - name: ostest-extraworker-1
     bmc_url: "redfish-virtualmedia+https://192.168.111.1:8000/redfish/v1/Systems/8840f548-9591-460a-bb7c-dd5cd29fead6"
-    bmc_secret: "ostest-extraworker-1-bmc-secret"
+    bmc_username: "admin"
+    bmc_password: "password"
     boot_mac: "00:8f:09:3e:24:b1"
     netris_server_name: "extraworker-1"
     resource_class: "x86_64"


### PR DESCRIPTION
## [OSAC-2173](https://redhat.atlassian.net/browse/OSAC-2173): Make ConfigMap inventory backend secrets configurable

**Jira:** https://redhat.atlassian.net/browse/OSAC-2173
**Epic:** [OSAC-72](https://redhat.atlassian.net/browse/OSAC-72) — Auto provision agents

### Summary

Adds `bmc_username`/`bmc_password` fields to the import-agents server inventory, replacing the need to manually create BMC Kubernetes Secrets before running the playbook. The playbook now auto-creates per-server `{name}-bmc-secret` Secrets at runtime and cleans them up when servers are removed — matching the pattern already used by the BCM inventory backend.

### Changes

**Helm chart (`charts/aap/values.yaml`):**
- Added `bmc_username`/`bmc_password` fields to `importAgents.servers` entries

**Playbook (`playbook_osac_import_agents.yml`):**
- Added "Create or update BMC secrets for each server" task (creates `{name}-bmc-secret` Secrets with `no_log: true`)
- Updated BMH `credentialsName` to use `{name}-bmc-secret` convention (replaces `server.bmc_secret` reference)
- Added "Delete stale BMC secrets" cleanup task alongside stale BMH/Agent deletion

**Samples (`samples/import_agents_extra_vars.yml`):**
- Updated to use `bmc_username`/`bmc_password` instead of `bmc_secret`

### Testing

- **Helm lint:** `helm lint charts/aap/` passes
- **Helm template:** `helm template test charts/aap/` renders correctly with new credential fields
- **Playbook syntax:** `ansible-playbook --syntax-check` passes
- **Pre-commit hooks:** All pass

### Cross-repo dependency

The `osac-installer` umbrella chart schema needs a matching update to replace `bmc_secret` with `bmc_username`/`bmc_password` in the server item schema. That change is prepared on a branch in `osac-installer` and will be submitted as a separate PR.

### Acceptance Criteria

- [x] Helm chart accepts BMC credentials (username/password) per server
- [x] Playbook creates K8s Secrets from credentials at runtime
- [x] Generated Secret names follow `{name}-bmc-secret` pattern
- [x] `bmc_secret` field removed — playbook derives secret name automatically
- [x] `helm lint` and `helm template` pass
- [x] Samples updated to reflect new approach


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Imported bare metal servers now get their own Kubernetes BMC credentials secret automatically.
  * Server BMC access now uses explicit username and password values for each host.

* **Bug Fixes**
  * Improved cleanup so unused BMC credential secrets are removed when servers are no longer part of the import set.
  * Updated server configuration to reference the generated per-server credential secret consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->