### PR TITLE
OSAC-2333: Add merge_group trigger to E2E workflow

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -7,6 +7,7 @@ permissions:
 on:
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: "0 */12 * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Adds `merge_group` to the E2E workflow triggers. This is a prerequisite for enabling GitHub merge queues ([github-config PR #134](https://github.com/osac-project/github-config/pull/134)).

When a PR enters the merge queue, GitHub creates a temporary merge ref on top of the latest `main` and fires a `merge_group` event. Without this trigger, the E2E workflow wouldn't run on that ref, causing the merge queue to time out.

## What changed

One line added to the `on:` block:
```yaml
merge_group:
```

## Test plan

- [ ] Verify E2E workflow still triggers normally on PRs (no behavioral change for `pull_request` events)
- [ ] After github-config PR #134 is applied, verify merge queue runs E2E against the merge group ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)