### PR TITLE
OSAC-2035: add missing ExternalIPAttachment job templates

### DIFF
--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -293,6 +293,30 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-create-external-ip-attachment"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_create_external_ip_attachment.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+  - name: "{{ aap_prefix }}-delete-external-ip-attachment"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_delete_external_ip_attachment.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
   - name: "{{ aap_prefix }}-create-security-group"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
@@ -108,18 +108,18 @@
         eip_allocated_address: >-
           {%- set ns = namespace(found='') -%}
           {%- for alloc in _eip_pool_allocs -%}
-          {%-   if not ns.found -%}
-          {%-     set cidr = alloc.prefix -%}
-          {%-     set net = cidr | ansible.utils.ipaddr('network') -%}
-          {%-     set prefix_len = cidr | ansible.utils.ipaddr('prefix') | int -%}
-          {%-     for i in range(1, 2 ** (32 - prefix_len) - 1) -%}
-          {%-       if not ns.found -%}
-          {%-         set candidate = net | ansible.utils.ipmath(i) -%}
-          {%-         if candidate not in _eip_allocated_addrs -%}
-          {%-           set ns.found = candidate -%}
-          {%-         endif -%}
-          {%-       endif -%}
-          {%-     endfor -%}
+          {%-   set cidr = alloc.prefix -%}
+          {%-   set net = cidr | ansible.utils.ipaddr('network') -%}
+          {%-   set prefix_len = cidr | ansible.utils.ipaddr('prefix') | int -%}
+          {%-   for i in range(1, 2 ** (32 - prefix_len) - 1) -%}
+          {%-     set candidate = net | ansible.utils.ipmath(i) -%}
+          {%-     if candidate not in _eip_allocated_addrs -%}
+          {%-       set ns.found = candidate -%}
+          {%-       break -%}
+          {%-     endif -%}
+          {%-   endfor -%}
+          {%-   if ns.found -%}
+          {%-     break -%}
           {%-   endif -%}
           {%- endfor -%}
           {{ ns.found }}

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_external_ip.yaml
@@ -108,18 +108,18 @@
         eip_allocated_address: >-
           {%- set ns = namespace(found='') -%}
           {%- for alloc in _eip_pool_allocs -%}
-          {%-   set cidr = alloc.prefix -%}
-          {%-   set net = cidr | ansible.utils.ipaddr('network') -%}
-          {%-   set prefix_len = cidr | ansible.utils.ipaddr('prefix') | int -%}
-          {%-   for i in range(1, 2 ** (32 - prefix_len) - 1) -%}
-          {%-     set candidate = net | ansible.utils.ipmath(i) -%}
-          {%-     if candidate not in _eip_allocated_addrs -%}
-          {%-       set ns.found = candidate -%}
-          {%-       break -%}
-          {%-     endif -%}
-          {%-   endfor -%}
-          {%-   if ns.found -%}
-          {%-     break -%}
+          {%-   if not ns.found -%}
+          {%-     set cidr = alloc.prefix -%}
+          {%-     set net = cidr | ansible.utils.ipaddr('network') -%}
+          {%-     set prefix_len = cidr | ansible.utils.ipaddr('prefix') | int -%}
+          {%-     for i in range(1, 2 ** (32 - prefix_len) - 1) -%}
+          {%-       if not ns.found -%}
+          {%-         set candidate = net | ansible.utils.ipmath(i) -%}
+          {%-         if candidate not in _eip_allocated_addrs -%}
+          {%-           set ns.found = candidate -%}
+          {%-         endif -%}
+          {%-       endif -%}
+          {%-     endfor -%}
           {%-   endif -%}
           {%- endfor -%}
           {{ ns.found }}


### PR DESCRIPTION
## Summary
- Re-add `create-external-ip-attachment` and `delete-external-ip-attachment` AAP job templates that were accidentally dropped during the [OSAC-2035](https://redhat.atlassian.net/browse/OSAC-2035) merge (the ExternalIP templates replaced the attachment ones instead of adding alongside them)

## Test plan
- [x] Run config-as-code on deployment to verify job templates are registered
- [x] Verify `create-external-ip-attachment` and `delete-external-ip-attachment` templates appear in AAP (ID=53, ID=54)
- [x] Verify existing ExternalIP templates still work (all 6 ExternalIP templates registered, total went from 32 → 38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)