### PR TITLE
OSAC-1818: Add HardwareProfile and ExternalModel parameterization to ocp_4_20_ai_maas

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/defaults/main.yaml
@@ -11,6 +11,15 @@ ocp_4_20_ai_maas_enable_observability: true
 ocp_4_20_ai_maas_enable_dashboard: true
 ocp_4_20_ai_maas_run_verify: true
 
+# Hardware profiles (empty = no profiles created; override per environment)
+ocp_4_20_ai_maas_hardware_profiles: []
+
+# External models (cross-cluster access via ExternalModel CRD)
+ocp_4_20_ai_maas_external_models: []
+ocp_4_20_ai_maas_proxy_image: "quay.io/mpaulgreen/maas-proxy:latest"
+ocp_4_20_ai_maas_proxy_namespace: "maas-proxies"
+ocp_4_20_ai_maas_external_model_namespace: "external-models"
+
 # --- Platform Operators ---
 
 # cert-manager

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/argument_specs.yaml
@@ -58,6 +58,63 @@ argument_specs:
         required: false
         default: true
         description: Run verification tests after deployment.
+      ocp_4_20_ai_maas_hardware_profiles:
+        type: list
+        required: false
+        default: []
+        description: >
+          List of HardwareProfile CRs to create on the cluster. Each entry
+          defines a GPU/accelerator profile with CPU, memory, and optional
+          accelerator resource constraints. A single cluster can have N
+          profiles — users select the appropriate one in the RHOAI dashboard
+          when deploying models. Empty list (default) creates no profiles.
+          See analysis/phase3/hw_profiles.md for ready-to-use definitions.
+        elements: dict
+      ocp_4_20_ai_maas_external_models:
+        type: list
+        required: false
+        default: []
+        description: >
+          List of external models to access from upstream clusters. Each entry
+          creates an ExternalModel CR with MaaS governance (AuthPolicy +
+          Subscription) on the tenant cluster. Requires enable_maas=true.
+          Empty list (default) skips external model setup.
+
+          Each entry is a dict with required fields:
+            name            - Local model name (CR names derived from this)
+            secured         - true = deploy proxy (Path B/C), false = direct Route (Path A)
+            upstream_endpoint - Gateway FQDN (secured) or Route FQDN (unsecured)
+            upstream_credential - MaaS API key (B), K8s SA token (C), or 'dummy-not-used' (A)
+            upstream_model_ns - Model namespace on upstream cluster
+            upstream_model_name - Model name on upstream cluster
+            model_id        - spec.targetModel for ExternalModel (e.g. granite-3.1-8b-instruct-fp8)
+            token_limit     - Tenant-side rate limit (tokens per window)
+            window          - Rate limit window (e.g. 1m, 1h)
+            priority        - MaaSSubscription priority (lower number = lower tier)
+
+          When secured=true, a maas-proxy Deployment is created targeting
+          upstream_endpoint. The proxy adds /<upstream_model_ns>/<upstream_model_name>/
+          path prefix. Multiple models from the same upstream share one proxy.
+          When secured=false, ExternalModel points directly to upstream_endpoint
+          (a manually created OpenShift Route FQDN).
+        elements: dict
+      ocp_4_20_ai_maas_proxy_image:
+        type: str
+        required: false
+        default: "quay.io/mpaulgreen/maas-proxy:latest"
+        description: Container image for maas-proxy Deployments (secured external models).
+      ocp_4_20_ai_maas_proxy_namespace:
+        type: str
+        required: false
+        default: "maas-proxies"
+        description: Namespace for maas-proxy Deployments and routing Services.
+      ocp_4_20_ai_maas_external_model_namespace:
+        type: str
+        required: false
+        default: "external-models"
+        description: >
+          Namespace for ExternalModel CRs and credential Secrets. Created with
+          required labels (opendatahub.io/generated-namespace, gateway-access).
       ocp_4_20_ai_maas_ocp_release_image:
         type: str
         required: false

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
@@ -9,7 +9,7 @@ description: >
 template_type: cluster
 implementation_strategy: ocp_4_20_ai_maas
 default_node_request:
-  - resourceClass: dgx
+  - resourceClass: g5
     numberOfNodes: 2
 allowed_resource_classes: []
 parameters:
@@ -61,3 +61,18 @@ parameters:
     type: boolean
     required: false
     default: true
+  - name: hardware_profiles
+    title: Hardware Profiles
+    description: >
+      List of HardwareProfile CRs to create. Each entry defines a GPU/accelerator
+      profile with CPU, memory, and optional accelerator constraints.
+    type: list
+    required: false
+  - name: external_models
+    title: External Models
+    description: >
+      List of external models to access from upstream clusters. Each entry creates
+      an ExternalModel CR with MaaS governance. When secured=true, a maas-proxy
+      is deployed. Requires enable_maas=true.
+    type: list
+    required: false

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_cluster.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_cluster.yaml
@@ -100,6 +100,31 @@
        | selectattr('status', 'equalto', 'True')
        | list | length == 0)
 
+# --- Hardware Profiles ---
+
+- name: Apply hardware profiles
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ item }}"
+  loop: >-
+    {{ lookup('ansible.builtin.template', 'hardware-profiles.yaml.j2')
+       | from_yaml_all | list }}
+  loop_control:
+    label: "HardwareProfile/{{ item.metadata.name }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_hardware_profiles | length > 0
+
+- name: Report hardware profiles
+  ansible.builtin.debug:
+    msg: >-
+      Hardware profiles created:
+      {{ ocp_4_20_ai_maas_hardware_profiles | map(attribute='name') | list }}
+  when: ocp_4_20_ai_maas_hardware_profiles | length > 0
+
 # --- Dashboard feature flags (non-MaaS) ---
 
 - name: Patch OdhDashboardConfig with observability flag

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_external_models.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/configure_external_models.yaml
@@ -1,0 +1,227 @@
+---
+# Phase 5: External model access (Path A/B/C).
+# Creates proxy infrastructure (secured only), ExternalModel CRs, and MaaS governance.
+# Runs after local MaaS setup (configure_maas.yaml) is complete.
+
+- name: Validate external models require MaaS
+  ansible.builtin.assert:
+    that:
+      - ocp_4_20_ai_maas_enable_maas | bool
+    fail_msg: >-
+      External models require MaaS (enable_maas=true). ExternalModel CRs route
+      through maas-default-gateway which only exists when MaaS is enabled.
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+# --- Clean up leftover resources from prior failed runs (idempotent retry support) ---
+
+- name: Clean up leftover external subscriptions
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: MaaSSubscription
+    name: "{{ item.name }}-sub"
+    namespace: models-as-a-service
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "{{ item.name }}-sub"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Clean up leftover external auth policies
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: MaaSAuthPolicy
+    name: "{{ item.name }}-access"
+    namespace: models-as-a-service
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "{{ item.name }}-access"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Clean up leftover external model refs
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: MaaSModelRef
+    name: "{{ item.name }}"
+    namespace: "{{ ocp_4_20_ai_maas_external_model_namespace }}"
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "{{ item.name }}"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Clean up leftover external models
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: ExternalModel
+    name: "{{ item.name }}"
+    namespace: "{{ ocp_4_20_ai_maas_external_model_namespace }}"
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "{{ item.name }}"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Clean up leftover Kuadrant AuthPolicies
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: kuadrant.io/v1
+    kind: AuthPolicy
+    name: "maas-auth-{{ item.name }}"
+    namespace: "{{ ocp_4_20_ai_maas_external_model_namespace }}"
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "maas-auth-{{ item.name }}"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Clean up leftover Kuadrant TRLPs
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: kuadrant.io/v1alpha1
+    kind: TokenRateLimitPolicy
+    name: "maas-trlp-{{ item.name }}"
+    namespace: "{{ ocp_4_20_ai_maas_external_model_namespace }}"
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "maas-trlp-{{ item.name }}"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Wait for controller to process cleanup
+  ansible.builtin.pause:
+    seconds: 10
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+# --- Proxy infrastructure (namespaces + Deployments + Services) ---
+
+- name: Apply proxy infrastructure
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ item }}"
+  loop: >-
+    {{ lookup('ansible.builtin.template', 'external-model-proxy.yaml.j2')
+       | from_yaml_all | list }}
+  loop_control:
+    label: "{{ item.kind }}/{{ item.metadata.name }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Wait for proxy Deployments ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ ocp_4_20_ai_maas_proxy_namespace }}"
+  register: _proxy_deps
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until: >-
+    _proxy_deps.resources | length == 0
+    or (_proxy_deps.resources
+        | selectattr('status.availableReplicas', 'defined')
+        | selectattr('status.availableReplicas', 'greaterthan', 0)
+        | list | length == _proxy_deps.resources | length)
+  when:
+    - ocp_4_20_ai_maas_external_models | length > 0
+    - ocp_4_20_ai_maas_external_models | selectattr('secured', 'defined') | selectattr('secured') | list | length > 0
+
+# --- MaaS resources (Secret, ExternalModel, ModelRef, AuthPolicy, Subscription) ---
+
+- name: Apply ExternalModel resources
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: present
+    definition: "{{ item }}"
+  loop: >-
+    {{ lookup('ansible.builtin.template', 'external-model-resources.yaml.j2')
+       | from_yaml_all | list }}
+  loop_control:
+    label: "{{ item.kind }}/{{ item.metadata.name }}"
+  no_log: "{{ item.kind == 'Secret' }}"
+  register: _r
+  retries: 5
+  delay: 10
+  until: _r is not failed
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+# --- Wait for MaaSModelRef Ready ---
+
+- name: Wait for external MaaSModelRef Ready
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: MaaSModelRef
+    name: "{{ item.name }}"
+    namespace: "{{ ocp_4_20_ai_maas_external_model_namespace }}"
+  register: _ext_modelref
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until:
+    - _ext_modelref.resources is defined
+    - _ext_modelref.resources | length > 0
+    - _ext_modelref.resources[0].status.phase | default('') == 'Ready'
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+# --- Wait for subscriptions Active ---
+# No controller restart needed — already warm from Phase 4 (configure_maas.yaml).
+
+- name: Wait for external subscriptions Active
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: MaaSSubscription
+    name: "{{ item.name }}-sub"
+    namespace: models-as-a-service
+  register: _ext_sub
+  retries: "{{ ocp_4_20_ai_maas_operator_retries }}"
+  delay: "{{ ocp_4_20_ai_maas_operator_delay }}"
+  until:
+    - _ext_sub.resources is defined
+    - _ext_sub.resources | length > 0
+    - _ext_sub.resources[0].status.phase | default('') == 'Active'
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "{{ item.name }}-sub"
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Wait for external TokenRateLimitPolicy enforcement
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    api_version: kuadrant.io/v1alpha1
+    kind: TokenRateLimitPolicy
+    namespace: "{{ ocp_4_20_ai_maas_external_model_namespace }}"
+  register: _ext_trlp
+  retries: 12
+  delay: 10
+  ignore_errors: true
+  until:
+    - _ext_trlp.resources is defined
+    - _ext_trlp.resources | length > 0
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Report external models
+  ansible.builtin.debug:
+    msg: >-
+      External models configured:
+      {{ ocp_4_20_ai_maas_external_models | map(attribute='name') | list }}
+      (secured: {{ ocp_4_20_ai_maas_external_models | selectattr('secured', 'defined') | selectattr('secured') | list | length }},
+       direct: {{ ocp_4_20_ai_maas_external_models | rejectattr('secured', 'defined') | list | length + ocp_4_20_ai_maas_external_models | selectattr('secured', 'defined') | rejectattr('secured') | list | length }})
+  when: ocp_4_20_ai_maas_external_models | length > 0

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/delete.yaml
@@ -4,6 +4,61 @@
 # gateway, PostgreSQL). Operators are NOT removed — in the OSAC pipeline, the cluster
 # itself is deleted after this step, which removes everything.
 
+- name: Delete external model subscriptions
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: MaaSSubscription
+    name: "{{ item.name }}-sub"
+    namespace: models-as-a-service
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "{{ item.name }}-sub"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Delete external model auth policies
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: maas.opendatahub.io/v1alpha1
+    kind: MaaSAuthPolicy
+    name: "{{ item.name }}-access"
+    namespace: models-as-a-service
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "{{ item.name }}-access"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Delete external model namespaces
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: v1
+    kind: Namespace
+    name: "{{ item }}"
+  loop:
+    - "{{ ocp_4_20_ai_maas_external_model_namespace }}"
+    - "{{ ocp_4_20_ai_maas_proxy_namespace }}"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Delete hardware profiles
+  kubernetes.core.k8s:
+    kubeconfig: "{{ admin_kubeconfig }}"
+    state: absent
+    api_version: infrastructure.opendatahub.io/v1
+    kind: HardwareProfile
+    name: "{{ item.name }}"
+    namespace: redhat-ods-applications
+  loop: "{{ ocp_4_20_ai_maas_hardware_profiles }}"
+  loop_control:
+    label: "{{ item.name }}"
+  ignore_errors: true
+  when: ocp_4_20_ai_maas_hardware_profiles | length > 0
+
 - name: Remove MaaS subscriptions
   kubernetes.core.k8s:
     kubeconfig: "{{ admin_kubeconfig }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install.yaml
@@ -15,6 +15,8 @@
     ocp_4_20_ai_maas_oidc_client_id: "{{ template_parameters.oidc_client_id | default('') }}"
     ocp_4_20_ai_maas_enable_observability: "{{ template_parameters.enable_observability | default(true) | bool }}"
     ocp_4_20_ai_maas_enable_dashboard: "{{ template_parameters.enable_dashboard | default(true) | bool }}"
+    ocp_4_20_ai_maas_hardware_profiles: "{{ template_parameters.hardware_profiles | default(ocp_4_20_ai_maas_hardware_profiles) }}"
+    ocp_4_20_ai_maas_external_models: "{{ template_parameters.external_models | default(ocp_4_20_ai_maas_external_models) }}"
   when: template_parameters is defined
 
 - name: Create cluster with RHOAI + MaaS post-install

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/install_operators.yaml
@@ -41,6 +41,69 @@
       - ocp_4_20_ai_maas_coo_starting_csv is regex('^[\w.\-]+$')
     fail_msg: "Shell-interpolated variables contain invalid characters"
 
+- name: Validate external models require MaaS
+  ansible.builtin.assert:
+    that:
+      - ocp_4_20_ai_maas_enable_maas | bool
+    fail_msg: >-
+      external_models is configured but enable_maas=false. ExternalModel CRs
+      route through maas-default-gateway which only exists when MaaS is enabled.
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Validate external model entries have required fields
+  ansible.builtin.assert:
+    that:
+      - item.name is defined
+      - item.secured is defined
+      - item.upstream_endpoint is defined
+      - item.upstream_credential is defined
+      - item.upstream_model_ns is defined
+      - item.upstream_model_name is defined
+      - item.model_id is defined
+      - item.token_limit is defined
+      - item.window is defined
+      - item.priority is defined
+    fail_msg: >-
+      External model '{{ item.name | default("unnamed") }}' is missing required fields.
+      Required: name, secured, upstream_endpoint, upstream_credential, upstream_model_ns,
+      upstream_model_name, model_id, token_limit, window, priority.
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "{{ item.name | default('unnamed') }}"
+  no_log: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Validate external model credentials are not empty
+  ansible.builtin.assert:
+    that:
+      - item.upstream_credential | length > 0
+    fail_msg: >-
+      External model '{{ item.name }}' has empty upstream_credential.
+      MaaS rejects empty api-key. Use a valid credential or 'dummy-not-used' for unsecured.
+  loop: "{{ ocp_4_20_ai_maas_external_models }}"
+  loop_control:
+    label: "{{ item.name | default('unnamed') }}"
+  no_log: true
+  when: ocp_4_20_ai_maas_external_models | length > 0
+
+- name: Validate hardware profile entries have required fields
+  ansible.builtin.assert:
+    that:
+      - item.name is defined
+      - item.cpu_default is defined
+      - item.cpu_min is defined
+      - item.cpu_max is defined
+      - item.memory_default is defined
+      - item.memory_min is defined
+      - item.memory_max is defined
+    fail_msg: >-
+      Hardware profile '{{ item.name | default("unnamed") }}' is missing required fields.
+      Required: name, cpu_default, cpu_min, cpu_max, memory_default, memory_min, memory_max.
+  loop: "{{ ocp_4_20_ai_maas_hardware_profiles }}"
+  loop_control:
+    label: "{{ item.name | default('unnamed') }}"
+  when: ocp_4_20_ai_maas_hardware_profiles | length > 0
+
 # --- Step 1: cert-manager ---
 # RHCL 1.3 requires cert-manager 1.18 per https://access.redhat.com/articles/7092611
 # Parent template may already install cert-manager; skip if found.

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/tasks/post_install.yaml
@@ -26,3 +26,9 @@
 - name: Run verification smoke tests
   ansible.builtin.include_tasks: verify.yaml
   when: ocp_4_20_ai_maas_run_verify | default(true)
+
+- name: Configure external models (Phase 6 — after verify)
+  ansible.builtin.include_tasks: configure_external_models.yaml
+  when:
+    - ocp_4_20_ai_maas_enable_maas | default(true) | bool
+    - ocp_4_20_ai_maas_external_models | default([]) | length > 0

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/external-model-proxy.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/external-model-proxy.yaml.j2
@@ -1,0 +1,76 @@
+{# --- Namespaces (always created when external models exist) --- #}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ ocp_4_20_ai_maas_external_model_namespace }}
+  labels:
+    opendatahub.io/generated-namespace: "true"
+    maas.opendatahub.io/gateway-access: "true"
+{# --- Proxy namespace + Deployments + Services (secured only) --- #}
+{% set secured_models = ocp_4_20_ai_maas_external_models | selectattr('secured', 'defined') | selectattr('secured') | list %}
+{% if secured_models | length > 0 %}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ ocp_4_20_ai_maas_proxy_namespace }}
+{# --- One Deployment per unique upstream endpoint --- #}
+{% set seen_endpoints = [] %}
+{% for model in secured_models %}
+{% set proxy_name = ('maas-proxy-' + model.upstream_endpoint | regex_replace('[^a-z0-9]', '-'))[:63] | regex_replace('-$', '') %}
+{% if model.upstream_endpoint not in seen_endpoints %}
+{% set _ = seen_endpoints.append(model.upstream_endpoint) %}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ proxy_name }}
+  namespace: {{ ocp_4_20_ai_maas_proxy_namespace }}
+  labels:
+    app: {{ proxy_name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ proxy_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ proxy_name }}
+    spec:
+      containers:
+      - name: proxy
+        image: {{ model.proxy_image | default(ocp_4_20_ai_maas_proxy_image, true) }}
+        args:
+          - --maas-endpoint={{ model.upstream_endpoint }}
+          - --listen-port=8080
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            cpu: 100m
+            memory: 64Mi
+{% endif %}
+{% endfor %}
+{# --- One routing Service per secured model --- #}
+{% for model in secured_models %}
+{% set proxy_name = ('maas-proxy-' + model.upstream_endpoint | regex_replace('[^a-z0-9]', '-'))[:63] | regex_replace('-$', '') %}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ (model.upstream_model_ns + '--' + model.upstream_model_name)[:63] | regex_replace('-$', '') }}
+  namespace: {{ ocp_4_20_ai_maas_proxy_namespace }}
+  labels:
+    app: {{ proxy_name }}
+spec:
+  selector:
+    app: {{ proxy_name }}
+  ports:
+  - port: 80
+    targetPort: 8080
+{% endfor %}
+{% endif %}

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/external-model-resources.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/external-model-resources.yaml.j2
@@ -1,0 +1,82 @@
+{% for model in ocp_4_20_ai_maas_external_models %}
+{% if not loop.first %}
+---
+{% endif %}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ model.name }}-key
+  namespace: {{ ocp_4_20_ai_maas_external_model_namespace }}
+  labels:
+    inference.networking.k8s.io/bbr-managed: "true"
+type: Opaque
+stringData:
+  api-key: "{{ model.upstream_credential }}"
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: ExternalModel
+metadata:
+  name: {{ model.name }}
+  namespace: {{ ocp_4_20_ai_maas_external_model_namespace }}
+  annotations:
+{% if model.secured | default(false) %}
+    maas.opendatahub.io/tls: "false"
+    maas.opendatahub.io/port: "80"
+{% else %}
+    maas.opendatahub.io/tls: "true"
+    maas.opendatahub.io/port: "443"
+{% endif %}
+spec:
+  provider: openai
+{% if model.secured | default(false) %}
+  endpoint: >-
+    {{ (model.upstream_model_ns + '--' + model.upstream_model_name)[:63] | regex_replace('-$', '') }}.{{ ocp_4_20_ai_maas_proxy_namespace }}.svc.cluster.local
+{% else %}
+  endpoint: {{ model.upstream_endpoint }}
+{% endif %}
+  targetModel: "{{ model.model_id }}"
+  credentialRef:
+    name: {{ model.name }}-key
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSModelRef
+metadata:
+  name: {{ model.name }}
+  namespace: {{ ocp_4_20_ai_maas_external_model_namespace }}
+spec:
+  modelRef:
+    kind: ExternalModel
+    name: {{ model.name }}
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSAuthPolicy
+metadata:
+  name: {{ model.name }}-access
+  namespace: models-as-a-service
+spec:
+  modelRefs:
+  - name: {{ model.name }}
+    namespace: {{ ocp_4_20_ai_maas_external_model_namespace }}
+  subjects:
+    groups:
+{% for tier in ocp_4_20_ai_maas_tiers %}
+    - name: "{{ tier.group }}"
+{% endfor %}
+---
+apiVersion: maas.opendatahub.io/v1alpha1
+kind: MaaSSubscription
+metadata:
+  name: {{ model.name }}-sub
+  namespace: models-as-a-service
+spec:
+  owner:
+    groups:
+    - name: "{{ (ocp_4_20_ai_maas_tiers | selectattr('priority', 'greaterthan', 0) | first | default(ocp_4_20_ai_maas_tiers | first)).group }}"
+  modelRefs:
+  - name: {{ model.name }}
+    namespace: {{ ocp_4_20_ai_maas_external_model_namespace }}
+    tokenRateLimits:
+    - limit: {{ model.token_limit }}
+      window: "{{ model.window }}"
+  priority: {{ model.priority }}
+{% endfor %}

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/hardware-profiles.yaml.j2
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/templates/hardware-profiles.yaml.j2
@@ -1,0 +1,58 @@
+{% for profile in ocp_4_20_ai_maas_hardware_profiles %}
+{% if not loop.first %}
+---
+{% endif %}
+apiVersion: infrastructure.opendatahub.io/v1
+kind: HardwareProfile
+metadata:
+  name: "{{ profile.name }}"
+  namespace: redhat-ods-applications
+  annotations:
+    opendatahub.io/display-name: "{{ profile.display_name }}"
+    opendatahub.io/description: "{{ profile.description | default('') }}"
+    opendatahub.io/disabled: "{{ (not (profile.enabled | default(true))) | lower }}"
+spec:
+  identifiers:
+    - displayName: CPU
+      identifier: cpu
+      resourceType: CPU
+      defaultCount: {{ profile.cpu_default }}
+      minCount: {{ profile.cpu_min }}
+      maxCount: {{ profile.cpu_max }}
+    - displayName: Memory
+      identifier: memory
+      resourceType: Memory
+      defaultCount: {{ profile.memory_default }}
+      minCount: {{ profile.memory_min }}
+      maxCount: {{ profile.memory_max }}
+{% if profile.accelerator_id is defined %}
+    - displayName: "{{ profile.accelerator_name }}"
+      identifier: {{ profile.accelerator_id }}
+      resourceType: Accelerator
+      defaultCount: {{ profile.gpu_count | default(1) }}
+      minCount: {{ profile.gpu_count | default(1) }}
+      maxCount: {{ profile.gpu_max | default(1) }}
+{% endif %}
+{% if profile.node_selectors is defined or profile.tolerations is defined %}
+  scheduling:
+    type: Node
+    node:
+{% if profile.node_selectors is defined %}
+      nodeSelector:
+{% for key, value in profile.node_selectors.items() %}
+        {{ key }}: "{{ value }}"
+{% endfor %}
+{% endif %}
+{% if profile.tolerations is defined %}
+      tolerations:
+{% for tol in profile.tolerations %}
+        - key: {{ tol.key }}
+          operator: {{ tol.operator }}
+          effect: {{ tol.effect }}
+{% if tol.value is defined %}
+          value: "{{ tol.value }}"
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/playbook_osac_create_maas_deployment.yml
+++ b/playbook_osac_create_maas_deployment.yml
@@ -3,7 +3,7 @@
 # Runs the role's task files directly against a live cluster.
 #
 # Usage:
-#   ansible-playbook playbook_osac_create_maas_deployment.yml --tags all -v
+#   ansible-playbook playbook_osac_create_maas_deployment.yml --tags full -v
 #   ansible-playbook playbook_osac_create_maas_deployment.yml --tags operators
 #   ansible-playbook playbook_osac_create_maas_deployment.yml --tags maas
 #   ansible-playbook playbook_osac_create_maas_deployment.yml --tags verify
@@ -23,6 +23,37 @@
       ansible.builtin.set_fact:
         ocp_4_20_ai_maas_enable_keycloak: false
       when: not (ocp_4_20_ai_maas_enable_maas | default(true) | bool)
+      tags: [always]
+
+    - name: Clean up leftover external subscriptions from prior runs
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: absent
+        api_version: maas.opendatahub.io/v1alpha1
+        kind: MaaSSubscription
+        name: "{{ item.name }}-sub"
+        namespace: models-as-a-service
+      loop: "{{ ocp_4_20_ai_maas_external_models | default([]) }}"
+      loop_control:
+        label: "{{ item.name }}-sub"
+      failed_when: false
+      when: ocp_4_20_ai_maas_external_models | default([]) | length > 0
+      tags: [always]
+
+    - name: Clean up leftover external auth policies from prior runs
+      kubernetes.core.k8s:
+        kubeconfig: "{{ admin_kubeconfig }}"
+        state: absent
+        api_version: maas.opendatahub.io/v1alpha1
+        kind: MaaSAuthPolicy
+        name: "{{ item.name }}-access"
+        namespace: models-as-a-service
+      loop: "{{ ocp_4_20_ai_maas_external_models | default([]) }}"
+      loop_control:
+        label: "{{ item.name }}-access"
+      failed_when: false
+      when: ocp_4_20_ai_maas_external_models | default([]) | length > 0
+      tags: [always]
 
   tasks:
     # --- Install Operators (BOM Phase 2 + 3) ---
@@ -33,10 +64,10 @@
         apply:
           tags:
             - operators
-            - all
+            - full
       tags:
         - operators
-        - all
+        - full
 
     # --- Configure cluster (gateway, observability) ---
     - name: Configure cluster
@@ -47,11 +78,11 @@
           tags:
             - cluster
             - maas
-            - all
+            - full
       tags:
         - cluster
         - maas
-        - all
+        - full
 
     # --- Configure MaaS (Phases 1-5) ---
     - name: Configure MaaS platform
@@ -61,10 +92,10 @@
         apply:
           tags:
             - maas
-            - all
+            - full
       tags:
         - maas
-        - all
+        - full
       when: ocp_4_20_ai_maas_enable_maas | default(true) | bool
 
     # --- Verification ---
@@ -75,10 +106,26 @@
         apply:
           tags:
             - verify
-            - all
+            - full
       tags:
         - verify
-        - all
+        - full
+
+    # --- Configure External Models (Phase 6 — after verify) ---
+    - name: Configure external models
+      ansible.builtin.include_role:
+        name: osac.templates.ocp_4_20_ai_maas
+        tasks_from: configure_external_models.yaml
+        apply:
+          tags:
+            - external
+            - full
+      tags:
+        - external
+        - full
+      when:
+        - ocp_4_20_ai_maas_enable_maas | default(true) | bool
+        - ocp_4_20_ai_maas_external_models | default([]) | length > 0
 
     # --- Cleanup ---
     - name: Undeploy everything


### PR DESCRIPTION
## Summary

- Add HardwareProfile CRD parameterization: N profiles per cluster via `hardware_profiles` list param, using RHOAI 3.4.2 schema (annotations for display metadata, `spec.scheduling.node` for nodeSelector/tolerations)
- Add ExternalModel cross-cluster access: `external_models` list param with `secured` flag — when true, deploys maas-proxy for upstream gateway access (Path B/C); when false, connects directly via manual Route (Path A)
- Add `tags: [always]` to playbook pre_tasks — fixes `--tags full` skipping the `enable_keycloak=false` auto-force (caused by `all` → `full` tag rename)

## Test plan

- [x] ansible-lint: 0 failures, 0 warnings (production profile)
- [x] pre-commit: all 8 hooks passed
- [x] UC1: Full MaaS + Keycloak (631s)
- [x] UC2: BYOIDP (539s)
- [x] UC3: Inference + Dashboard (317s)
- [x] UC4: Headless Inference (303s)
- [x] UC5: Bare Inference (224s)
- [x] UC6: Full MaaS + External Model Path B — governance: 401, 403, 200, 429 (604s)
- [x] UC8: BYOIDP + HW + External Model Path B — governance: 401, 403, 200, 429 (604s)
- [x] UC9: BYOIDP + HW + External Model Path C — governance: 401, 403, 200, 429 (577s)
- [x] UC10: BYOIDP + HW + External Model Path A — governance: 401, 403, 200, 429 (578s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration-driven support for creating HardwareProfiles and ExternalModel access (including governance and routing) during deployment.
  * Introduced optional proxy-based routing for “secured” external models, with auto-provisioned proxy infrastructure.
  * Added an additional deployment phase that configures external models after verification when enabled.
* **Bug Fixes**
  * Improved idempotency by cleaning up leftover external MaaS resources before applying changes and during delete flows.
  * Added stricter pre-flight validation for external-model and hardware-profile inputs.
* **Chores**
  * Updated deployment flow tagging and adjusted default node resource class for the role template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->