### PR TITLE
NO-ISSUE: Double wait_for_clusteroperators timeout budget

### DIFF
--- a/collections/ansible_collections/osac/service/roles/wait_for/defaults/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/wait_for/defaults/main.yaml
@@ -2,7 +2,13 @@ wait_for_dns_retries: 180
 wait_for_dns_delay: 10
 wait_for_cluster_retries: 180
 wait_for_cluster_delay: 10
-wait_for_clusteroperators_retries: 60
+# 30 min (60 * 30s) was confirmed too tight on genuinely fresh/cold EC2
+# hardware via real CI dispatches: TimeoutError on ClusterOrder Ready with
+# last value 'Failed', recurring in ~30% of real dispatches (2 of 7 in one
+# session), while a fully warm debug-box environment completes the entire
+# cluster-creation flow (not just this step) in ~21 min. Doubled to give
+# real headroom for cold-hardware ClusterOperator payload rollout.
+wait_for_clusteroperators_retries: 120
 wait_for_clusteroperators_delay: 30
 wait_for_nodes_retries: 60
 wait_for_nodes_delay: 30


### PR DESCRIPTION
## Summary

Confirmed via 6 parallel real CI dispatches (osac-test-infra `e2e-caas-netris`): 2 of 7 total real dispatches today failed with `TimeoutError` on `ClusterOrder Ready`, last value `'Failed'` — the underlying `HostedCluster` genuinely reconciles successfully, but the AAP job that creates it fails first, because "Wait for all ClusterOperators to become available" (`wait_for_cluster_operators.yaml`) only gets 30 minutes (60 retries × 30s).

A fully warm debug-box environment completes the **entire** cluster-creation flow (not just this one step) in ~21 minutes, so 30 minutes for just the ClusterOperator payload rollout is plausible to exceed on genuinely cold/fresh EC2 hardware where every operator's images need a first-time pull.

## Fix

Doubled `wait_for_clusteroperators_retries` from 60 to 120 (60 minutes total instead of 30).

## Test plan

- [x] YAML syntax + `ansible-lint` pass.
- [ ] Pending: a matching increase to the pytest-side `wait_for_cluster_ready` timeout in `osac-test-infra` (otherwise the test itself would just time out first with a different message), and a follow-up real CI dispatch to confirm the recurrence rate drops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default wait-and-retry window for cluster operator readiness, reducing failures during slower fresh or cold hardware rollouts.
  * Added guidance explaining the expanded retry allowance and rollout timing considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->