### PR TITLE
NO-ISSUE: creates test HyperConverged CR via v1 to fix CI flake

### DIFF
--- a/tests/integration/setup_test_env.sh
+++ b/tests/integration/setup_test_env.sh
@@ -93,8 +93,13 @@ kubectl create namespace openshift-cnv || true
 
 # 5. Create minimal HyperConverged CR for GPU passthrough tests
 echo "Creating HyperConverged CR for GPU passthrough tests..."
+# Created via v1, matching the version the ocp_virt_vm role's GPU passthrough
+# task prefers (and falls back from) and the version the test itself reads
+# through in baseline.yml. Creating through v1beta1 while reading/patching
+# through v1 lets the CRD's structural defaulting populate the object under
+# one version's schema and validate it under the other's on the next write.
 kubectl apply -f - <<HCEOF
-apiVersion: hco.kubevirt.io/v1beta1
+apiVersion: hco.kubevirt.io/v1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged


### PR DESCRIPTION
## Summary
- The integration test setup creates the test HyperConverged CR through v1beta1, while the ocp_virt_vm role's GPU passthrough task (and the test's own verification step) read and patch it through v1
- Where the two API versions' schemas diverge for spec.featureGates (object under v1beta1, array under v1, no conversion webhook between them), this cross-version mismatch causes any later write to fail full-object CEL validation with a confusing type-mismatch error surfaced as a uniqueness rule violation
- Creating the CR through v1 for consistency with the rest of the flow fixes compute_instance_with_gpu_create:baseline; reproduced and verified locally with a kind cluster before and after the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the integration test environment to use the current HyperConverged API version.
  - Added guidance documenting API version selection, defaulting, and validation expectations to improve test consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->