### PR TITLE
OSAC-1823: Also restart bare metal fulfillment operator to pick up API token

### DIFF
--- a/charts/aap/templates/hooks/create-api-token.yaml
+++ b/charts/aap/templates/hooks/create-api-token.yaml
@@ -111,6 +111,12 @@ spec:
             oc rollout restart deploy/osac-operator -n {{ .Release.Namespace }}
             oc rollout status deploy/osac-operator -n {{ .Release.Namespace }} --timeout=120s
             echo "Operator restarted."
+            if oc get deploy/bmf-operator-controller-manager -n {{ .Release.Namespace }} &>/dev/null; then
+              echo "Restarting BMF operator to pick up new token..."
+              oc rollout restart deploy/bmf-operator-controller-manager -n {{ .Release.Namespace }}
+              oc rollout status deploy/bmf-operator-controller-manager -n {{ .Release.Namespace }} --timeout=120s
+              echo "BMF operator restarted."
+            fi
         env:
         - name: HOME
           value: /tmp


### PR DESCRIPTION
Before this change bare-metal-fulfillment-operator would fail to provision hosts because the token is set to optional but the deployment was not rolled out after the secret was created.

This commit treats BMF operator the same as osac-operator.

Relates to https://redhat.atlassian.net/browse/OSAC-1823