### PR TITLE
OSAC-2038: add Netris NATGateway SNAT template role

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/netris/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/meta/argument_specs.yaml
@@ -113,3 +113,22 @@ argument_specs:
         type: dict
         required: true
         description: ExternalIP CR from fulfillment-api via EDA payload
+
+  create_nat_gateway:
+    options:
+      nat_gateway:
+        type: dict
+        required: true
+        description: NATGateway CR from fulfillment-api via EDA payload
+      template_parameters:
+        type: dict
+        description: Template-specific parameters (reserved for future use)
+        options: {}
+        default: {}
+
+  delete_nat_gateway:
+    options:
+      nat_gateway:
+        type: dict
+        required: true
+        description: NATGateway CR from fulfillment-api via EDA payload

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_nat_gateway.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_nat_gateway.yaml
@@ -1,0 +1,83 @@
+---
+# NATGateway maps to a Netris SNAT rule
+# Creates an SNAT rule on the SoftGate: VN CIDR -> ExternalIP address
+# All egress from the VirtualNetwork is source-NATted to the ExternalIP
+
+- name: Validate NATGateway annotations
+  ansible.builtin.assert:
+    that:
+      - nat_gateway.metadata is defined
+      - nat_gateway.metadata.annotations is defined
+      - "'osac.openshift.io/externalip-name' in nat_gateway.metadata.annotations"
+      - "'osac.openshift.io/vn-ipv4-cidr' in nat_gateway.metadata.annotations"
+    fail_msg: >-
+      NATGateway requires annotations
+      'osac.openshift.io/externalip-name' (ExternalIP CR name) and
+      'osac.openshift.io/vn-ipv4-cidr' (VirtualNetwork IPv4 CIDR).
+
+- name: Extract NATGateway configuration
+  ansible.builtin.set_fact:
+    natgw_name: "{{ nat_gateway.metadata.name }}"
+    natgw_namespace: "{{ nat_gateway.metadata.namespace }}"
+    natgw_externalip_name: >-
+      {{ nat_gateway.metadata.annotations['osac.openshift.io/externalip-name'] }}
+    natgw_vn_ipv4_cidr: >-
+      {{ nat_gateway.metadata.annotations['osac.openshift.io/vn-ipv4-cidr'] }}
+
+- name: Look up ExternalIP CR to get allocated address
+  kubernetes.core.k8s_info:
+    api_version: osac.openshift.io/v1alpha1
+    kind: ExternalIP
+    name: "{{ natgw_externalip_name }}"
+    namespace: "{{ natgw_namespace }}"
+  register: _natgw_eip_lookup
+
+- name: Validate ExternalIP CR found with allocated address
+  ansible.builtin.assert:
+    that:
+      - _natgw_eip_lookup.resources | length > 0
+      - _natgw_eip_lookup.resources[0].metadata.annotations['osac.openshift.io/allocated-address'] is defined
+    fail_msg: >-
+      ExternalIP '{{ natgw_externalip_name }}' not found or missing
+      'osac.openshift.io/allocated-address' annotation. The ExternalIP must
+      be allocated before creating a NATGateway.
+
+- name: Extract allocated external IP address
+  ansible.builtin.set_fact:
+    natgw_snat_ip: >-
+      {{ _natgw_eip_lookup.resources[0].metadata.annotations['osac.openshift.io/allocated-address'] }}
+
+- name: Display NATGateway information
+  ansible.builtin.debug:
+    msg:
+      - "Creating Netris SNAT rule for NATGateway '{{ natgw_name }}'"
+      - "VN CIDR (source): {{ natgw_vn_ipv4_cidr }}"
+      - "ExternalIP (SNAT to): {{ natgw_snat_ip }} (from ExternalIP '{{ natgw_externalip_name }}')"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Create SNAT rule for NATGateway
+  ansible.builtin.include_role:
+    name: netris.controller.nat
+    tasks_from: create
+  vars:
+    nat_name: "{{ natgw_name }}-snat"
+    nat_site_id: "{{ netris_site_id }}"
+    nat_vpc_id: "{{ netris_mgmt_vpc_id }}"
+    nat_vpc_name: "{{ netris_mgmt_vpc_name | default('') }}"
+    nat_action: snat
+    nat_protocol: all
+    nat_source_address: "{{ natgw_vn_ipv4_cidr }}"
+    nat_snat_to_ip: "{{ natgw_snat_ip }}/32"
+    nat_comment: "OSAC NATGateway {{ natgw_name }}"
+
+- name: Display SNAT rule creation result
+  ansible.builtin.debug:
+    msg: >-
+      SNAT rule '{{ natgw_name }}-snat'
+      {{ (nat_already_existed | default(false)) | ternary('already exists', 'created successfully') }}
+      (ID: {{ nat_id | default('unknown') }})
+      — {{ natgw_vn_ipv4_cidr }} -> {{ natgw_snat_ip }}

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_nat_gateway.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_nat_gateway.yaml
@@ -1,0 +1,27 @@
+---
+# NATGateway deletion — removes the SNAT rule from Netris
+
+- name: Extract NATGateway name
+  ansible.builtin.set_fact:
+    natgw_name: "{{ nat_gateway.metadata.name }}"
+
+- name: Display NATGateway deletion info
+  ansible.builtin.debug:
+    msg: "Deleting Netris SNAT rule for NATGateway '{{ natgw_name }}'"
+
+- name: Ensure Netris auth
+  ansible.builtin.include_role:
+    name: netris.controller.auth
+  when: netris_session_cookie is not defined
+
+- name: Delete SNAT rule for NATGateway
+  ansible.builtin.include_role:
+    name: netris.controller.nat
+    tasks_from: delete
+  vars:
+    nat_name: "{{ natgw_name }}-snat"
+    nat_site_id: "{{ netris_site_id }}"
+
+- name: Display deletion result
+  ansible.builtin.debug:
+    msg: "SNAT rule '{{ natgw_name }}-snat' deletion completed"

--- a/playbook_osac_create_nat_gateway.yml
+++ b/playbook_osac_create_nat_gateway.yml
@@ -1,0 +1,27 @@
+---
+- name: Create a NATGateway resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    nat_gateway: "{{ ansible_eda.event.payload }}"
+    nat_gateway_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display NATGateway information
+      ansible.builtin.debug:
+        msg:
+          - "NATGateway name: {{ nat_gateway_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected NATGateway role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: create_nat_gateway

--- a/playbook_osac_delete_nat_gateway.yml
+++ b/playbook_osac_delete_nat_gateway.yml
@@ -1,0 +1,27 @@
+---
+- name: Delete a NATGateway resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    nat_gateway: "{{ ansible_eda.event.payload }}"
+    nat_gateway_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/implementation-strategy'] }}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display NATGateway information
+      ansible.builtin.debug:
+        msg:
+          - "Deleting NATGateway: {{ nat_gateway_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected NATGateway role
+      ansible.builtin.include_role:
+        name: "{{ template_id_override | default('osac.templates.' + (implementation_strategy | replace('-', '_'))) }}"
+        tasks_from: delete_nat_gateway


### PR DESCRIPTION
## [OSAC-2038](https://redhat.atlassian.net/browse/OSAC-2038): Add Netris NATGateway SNAT template role

**Jira:** https://redhat.atlassian.net/browse/OSAC-2038
**Epic:** [OSAC-2044](https://redhat.atlassian.net/browse/OSAC-2044) — Netris Unified Networking Template Roles
**Feature:** [OSAC-2043](https://redhat.atlassian.net/browse/OSAC-2043) — Fabric Manager - Netris

### Summary

Adds `create_nat_gateway.yaml` and `delete_nat_gateway.yaml` task files to `osac.templates.netris`, implementing the NATGateway (SNAT) provisioning for the unified networking API. The create task resolves the ExternalIP allocated address and VirtualNetwork CIDR from CR annotations, then creates a Netris SNAT rule via `netris.controller.nat`. The delete task removes the SNAT rule by name.

### Changes

**Template role tasks:**
- `create_nat_gateway.yaml` — validates annotations, looks up ExternalIP CR for allocated address, creates SNAT rule (source: VN CIDR, snatToIP: ExternalIP address)
- `delete_nat_gateway.yaml` — deletes SNAT rule by name (`{name}-snat`)

**Meta:**
- `argument_specs.yaml` — added `create_nat_gateway` and `delete_nat_gateway` entry points

**Playbooks:**
- `playbook_osac_create_nat_gateway.yml` — dispatches to implementation role
- `playbook_osac_delete_nat_gateway.yml` — dispatches to implementation role

### Annotation Contract

The role expects the operator to set these annotations on the NATGateway CR before dispatching:
- `osac.openshift.io/externalip-name` — resolved ExternalIP CR name
- `osac.openshift.io/vn-ipv4-cidr` — resolved VirtualNetwork IPv4 CIDR
- `osac.openshift.io/implementation-strategy` — `netris`

### Testing

- **ansible-lint:** Passes at production profile (0 failures, 0 warnings)
- **Syntax check:** Both playbooks pass
- **Integration tests:** N/A — validated via AAP job execution against Netris controller

### Acceptance Criteria

- [x] `create_nat_gateway.yaml` exists and creates SNAT rule via `netris.controller.nat`
- [x] `delete_nat_gateway.yaml` exists and deletes SNAT rule via `netris.controller.nat`
- [x] SNAT rule source address is VN IPv4 CIDR
- [x] SNAT rule snatToIP is ExternalIP allocated address
- [x] Top-level playbooks dispatch to implementation role
- [x] `argument_specs.yaml` updated with new entry points
- [x] `ansible-lint` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for creating NAT gateway SNAT rules from incoming event data.
  * Added support for deleting NAT gateway SNAT rules from incoming event data.
  * Added dynamic role selection based on the gateway’s implementation strategy, with an override option.
  * Added validation and status messaging for NAT gateway creation and deletion steps.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->