### PR TITLE
OSAC-2185: Gate chart publish on image build success

### DIFF
--- a/.github/scripts/verify-tag-matches-sha.sh
+++ b/.github/scripts/verify-tag-matches-sha.sh
@@ -7,7 +7,8 @@
 # Required env vars: GH_TOKEN, REPO, TAG, GUARDED_SHA
 set -euo pipefail
 
-read -r current_type current_sha <<< "$(gh api "repos/${REPO}/git/refs/tags/${TAG}" --jq '[.object.type, .object.sha] | @tsv')"
+ref_json="$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '[.object.type, .object.sha] | @tsv')"
+read -r current_type current_sha <<< "$ref_json"
 if [[ "$current_type" == "tag" ]]; then
   # Annotated tag: the ref's object.sha is the tag object, not the commit - peel it.
   current_sha="$(gh api "repos/${REPO}/git/tags/${current_sha}" --jq .object.sha)"

--- a/.github/scripts/verify-tag-matches-sha.sh
+++ b/.github/scripts/verify-tag-matches-sha.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Verifies that a git tag still resolves to the guarded commit SHA that was
+# validated by this workflow's guard job, protecting against a force-push/
+# retag race between the image build and any subsequent chart-publish or
+# release step.
+#
+# Required env vars: GH_TOKEN, REPO, TAG, GUARDED_SHA
+set -euo pipefail
+
+read -r current_type current_sha <<< "$(gh api "repos/${REPO}/git/refs/tags/${TAG}" --jq '[.object.type, .object.sha] | @tsv')"
+if [[ "$current_type" == "tag" ]]; then
+  # Annotated tag: the ref's object.sha is the tag object, not the commit - peel it.
+  current_sha="$(gh api "repos/${REPO}/git/tags/${current_sha}" --jq .object.sha)"
+fi
+
+if [[ "$current_sha" != "$GUARDED_SHA" ]]; then
+  echo "::error::Tag '${TAG}' now points at ${current_sha}, not the guarded commit ${GUARDED_SHA} (force-pushed?). Refusing to proceed."
+  exit 1
+fi
+
+echo "Tag '${TAG}' still points at the guarded commit ${GUARDED_SHA}."

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -13,6 +13,8 @@ jobs:
   guard:
     name: Verify image build succeeded
     runs-on: ubuntu-latest
+    # Read-only job: only inspects workflow_run event metadata, no repo/API access needed.
+    permissions: {}
     if: >
       github.event.workflow_run.event == 'push' &&
       startsWith(github.event.workflow_run.head_branch, 'v')
@@ -21,12 +23,20 @@ jobs:
       sha: ${{ github.event.workflow_run.head_sha }}
     steps:
     - name: Check image build result
+      env:
+        CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
-        if [[ "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
-          echo "::error::Image build for tag ${{ github.event.workflow_run.head_branch }} did not succeed (conclusion: ${{ github.event.workflow_run.conclusion }}). Refusing to publish chart."
+        semver_re='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(-[0-9A-Za-z]+)*(\.[0-9A-Za-z]+(-[0-9A-Za-z]+)*)*)?(\+[0-9A-Za-z]+(-[0-9A-Za-z]+)*(\.[0-9A-Za-z]+(-[0-9A-Za-z]+)*)*)?$'
+        if ! [[ "$HEAD_BRANCH" =~ $semver_re ]]; then
+          echo "::error::Tag '$HEAD_BRANCH' is not a valid semver release tag"
           exit 1
         fi
-        echo "Image build succeeded for tag ${{ github.event.workflow_run.head_branch }}"
+        if [[ "$CONCLUSION" != "success" ]]; then
+          echo "::error::Image build for tag $HEAD_BRANCH did not succeed (conclusion: $CONCLUSION). Refusing to publish chart."
+          exit 1
+        fi
+        echo "Image build succeeded for tag $HEAD_BRANCH"
 
   publish-aap-chart:
     name: Publish osac-aap chart
@@ -37,9 +47,10 @@ jobs:
       packages: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:
         ref: ${{ needs.guard.outputs.sha }}
+        persist-credentials: false
 
     - name: Set up Helm
       uses: azure/setup-helm@v5
@@ -69,6 +80,18 @@ jobs:
       run: |
         helm push osac-aap-${{ steps.version.outputs.version }}.tgz \
           oci://${{ env.REGISTRY }}/${{ env.CHARTS_REPO }}
+
+    - name: Verify tag still points at the guarded commit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}
+        GUARDED_SHA: ${{ needs.guard.outputs.sha }}
+      run: |
+        CURRENT_SHA="$(gh api "repos/${{ github.repository }}/git/refs/tags/${TAG}" --jq .object.sha)"
+        if [[ "$CURRENT_SHA" != "$GUARDED_SHA" ]]; then
+          echo "::error::Tag '${TAG}' now points at ${CURRENT_SHA}, not the guarded commit ${GUARDED_SHA} (force-pushed?). Refusing to create a release."
+          exit 1
+        fi
 
     - name: Create GitHub Release
       run: |

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -63,7 +63,7 @@ jobs:
       run: .github/scripts/verify-tag-matches-sha.sh
 
     - name: Set up Helm
-      uses: azure/setup-helm@v5
+      uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310  # v5.0.1
       with:
         version: v3.17.0
 
@@ -71,7 +71,7 @@ jobs:
       env:
         REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         REGISTRY_USERNAME: ${{ github.actor }}
-      run: echo "${REGISTRY_PASSWORD}" | helm registry login ${{ env.REGISTRY }} -u "${REGISTRY_USERNAME}" --password-stdin
+      run: echo "${REGISTRY_PASSWORD}" | helm registry login "${REGISTRY}" -u "${REGISTRY_USERNAME}" --password-stdin
 
     - name: Extract version from tag
       id: version

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -27,7 +27,7 @@ jobs:
         CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
-        semver_re='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+(-[0-9A-Za-z]+)*(\.[0-9A-Za-z]+(-[0-9A-Za-z]+)*)*)?(\+[0-9A-Za-z]+(-[0-9A-Za-z]+)*(\.[0-9A-Za-z]+(-[0-9A-Za-z]+)*)*)?$'
+        semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
         if ! [[ "$HEAD_BRANCH" =~ $semver_re ]]; then
           echo "::error::Tag '$HEAD_BRANCH' is not a valid semver release tag"
           exit 1
@@ -51,6 +51,14 @@ jobs:
       with:
         ref: ${{ needs.guard.outputs.sha }}
         persist-credentials: false
+
+    - name: Verify tag still points at the guarded commit
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}
+        GUARDED_SHA: ${{ needs.guard.outputs.sha }}
+        REPO: ${{ github.repository }}
+      run: .github/scripts/verify-tag-matches-sha.sh
 
     - name: Set up Helm
       uses: azure/setup-helm@v5
@@ -86,12 +94,8 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ needs.guard.outputs.tag }}
         GUARDED_SHA: ${{ needs.guard.outputs.sha }}
-      run: |
-        CURRENT_SHA="$(gh api "repos/${{ github.repository }}/git/refs/tags/${TAG}" --jq .object.sha)"
-        if [[ "$CURRENT_SHA" != "$GUARDED_SHA" ]]; then
-          echo "::error::Tag '${TAG}' now points at ${CURRENT_SHA}, not the guarded commit ${GUARDED_SHA} (force-pushed?). Refusing to create a release."
-          exit 1
-        fi
+        REPO: ${{ github.repository }}
+      run: .github/scripts/verify-tag-matches-sha.sh
 
     - name: Create GitHub Release
       run: |
@@ -99,6 +103,7 @@ jobs:
           --repo "${{ github.repository }}" \
           --title "osac-aap ${TAG}" \
           --generate-notes \
+          --verify-tag \
         || gh release edit "${TAG}" \
           --repo "${{ github.repository }}" \
           --title "osac-aap ${TAG}"

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -27,7 +27,9 @@ jobs:
         CONCLUSION: ${{ github.event.workflow_run.conclusion }}
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
-        semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+        # No build-metadata (+...) suffix allowed: this tag is used verbatim as a
+        # container image tag downstream, and Docker/OCI tags cannot contain '+'.
+        semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)(\.((0|[1-9][0-9]*)|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*)?$'
         if ! [[ "$HEAD_BRANCH" =~ $semver_re ]]; then
           echo "::error::Tag '$HEAD_BRANCH' is not a valid semver release tag"
           exit 1
@@ -66,7 +68,10 @@ jobs:
         version: v3.17.0
 
     - name: Log in to GHCR
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+      env:
+        REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        REGISTRY_USERNAME: ${{ github.actor }}
+      run: echo "${REGISTRY_PASSWORD}" | helm registry login ${{ env.REGISTRY }} -u "${REGISTRY_USERNAME}" --password-stdin
 
     - name: Extract version from tag
       id: version
@@ -100,13 +105,14 @@ jobs:
     - name: Create GitHub Release
       run: |
         gh release create "${TAG}" \
-          --repo "${{ github.repository }}" \
+          --repo "${REPO}" \
           --title "osac-aap ${TAG}" \
           --generate-notes \
           --verify-tag \
         || gh release edit "${TAG}" \
-          --repo "${{ github.repository }}" \
+          --repo "${REPO}" \
           --title "osac-aap ${TAG}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ needs.guard.outputs.tag }}
+        REPO: ${{ github.repository }}

--- a/.github/workflows/publish-charts.yaml
+++ b/.github/workflows/publish-charts.yaml
@@ -1,17 +1,36 @@
 name: Publish Helm Charts
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_run:
+    workflows: ["Build execution environment"]
+    types: [completed]
 
 env:
   REGISTRY: ghcr.io
   CHARTS_REPO: ${{ github.repository_owner }}/charts
 
 jobs:
+  guard:
+    name: Verify image build succeeded
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
+    outputs:
+      tag: ${{ github.event.workflow_run.head_branch }}
+      sha: ${{ github.event.workflow_run.head_sha }}
+    steps:
+    - name: Check image build result
+      run: |
+        if [[ "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
+          echo "::error::Image build for tag ${{ github.event.workflow_run.head_branch }} did not succeed (conclusion: ${{ github.event.workflow_run.conclusion }}). Refusing to publish chart."
+          exit 1
+        fi
+        echo "Image build succeeded for tag ${{ github.event.workflow_run.head_branch }}"
+
   publish-aap-chart:
     name: Publish osac-aap chart
+    needs: guard
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,6 +38,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      with:
+        ref: ${{ needs.guard.outputs.sha }}
 
     - name: Set up Helm
       uses: azure/setup-helm@v5
@@ -30,7 +51,9 @@ jobs:
 
     - name: Extract version from tag
       id: version
-      run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      env:
+        TAG: ${{ needs.guard.outputs.tag }}
+      run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
     - name: Update image tag in values.yaml
       run: |
@@ -49,12 +72,13 @@ jobs:
 
     - name: Create GitHub Release
       run: |
-        gh release create "${GITHUB_REF_NAME}" \
+        gh release create "${TAG}" \
           --repo "${{ github.repository }}" \
-          --title "osac-aap ${GITHUB_REF_NAME}" \
+          --title "osac-aap ${TAG}" \
           --generate-notes \
-        || gh release edit "${GITHUB_REF_NAME}" \
+        || gh release edit "${TAG}" \
           --repo "${{ github.repository }}" \
-          --title "osac-aap ${GITHUB_REF_NAME}"
+          --title "osac-aap ${TAG}"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ needs.guard.outputs.tag }}


### PR DESCRIPTION
## Summary

`publish-charts.yaml` and `execution-environment.yml` currently trigger independently off the same `v*` tag push, with no dependency between them — a chart can be marked "published" even if the matching execution-environment image never got built. This exact class of gap caused the [OSAC-2174](https://redhat.atlassian.net/browse/OSAC-2174) production incident in a sibling repo (chart referenced an image that was never built, resulting in `ImagePullBackOff`).

This PR changes `publish-charts.yaml` to trigger via `workflow_run` on `Build execution environment` completing, gated by a new `guard` job:

- Skips (neutral, not a false green) if the completion isn't from a tag push (e.g. PR builds, pushes to `main`).
- **Fails loudly (red)** if the image build for the tag did not succeed.
- Only lets the chart-publish job proceed if the image build for that *same tag* succeeded.

The single `publish-aap-chart` job now `needs: guard`, pins its checkout to `needs.guard.outputs.sha`, and uses `needs.guard.outputs.tag` instead of `$GITHUB_REF_NAME` (which doesn't reliably resolve to the tag under a `workflow_run` event) for both version extraction and the inline `gh release create` step.

## Testing

Live end-to-end verified on a personal fork, not just static analysis:
- Pushed a `v*` test tag → image build ran → succeeded → `publish-charts` triggered afterward (not in parallel) → chart published → GitHub Release created. Full run: green.
- Confirmed the negative path: a `push` to `main` (non-tag) completing the image workflow correctly results in `publish-charts` being **skipped**, not a false green.
- Validated with `actionlint` (0 errors) on the final workflow file.

## Acceptance criteria ([OSAC-2185](https://redhat.atlassian.net/browse/OSAC-2185))

- [x] Chart publish cannot succeed (or create a GitHub Release) unless the matching image was confirmed to exist for that tag.
- [x] A simulated image-build failure on a tag push causes `publish-charts` to fail loudly rather than complete green.

Jira: https://redhat.atlassian.net/browse/OSAC-2185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated chart publishing to trigger only after the build execution workflow finishes successfully, rather than on direct version tag pushes.
  * Added validation to ensure publishing is based on a proper version tag from the expected branch and that the upstream workflow concluded successfully.
  * Added an extra verification step to confirm the guarded tag still resolves to the expected commit before creating/updating the GitHub Release, with a dedicated script performing the check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->