### PR TITLE
OSAC-2822: skip CI for docs-only and metadata-only PRs

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -8,6 +8,11 @@ concurrency:
 on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -29,7 +29,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.docs-only != 'true' }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            docs-only:
+              - 'OWNERS'
+              - 'LICENSE'
+              - '*.md'
+              - 'docs/**'
+
   e2e-vmaas-full-install:
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
     uses: osac-project/osac-test-infra/.github/workflows/e2e-vmaas-full-install.yml@main
     with:
       test-suite: ${{ inputs.test-suite || 'vmaas' }}
@@ -47,3 +68,11 @@ jobs:
       # Checkout osac-test-infra for tests/Containerfile (not the caller repo)
       test-infra-repository: osac-project/osac-test-infra
       test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+
+  e2e:
+    if: always()
+    needs: [changes, e2e-vmaas-full-install]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/execution-environment.yml
+++ b/.github/workflows/execution-environment.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
 
 jobs:
   build-execution-environment:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,11 @@ concurrency:
 on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,6 +2,11 @@ name: pre-commit
 
 on:
   pull_request:
+    paths-ignore:
+      - 'OWNERS'
+      - 'LICENSE'
+      - '*.md'
+      - 'docs/**'
 
 jobs:
   pre-commit:


### PR DESCRIPTION
## Summary

Add paths-ignore filters to all PR-triggered workflows so they don't run when only non-code files change (OWNERS, LICENSE, *.md, docs/**).

Scheduled and workflow_dispatch triggers are unaffected.

Companion PR: https://github.com/osac-project/github-config/pull/131 (migrates required status checks to rulesets so skipped checks don't block merge)

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Documentation-only pull requests no longer trigger several automated validation workflows.
  * End-to-end validation now detects documentation-only changes and skips unnecessary installation tests.
  * End-to-end job results continue to report failures or cancellations clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->