### PR TITLE
NO-ISSUE: fix docs-only path filter for e2e skip

### DIFF
--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -34,19 +34,19 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.docs-only != 'true' }}
+      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
     steps:
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
         if: github.event_name == 'pull_request'
         id: filter
         with:
-          predicate-quantifier: 'every'
           filters: |
-            docs-only:
-              - 'OWNERS'
-              - 'LICENSE'
-              - '*.md'
-              - 'docs/**'
+            code:
+              - '**'
+              - '!OWNERS'
+              - '!LICENSE'
+              - '!*.md'
+              - '!docs/**'
 
   e2e-vmaas-full-install:
     needs: changes


### PR DESCRIPTION
The previous predicate-quantifier:'every' approach was broken — dorny/paths-filter applies 'every' at the pattern level per file (all patterns must match each file), not at the file level (all files must match at least one pattern). This meant docs-only was always false and e2e always ran.

Replace with a negation-based 'code' filter: match everything except OWNERS, LICENSE, *.md, and docs/**. E2e runs only when code files change.

Assisted-by: Claude Code <noreply@anthropic.com>