### PR TITLE
OSAC-2522: Fix ocp_virt_vm AAP role for removed cores/memory_gib fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,8 +99,10 @@ capabilities:
 ```yaml
 template_type: compute_instance
 spec_defaults:
-  cores: 2
-  memory_gib: 2
+  # cores/memory_gib are reserved (removed) on ComputeInstanceTemplateSpecDefaults —
+  # instance_type is now the sole, mandatory way to size a ComputeInstance.
+  # Set spec_defaults.instance_type here to give the template a default, or
+  # omit it to require callers to always pass instance_type explicitly.
   boot_disk:
     size_gib: 10
   image:
@@ -437,8 +439,7 @@ OPA policies enforce isolation at runtime (handled by fulfillment-service).
    template_type: compute_instance
    implementation_strategy: <backend>
    spec_defaults:
-     cores: 2
-     memory_gib: 2
+     # cores/memory_gib are reserved (removed); instance_type is mandatory.
      boot_disk:
        size_gib: 10
    parameters:

--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -221,14 +221,12 @@ class ComputeInstanceTemplateSpecDefaults(Base):
     """Default values for compute instance spec fields.
 
     Maps from Ansible camelCase (defaults/main.yaml) to proto snake_case.
+
+    Note: cores/memory_gib are intentionally absent — they are reserved
+    (removed) on the fulfillment-service ComputeInstanceTemplateSpecDefaults
+    proto. instance_type is now the sole way to size a ComputeInstance.
     """
 
-    cores: int | None = None
-    memory_gib: int | None = pydantic.Field(
-        default=None,
-        validation_alias=pydantic.AliasChoices("memoryGiB", "memoryGib", "memory_gib"),
-        serialization_alias="memory_gib",
-    )
     image: ComputeInstanceImage | None = None
     boot_disk: ComputeInstanceDisk | None = pydantic.Field(
         default=None,

--- a/collections/ansible_collections/osac/templates/README.md
+++ b/collections/ansible_collections/osac/templates/README.md
@@ -147,8 +147,10 @@ single file: `meta/osac.yaml`.
    template_type: compute_instance
 
    spec_defaults:
-     cores: 2
-     memory_gib: 2
+     # cores/memory_gib are reserved (removed); instance_type is the sole,
+     # mandatory way to size a ComputeInstance. Set spec_defaults.instance_type
+     # here to give the template a default, or omit it to require callers to
+     # always pass instance_type explicitly.
      boot_disk:
        size_gib: 10
      image:

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/defaults/main.yaml
@@ -28,9 +28,10 @@ default_arg_specs:
   exposed_ports: "22/tcp"
 
 # Defaults for ComputeInstance spec fields (Linux profile).
+# cores/memoryGiB are not defaulted here: they are resolved by osac-operator
+# from spec.instanceType (mandatory) and are always present on the CR by the
+# time this role runs.
 default_spec:
-  cores: 2
-  memoryGiB: 2
   bootDisk:
     sizeGiB: 10
   image:
@@ -42,8 +43,6 @@ _guest_os_windows_default_arg_specs:
   exposed_ports: "3389/tcp"
 
 _guest_os_windows_default_spec:
-  cores: 2
-  memoryGiB: 4
   bootDisk:
     sizeGiB: 40
   image:

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/meta/osac.yaml
@@ -9,8 +9,6 @@ description: >
 template_type: compute_instance
 
 spec_defaults:
-  cores: 2
-  memory_gib: 2
   boot_disk:
     size_gib: 10
   image:

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_validate.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tasks/create_validate.yaml
@@ -3,10 +3,20 @@
   ansible.builtin.set_fact:
     params: "{{ default_arg_specs | combine(template_parameters | default({})) }}"
 
+- name: Require spec.cores and spec.memoryGiB from resolved instance_type
+  ansible.builtin.assert:
+    that:
+      - compute_instance.spec.cores is defined
+      - compute_instance.spec.memoryGiB is defined
+    fail_msg: >-
+      ComputeInstance must have spec.cores and spec.memoryGiB set.
+      These are resolved by osac-operator from spec.instanceType — ensure the
+      ComputeInstance (or its template) specifies a valid instance_type.
+
 - name: Extract VM configuration from ComputeInstance spec
   ansible.builtin.set_fact:
-    vm_cpu_cores: "{{ (compute_instance.spec.cores | default(default_spec.cores)) | int }}"
-    vm_memory: "{{ (compute_instance.spec.memoryGiB | default(default_spec.memoryGiB)) | string + 'Gi' }}"
+    vm_cpu_cores: "{{ compute_instance.spec.cores | int }}"
+    vm_memory: "{{ compute_instance.spec.memoryGiB | string + 'Gi' }}"
     vm_boot_disk_size: "{{ (compute_instance.spec.bootDisk.sizeGiB | default(default_spec.bootDisk.sizeGiB)) | string + 'Gi' }}"
     vm_image_source: "{{ compute_instance.spec.image.sourceRef | default(default_spec.image.sourceRef) }}"
     vm_run_strategy: "{{ compute_instance.spec.runStrategy | default(default_spec.runStrategy) }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-defaults-test.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-defaults-test.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: osac-system
 spec:
   templateID: osac.templates.ocp_virt_vm
+  cores: 2
+  memoryGiB: 2
   networkAttachments:
     - subnetRef: test-subnet
 status:

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-missing-cores-test.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-missing-cores-test.yaml
@@ -2,19 +2,11 @@
 apiVersion: osac.openshift.io/v1alpha1
 kind: ComputeInstance
 metadata:
-  name: test-vm-sgs
+  name: test-vm-missing-cores
   namespace: osac-system
 spec:
   templateID: osac.templates.ocp_virt_vm
-  cores: 2
-  memoryGiB: 2
   networkAttachments:
     - subnetRef: test-subnet
-      securityGroupRefs:
-        - securitygroup-web01
-        - securitygroup-db01
-    - subnetRef: monitoring-subnet
-      securityGroupRefs:
-        - securitygroup-mon01
 status:
   desiredConfigVersion: "1"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-no-subnet-test.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-no-subnet-test.yaml
@@ -6,5 +6,7 @@ metadata:
   namespace: osac-system
 spec:
   templateID: osac.templates.ocp_virt_vm
+  cores: 2
+  memoryGiB: 2
 status:
   desiredConfigVersion: "1"

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-unknown-os-test.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-unknown-os-test.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   templateID: osac.templates.ocp_virt_vm
   guestOSFamily: "freebsd"
+  cores: 2
+  memoryGiB: 2
   networkAttachments:
     - subnetRef: test-subnet
   image:

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-windows-with-image-test.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/fixtures/computeinstance-windows-with-image-test.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   templateID: osac.templates.ocp_virt_vm
   guestOSFamily: "windows"
+  cores: 2
+  memoryGiB: 4
   networkAttachments:
     - subnetRef: test-subnet
   image:

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/test.yml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/tests/test.yml
@@ -37,10 +37,15 @@
 #
 #   Test 11 (Missing networkAttachments rejected):
 #     ansible-playbook ... -e test_create_missing_subnet_fails=true
+#
+#   Test 12 (Missing spec.cores/memoryGiB rejected):
+#     ansible-playbook ... -e test_create_missing_cores_fails=true
 
 # ──────────────────────────────────────────────────────────────
 # Test 1: Verify spec defaults are merged into a minimal fixture
-# Expected: CPU=2, memory=2Gi, disk=10Gi, image=fedora, runStrategy=Always
+# Expected: CPU/memory read from spec (resolved by osac-operator from
+# instance_type); disk=10Gi, image=fedora, runStrategy=Always still come
+# from role defaults.
 # ──────────────────────────────────────────────────────────────
 - name: "Test ocp_virt_vm -- spec defaults are merged correctly"
   hosts: localhost
@@ -73,19 +78,19 @@
               - compute_instance.metadata.name == "test-vm-defaults"
             fail_msg: "Compute instance name not extracted correctly"
 
-        - name: Verify default CPU cores applied
+        - name: Verify CPU cores read from resolved spec
           ansible.builtin.assert:
             that:
               - vm_cpu_cores is defined
               - vm_cpu_cores | int == 2
-            fail_msg: "Expected default cpu cores of 2, got {{ vm_cpu_cores | default('undefined') }}"
+            fail_msg: "Expected cpu cores of 2 from spec.cores, got {{ vm_cpu_cores | default('undefined') }}"
 
-        - name: Verify default memory applied
+        - name: Verify memory read from resolved spec
           ansible.builtin.assert:
             that:
               - vm_memory is defined
               - vm_memory == "2Gi"
-            fail_msg: "Expected default memory of 2Gi, got {{ vm_memory | default('undefined') }}"
+            fail_msg: "Expected memory of 2Gi from spec.memoryGiB, got {{ vm_memory | default('undefined') }}"
 
         - name: Verify default boot disk size applied
           ansible.builtin.assert:
@@ -280,7 +285,7 @@
             fail_msg: "Expected vm_image_source from spec, got {{ vm_image_source | default('undefined') }}"
 
 # Test 6: Unknown OS value falls through to linux defaults
-# Expected: CPU=2, memory=2Gi, disk=10Gi (linux defaults, not Windows)
+# Expected: CPU/memory from spec (2/2Gi), disk=10Gi (linux default, not Windows)
 # ──────────────────────────────────────────────────────────────
 - name: "Test ocp_virt_vm -- Unknown OS value falls through to linux behavior"
   hosts: localhost
@@ -303,22 +308,26 @@
             compute_instance: "{{ lookup('file', 'fixtures/computeinstance-unknown-os-test.yaml') | from_yaml }}"
             template_parameters: {}
 
+        - name: Set compute instance name
+          ansible.builtin.set_fact:
+            compute_instance_name: "{{ compute_instance.metadata.name }}"
+
         - name: Run create_validate
           ansible.builtin.include_role:
             name: osac.templates.ocp_virt_vm
             tasks_from: create_validate.yaml
 
-        - name: Assert CPU cores match linux default not Windows
+        - name: Assert CPU cores come from spec (2 cores)
           ansible.builtin.assert:
             that:
               - vm_cpu_cores | int == 2
-            fail_msg: "Expected linux default (2 cores), got {{ vm_cpu_cores | default('undefined') }}"
+            fail_msg: "Expected 2 cores from spec.cores, got {{ vm_cpu_cores | default('undefined') }}"
 
-        - name: Assert memory matches linux default not Windows
+        - name: Assert memory comes from spec (2Gi)
           ansible.builtin.assert:
             that:
               - vm_memory == "2Gi"
-            fail_msg: "Expected linux default (2Gi), got {{ vm_memory | default('undefined') }}"
+            fail_msg: "Expected 2Gi from spec.memoryGiB, got {{ vm_memory | default('undefined') }}"
 
         - name: Assert boot disk size matches linux default not Windows
           ansible.builtin.assert:
@@ -597,3 +606,55 @@
             fail_msg: >-
               Expected create_validate to fail when spec.networkAttachments
               is not set on the ComputeInstance
+
+# ──────────────────────────────────────────────────────────────
+# Test 12: Missing spec.cores/memoryGiB must fail validation
+# Expected: validation fails with message about spec.cores/spec.memoryGiB
+# (these are resolved by osac-operator from instance_type; there is no
+# role-level default anymore since instance_type is mandatory)
+# ──────────────────────────────────────────────────────────────
+- name: "Test ocp_virt_vm -- missing spec.cores/memoryGiB rejected"
+  hosts: localhost
+
+  collections:
+    - osac.templates
+
+  vars:
+    compute_instance_label: "osac.openshift.io/computeinstance"
+
+  tasks:
+    - when: test_create_missing_cores_fails | default(false) | bool
+      block:
+        - name: Read ComputeInstance fixture without spec.cores/memoryGiB
+          ansible.builtin.set_fact:
+            compute_instance: "{{ lookup('file', 'fixtures/computeinstance-missing-cores-test.yaml') | from_yaml }}"
+
+        - name: Set compute instance name
+          ansible.builtin.set_fact:
+            compute_instance_name: "{{ compute_instance.metadata.name }}"
+
+        - name: Run create_validate (expect failure — no spec.cores/memoryGiB)
+          block:
+            - name: Include create_validate
+              ansible.builtin.include_role:
+                name: osac.templates.ocp_virt_vm
+                tasks_from: create_validate.yaml
+          rescue:
+            - name: Capture error message
+              ansible.builtin.set_fact:
+                validation_error: "{{ ansible_failed_result.msg | default('') }}"
+                missing_cores_failed: true
+
+            - name: Verify failure was due to missing spec.cores/memoryGiB
+              ansible.builtin.assert:
+                that:
+                  - "'spec.cores and spec.memoryGiB' in validation_error"
+                fail_msg: "Validation failed for unexpected reason: {{ validation_error }}"
+
+        - name: Verify validation failed without spec.cores/memoryGiB
+          ansible.builtin.assert:
+            that:
+              - missing_cores_failed | default(false)
+            fail_msg: >-
+              Expected create_validate to fail when spec.cores/spec.memoryGiB
+              are not set on the ComputeInstance


### PR DESCRIPTION
## Summary
- fulfillment-service ([OSAC-1222](https://redhat.atlassian.net/browse/OSAC-1222)) reserved `cores`/`memory_gib` on `ComputeInstanceSpec` and `ComputeInstanceTemplateSpecDefaults`, making `instance_type` the sole, mandatory way to size a `ComputeInstance` — but the `ocp_virt_vm` AAP role was never updated, so `playbook_osac_config_as_code.yml` currently fails outright (HTTP 400) when registering/updating this compute template, since the private REST gateway's `protojson` unmarshaler rejects unknown fields.
- Removes the stale `cores`/`memory_gib` defaults from the template's `meta/osac.yaml` and role defaults (no `instance_type` default added — callers must specify `instance_type` explicitly), and replaces the old defaulting fallback in `create_validate.yaml` with an explicit required-field check.
- Fixes the same stale field definitions in the shared `find_template_roles.py` schema used by `enumerate_templates`/`publish_templates` to serialize *any* compute template's `spec_defaults` to the API, plus two docs (`AGENTS.md`, `templates/README.md`) that still showed the old `cores`/`memory_gib` shape as the standard pattern for new compute templates.

## Jira
[OSAC-2522](https://redhat.atlassian.net/browse/OSAC-2522)

## Test plan
- [x] `ansible-lint` passes on the changed role and filter plugin
- [x] All 12 `ocp_virt_vm` offline role test scenarios pass (`tests/test.yml`), including a new test verifying `create_validate.yaml` fails fast when `spec.cores`/`spec.memoryGiB` are missing
- [x] Confirmed via code inspection that `osac-operator`'s reconciler still resolves `instance_type` → `spec.cores`/`spec.memoryGiB` on the CR before the AAP job runs, so the role's runtime behavior is otherwise unchanged
- [ ] No test coverage exists for `find_template_roles.py` in this repo (pre-existing gap, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - Compute instance sizing now uses `instance_type` as the required sizing input.
  - VM CPU and memory values are resolved before deployment and must be explicitly available.
  - Deployments fail with guidance when valid sizing information is missing.

- **Documentation**
  - Updated template creation and backend guidance to reflect the `instance_type`-only model.
  - Clarified that CPU and memory values are derived rather than configured as template defaults.

- **Tests**
  - Updated validation scenarios and fixtures for resolved resource sizing.
  - Added coverage for missing CPU or memory configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->