### PR TITLE
NO-ISSUE: Harden ansible-lint.yml and integration-tests.yml workflows

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -12,18 +12,23 @@ on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   ansible-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version-file: "pyproject.toml"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,18 +12,23 @@ on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
 
       - name: "Set up Python"
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version-file: "pyproject.toml"
 


### PR DESCRIPTION
## Summary

Follow-up to #413 (splitting `tests.yml` into `ansible-lint.yml` / `integration-tests.yml`). An automated review on #413 flagged 3 hardening gaps that were correct but out of scope for that PR (a pure split with no logic changes) — this PR addresses them:

- Add `permissions: contents: read` (neither workflow needs write access to the token)
- Set `persist-credentials: false` on checkout (neither workflow pushes anything)
- Pin `actions/checkout`, `astral-sh/setup-uv`, `actions/setup-python` to immutable commit SHAs instead of mutable version tags

Scoped to just the two files created by #413, not a repo-wide audit — the other CI workflows in this repo (`execution-environment.yml`, `helm-lint.yaml`, `pre-commit.yaml`, `publish-charts.yaml`) follow the same pre-existing pattern and are left alone here.

**Depends on #413** — based on its branch since these files don't exist on `main` yet.

## Test plan

- [x] `pre-commit run` passes locally on both files
- [x] YAML syntax validated
- [ ] CI (ansible-lint, integration-tests) passes on this branch