### PR TITLE
NO-ISSUE: Create capi-provider-role RBAC for Agent-platform HostedClusters

### DIFF
--- a/collections/ansible_collections/ci/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/ci/steps/roles/cluster_infra/tasks/create.yaml
@@ -8,41 +8,6 @@
   retries: 30
   delay: 10
 
-- name: Create CAPI provider RBAC for agent access
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: Role
-      metadata:
-        name: "capi-provider-{{ cluster_infra_name }}"
-        namespace: "{{ hosted_cluster_default_agent_namespace | default('hardware-inventory') }}"
-      rules:
-      - apiGroups: ["agent-install.openshift.io"]
-        resources: ["agents"]
-        verbs: ["get", "list", "watch", "update", "patch"]
-      - apiGroups: [""]
-        resources: ["secrets"]
-        verbs: ["get", "list", "watch"]
-
-- name: Bind CAPI provider to agent namespace
-  kubernetes.core.k8s:
-    state: present
-    definition:
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: RoleBinding
-      metadata:
-        name: "capi-provider-{{ cluster_infra_name }}"
-        namespace: "{{ hosted_cluster_default_agent_namespace | default('hardware-inventory') }}"
-      roleRef:
-        apiGroup: rbac.authorization.k8s.io
-        kind: Role
-        name: "capi-provider-{{ cluster_infra_name }}"
-      subjects:
-      - kind: ServiceAccount
-        name: capi-provider
-        namespace: "{{ cluster_infra_namespace }}-{{ cluster_infra_name }}"
-
 - name: Set skip network flags for CI
   ansible.builtin.set_fact:
     manage_agents_skip_network_detach: true

--- a/collections/ansible_collections/ci/steps/roles/cluster_infra/tasks/delete.yaml
+++ b/collections/ansible_collections/ci/steps/roles/cluster_infra/tasks/delete.yaml
@@ -10,14 +10,3 @@
   vars:
     manage_agents_cluster_order_name: "{{ cluster_infra_name }}"
     manage_agents_idle_agents_network: "unused-in-ci"
-
-- name: Delete CAPI provider RBAC
-  kubernetes.core.k8s:
-    state: absent
-    api_version: rbac.authorization.k8s.io/v1
-    kind: "{{ item }}"
-    name: "capi-provider-{{ cluster_infra_name }}"
-    namespace: "{{ hosted_cluster_default_agent_namespace | default('hardware-inventory') }}"
-  loop:
-    - RoleBinding
-    - Role

--- a/collections/ansible_collections/osac/service/roles/hosted_cluster/tasks/create_hosted_cluster.yaml
+++ b/collections/ansible_collections/osac/service/roles/hosted_cluster/tasks/create_hosted_cluster.yaml
@@ -87,6 +87,29 @@
     state: present
     definition: "{{ hosted_cluster_definition }}"
 
+# HyperShift's Agent-platform CAPI provider requires a Role named exactly
+# "capi-provider-role" in the Agent namespace (agentNamespace above, e.g.
+# "hardware-inventory") -- hypershift-operator creates the matching
+# RoleBinding itself once this Role exists. No "secrets" access is needed:
+# HyperShift's own auto-created "capi-provider" Role in the
+# hosted-control-plane namespace already covers that. See the PR description
+# for supporting references. Centralized here (rather than per-backend under
+# cluster_infra) since every backend needs this identically, and this step
+# always runs before "Create cluster infrastructure".
+- name: Create CAPI provider Role for agent access
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: capi-provider-role
+        namespace: "{{ hosted_cluster_default_agent_namespace }}"
+      rules:
+        - apiGroups: ["agent-install.openshift.io"]
+          resources: ["agents"]
+          verbs: ["*"]
+
 - name: Set nodepool prefix
   ansible.builtin.set_fact:
     nodepool_prefix: "nodepool-{{ hosted_cluster_name }}"


### PR DESCRIPTION
## Summary

HyperShift's Agent-platform CAPI provider (`cluster-api-provider-agent`) requires a `Role` named exactly `capi-provider-role` in the Agent namespace (`hcluster.Spec.Platform.Agent.AgentNamespace`, e.g. `hardware-inventory`), granting access to `agent-install.openshift.io` Agents. Without it, HostedCluster reconciliation fails outright and never progresses:

```
failed to reconcile platform credentials: failed to reconcile Agent RoleBinding: rolebindings.rbac.authorization.k8s.io "capi-provider-role" not found
```

Confirmed via a real live dispatch (osac-test-infra's CaaS/Netris e2e flow) — the HostedCluster got stuck indefinitely at "Waiting for hosted control plane to be healthy".

`ci.steps.cluster_infra` previously attempted to create this Role/RoleBinding in its `create.yaml`/`delete.yaml`, in the correct (Agent) namespace, but with the wrong Role name (`capi-provider-<cluster-name>` instead of the fixed name HyperShift's CLI and reconciler actually look for) and an unnecessary, incorrectly-cross-referenced RoleBinding — so it never actually satisfied HyperShift's reconciler, regardless of which backend was active.

This PR removes that broken attempt and moves a corrected version into `osac.service.hosted_cluster`'s `create_hosted_cluster.yaml` instead, since every backend needs this identically, and "Create hosted cluster" already runs before "Create cluster infrastructure" for every template (confirmed via `osac.templates.ocp_ci_small`'s `install.yaml` step order).

## What changed

- Only the `Role` is created — no `RoleBinding`. `hypershift-operator` creates its own RoleBinding (named `cluster-api-agent-<hcp-namespace>`, also in the Agent namespace) once the Role exists: [agent.go#L136-L165](https://github.com/openshift/hypershift/blob/6142e463a546266c45e90315d99ddcc57d89a5cd/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go#L136-L165) (`ReconcileCredentials`).
- The Role's exact name/namespace/rules match what HyperShift's own CLI generates for the same purpose: [create.go#L109-L129](https://github.com/openshift/hypershift/blob/6142e463a546266c45e90315d99ddcc57d89a5cd/cmd/cluster/agent/create.go#L109-L129).
- No `secrets` access is needed on this Role (dropped from the old, removed version): `cluster-api-provider-agent`'s controllers only ever read/label Secrets scoped to the hosted-control-plane namespace, not the Agent namespace — [agentmachine_controller.go#L80-L87](https://github.com/openshift/cluster-api-provider-agent/blob/79696ce0764acd8ef785073d32c0d39f8ada753e/controllers/agentmachine_controller.go#L80-L87) (RBAC markers; bootstrap-data secret is read from `machine.Namespace`, the HCP namespace) — and HyperShift's own auto-created `capi-provider` Role in the HCP namespace already grants secrets access there in full: [role.yaml](https://github.com/openshift/hypershift/blob/6142e463a546266c45e90315d99ddcc57d89a5cd/control-plane-operator/controllers/hostedcontrolplane/v2/assets/capi-provider/role.yaml).
- No per-cluster deletion is needed or performed: the Role lives in the shared Agent/BMH namespace (not a per-cluster namespace), so it's a static resource used by every HostedCluster in that namespace — deleting it on any single cluster's teardown would break every other cluster still relying on it. HyperShift's own per-cluster cleanup only ever removes the RoleBinding it auto-created, never this Role: [agent.go#L207-L214](https://github.com/openshift/hypershift/blob/6142e463a546266c45e90315d99ddcc57d89a5cd/hypershift-operator/controllers/hostedcluster/internal/platform/agent/agent.go#L207-L214) (`DeleteCredentials`).

## Test plan

- [x] Verified live on a real debug-box HostedCluster: after creating just the Role in the Agent namespace, HostedCluster's `ReconciliationSucceeded` condition flipped to `True` within seconds.
- [x] Confirmed via a fresh `hypershift-operator` restart that this wasn't a caching artifact — a fresh pod's very first reconcile attempt succeeded too.
- [x] `hypershift-operator` auto-created the expected `cluster-api-agent-*` RoleBinding as predicted by the source, with no manual RoleBinding present.
- [x] A real Agent successfully attached to the cluster as a worker node.
- [x] `ansible-lint` and YAML syntax checks pass on all changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Cluster provisioning now waits for the control plane namespace to become available before continuing.
  * Required agent access is configured automatically in the appropriate namespace during hosted-cluster creation.
  * Cluster deletion now performs agent cleanup and network handling more reliably.

* **Bug Fixes**
  * Removed outdated access-resource creation and deletion steps from CI workflows, reducing redundant configuration and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->