### PR TITLE
NO-ISSUE: add default values to hardware_profiles and external_models parameters

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
@@ -68,6 +68,7 @@ parameters:
       profile with CPU, memory, and optional accelerator constraints.
     type: list
     required: false
+    default: []
   - name: external_models
     title: External Models
     description: >
@@ -76,3 +77,4 @@ parameters:
       is deployed. Requires enable_maas=true.
     type: list
     required: false
+    default: []


### PR DESCRIPTION
## Summary

- Adds `default: []` to `hardware_profiles` and `external_models` parameters in
  `ocp_4_20_ai_maas/meta/osac.yaml`
- Fixes collision between osac-aap#409 and fulfillment-service#691: the new
  fulfillment-service validation rejects non-editable field definitions without a
  default value (`InvalidArgument`), which blocks the submodule bump in
  osac-installer#424
- The empty-list default is consistent with `defaults/main.yaml` and
  `argument_specs.yaml`, which already default both to `[]`

## Test plan

- [ ] Verify osac-installer submodule bump succeeds with both this fix and
      fulfillment-service#691 merged
- [ ] E2E: catalog item creation with the ocp_4_20_ai_maas template passes
      validation

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added empty defaults for hardware profiles and external models, allowing configurations to omit these optional settings without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->