### PR TITLE
OSAC-2186: Pin configAsCode.eeImage/projectGitBranch at release

### DIFF
--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -80,8 +80,29 @@ jobs:
       run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
     - name: Update image tag in values.yaml
+      env:
+        VERSION: ${{ steps.version.outputs.version }}
       run: |
-        sed -i "s|image: ghcr.io/osac-project/osac-aap:latest|image: ghcr.io/osac-project/osac-aap:v${{ steps.version.outputs.version }}|" charts/aap/values.yaml
+        if [[ ! "$VERSION" =~ ^[0-9A-Za-z._-]+$ ]]; then
+          echo "Invalid release version: $VERSION" >&2
+          exit 1
+        fi
+
+        # sed exits 0 even when a pattern matches zero lines, so a future values.yaml
+        # format change could silently leave a placeholder unpinned. Verify the expected
+        # replacement actually landed and fail the release instead of packaging stale values.
+        replace_and_verify() {
+          local old="$1" new="$2"
+          sed -i "s|${old}|${new}|" charts/aap/values.yaml
+          if ! grep -qF -- "${new}" charts/aap/values.yaml; then
+            echo "::error::Expected '${new}' not found in charts/aap/values.yaml after substitution (placeholder '${old}' may be missing or already changed)" >&2
+            exit 1
+          fi
+        }
+
+        replace_and_verify "image: ghcr.io/osac-project/osac-aap:latest" "image: ghcr.io/osac-project/osac-aap:v${VERSION}"
+        replace_and_verify "eeImage: \"\"" "eeImage: \"ghcr.io/osac-project/osac-aap:v${VERSION}\""
+        replace_and_verify "projectGitBranch: \"\"" "projectGitBranch: \"v${VERSION}\""
 
     - name: Package chart
       run: |


### PR DESCRIPTION
## Summary

- `charts/aap/values.yaml` declares `configAsCode.eeImage` and `configAsCode.projectGitBranch` as empty-string placeholders. `bootstrap.image` is patched to the exact release version by `publish-charts.yaml` before packaging, but these two fields were never touched by the release workflow.
- Because Helm's `{{- with }}` treats an empty string as falsy, the chart template omits `AAP_EE_IMAGE`/`AAP_PROJECT_GIT_BRANCH` from the generated Secret whenever these are unset, and the Ansible config-as-code layer (`playbooks/vars/config.yml`) then falls back to `ghcr.io/osac-project/osac-aap:latest` / `main`. A released chart deployed with default values therefore silently runs an unpinned execution-environment image and syncs automation content from `main` instead of the tested release.
- Added two `sed` substitutions alongside the existing `bootstrap.image` patch so both fields default to the release version/tag, consistent with how `bootstrap.image` is already handled. The committed `values.yaml` placeholders are intentionally left unchanged — only the release-time patch step is extended.

### Hardening added in response to CodeRabbit review

- **Tag injection (Critical/Security):** `steps.version.outputs.version` (derived from the pushed tag's `GITHUB_REF_NAME`) was interpolated directly via `${{ }}` template expansion into the shell script. GitHub Actions substitutes `${{ }}` as raw text before bash parses it, so a maliciously crafted tag name could break out of the `sed` argument and run arbitrary commands in this privileged release job (`contents: write`, `packages: write`). Fixed by passing the version through `env:` and validating it against `^[0-9A-Za-z._-]+$` before use, applied to all three substitutions (including the pre-existing `bootstrap.image` line).
- **Fail closed on a missing placeholder (Data Integrity):** `sed` exits `0` even when it matches zero lines, so a future `values.yaml` format change could silently leave a placeholder unpinned with no error. Added a `replace_and_verify` check after each substitution that fails the workflow if the expected replacement isn't found.

Verified locally (not just by inspection):
- The substitutions produce valid YAML and leave the unrelated `projectGitUri` field untouched.
- A crafted malicious tag value is rejected by the validation regex before reaching `sed`.
- A simulated missing/altered placeholder now aborts the workflow with a clear error instead of silently succeeding.

## Test plan

- [ ] Push a `v*` tag (or dry-run the workflow) and confirm the packaged chart's `values.yaml` has `eeImage` and `projectGitBranch` pinned to the release version/tag rather than empty strings.
- [ ] Confirm `bootstrap.image` patch behavior is unchanged.
- [x] Confirmed locally that a crafted tag value (e.g. containing `; touch /tmp/PWNED`) is rejected by the version validation instead of executing.
- [x] Confirmed locally that a missing/altered placeholder now fails the step instead of silently proceeding.

Fixes [OSAC-2186](https://redhat.atlassian.net/browse/OSAC-2186).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved chart publishing reliability by deriving the release version from the workflow output and validating it against an allowed format.
  * Updated chart values in a coordinated way (image, execution environment image, and project branch) to keep them consistent.
  * Added post-update verification; publishing now fails with a clear error if the expected changes are not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->