### PR TITLE
OSAC-2124: add CaaS agent binding labels reference documentation

### DIFF
--- a/docs/agent-labels.md
+++ b/docs/agent-labels.md
@@ -93,7 +93,7 @@ containing multiple slashes are rejected by the Kubernetes API server.
 
 Keys like these are invalid Kubernetes label keys:
 
-```
+```text
 inventory.agent-install.openshift.io/extra-labels/osac.openshift.io/resource_class=fc430
 ```
 
@@ -120,8 +120,8 @@ inventory file (recommended) or by patching the Agent CR after registration.
 servers:
   - name: node001
     bmc_url: "redfish-virtualmedia+https://192.168.1.21:8000/redfish/v1/Systems/<uuid>"
-    bmc_username: "admin"
-    bmc_password: "password"
+    bmc_username: "<BMC_USERNAME>"
+    bmc_password: "<BMC_PASSWORD>"
     boot_mac: "AA:BB:CC:DD:EE:01"
     netris_server_name: "server-01"
     resource_class: "fc430"
@@ -160,7 +160,7 @@ oc get agent -n hardware-inventory \
 
 ## Label Lifecycle
 
-```
+```text
 1. Server imported (BMH/BCM/NICo playbook)
    -> Agent CR created with: resource_class, netris.server/name (if Netris)
 

--- a/docs/agent-labels.md
+++ b/docs/agent-labels.md
@@ -14,7 +14,7 @@ provisioning to fail silently or stall indefinitely.
 
 | Label Key | Operator Action | Required For |
 |-----------|-----------------|--------------|
-| `osac.openshift.io/resource_class` | Set via inventory | Agent selection and NodePool matching |
+| `osac.openshift.io/resource_class` | Set by import path | Agent selection and NodePool matching |
 
 ### Controller-Managed Labels
 
@@ -32,7 +32,7 @@ Classifies the server's hardware type (e.g., `fc430`, `gpu-large`). Used by
 ClusterOrder's `nodeRequests[].resourceClass`, and by NodePool
 `agentLabelSelector` to bind agents to the correct pool.
 
-**Set by:** All import paths write this label from the inventory:
+**Set by:** Each import path derives this label from its backend-specific source:
 - BMH import (`playbook_osac_import_agents.yml`) - from `server.resource_class`
 - BCM import (`playbook_osac_import_bcm_agents.yml`) - from BCM notes field
 - NICo - from NICo instance type
@@ -145,7 +145,7 @@ servers:
 ```
 
 The import playbook reads `resource_class` and `netris_server_name` from the
-inventory and applies them as properly formatted Kubernetes labels. See
+inventory and applies them as properly-formatted Kubernetes labels. See
 [Bare Metal Agent Import](import-agents.md) for the full inventory format.
 
 **Manual patching (import-time labels only, for debugging or one-off):**

--- a/docs/agent-labels.md
+++ b/docs/agent-labels.md
@@ -1,0 +1,176 @@
+# CaaS Agent Binding Labels
+
+Assisted Installer Agent CRs must carry specific Kubernetes labels for OSAC
+cluster provisioning and scale-out to work. This document is the canonical
+reference for those labels.
+
+## Required Labels
+
+These labels must be present on every Agent CR before a CaaS cluster can be
+provisioned. Missing any of them causes provisioning to fail silently or
+stall indefinitely.
+
+| Label Key | Set By | Required For |
+|-----------|--------|--------------|
+| `osac.openshift.io/resource_class` | Import playbook (BMH, BCM, or NICo) | Agent selection and NodePool matching |
+| `osac.openshift.io/clusterorder` | Provisioning automation (automatic) | HyperShift agent-to-NodePool binding |
+| `netris.server/name` | Import playbook (Netris backend only) | Netris server cluster creation |
+
+### `osac.openshift.io/resource_class`
+
+Classifies the server's hardware type (e.g., `fc430`, `gpu-large`). Used by
+`select_and_label_new_agents` to find available agents matching the
+ClusterOrder's `nodeRequests[].resourceClass`, and by NodePool
+`agentLabelSelector` to bind agents to the correct pool.
+
+**Set by:** All import paths write this label from the inventory:
+- BMH import (`playbook_osac_import_agents.yml`) - from `server.resource_class`
+- BCM import (`playbook_osac_import_bcm_agents.yml`) - from BCM notes field
+- NICo - from NICo instance type
+
+**Defined in:** `group_vars/all/osac_common_labels.yaml` as `agent_resource_class_label`
+
+**If missing:** `select_and_label_new_agents` finds zero matching agents.
+Provisioning fails with _"0 agents were added to the cluster instead of N"_.
+No NodePool binding ever happens.
+
+### `osac.openshift.io/clusterorder`
+
+Binds an agent to a specific ClusterOrder so that HyperShift's CAPI provider
+can select it via the NodePool's `agentLabelSelector`.
+
+**Set by:** The provisioning automation (`select_and_label_new_agents.yml`)
+sets this label automatically when a cluster is created or scaled out.
+Operators do **not** need to set this label manually.
+
+**Defined in:** `group_vars/all/osac_common_labels.yaml` as `cluster_order_label`
+
+**If missing:** HyperShift CAPI never selects the agent. The NodePool stays
+at `NoSuitableAgents` indefinitely.
+
+### `netris.server/name`
+
+Maps the agent to its corresponding Netris server entry. Only required when
+using the Netris network backend.
+
+**Set by:** The BMH import playbook (`playbook_osac_import_agents.yml`) from
+`server.netris_server_name` in the inventory file.
+
+**Defined in:** `group_vars/all/netris.yaml` as `netris_agent_server_name_label`
+
+**If missing (Netris backend):** The Netris server cluster is created with an
+empty server list. Workers are never added to the network segment.
+
+**If missing (non-Netris backend):** No impact. This label is only checked by
+the Netris integration.
+
+## Optional Labels
+
+These labels are set by specific import paths for metadata purposes. They are
+not required for provisioning but may be useful for operations and debugging.
+
+| Label Key | Set By | Purpose |
+|-----------|--------|---------|
+| `osac.openshift.io/rack` | BCM import | Rack position from BCM inventory |
+| `osac.openshift.io/host_uuid` | Various | Host identification |
+| `osac.openshift.io/managed-by` | Import playbooks | Tracks which import playbook manages the BMH/Agent lifecycle |
+
+## Invalid Label Keys (Common Mistake)
+
+Upstream assisted-install documentation uses an
+`inventory.agent-install.openshift.io/extra-labels/` mechanism to set labels
+on Agent CRs. **Do not use this mechanism for OSAC labels.** Label keys
+containing multiple slashes are rejected by the Kubernetes API server.
+
+### What fails
+
+Keys like these are invalid Kubernetes label keys:
+
+```
+inventory.agent-install.openshift.io/extra-labels/osac.openshift.io/resource_class=fc430
+```
+
+The Kubernetes API server rejects the Agent CR mutation entirely because the
+label key `inventory.agent-install.openshift.io/extra-labels/osac.openshift.io/resource_class`
+contains more than one slash. A valid label key has at most one slash
+separating a DNS prefix from the name segment (e.g., `osac.openshift.io/resource_class`).
+
+### Symptoms
+
+- Agent stays in `Pending` with no binding-related error
+- NodePool shows `NoSuitableAgents`
+- No clear error message pointing to the label key format
+
+### Correct Approach
+
+Apply OSAC labels directly on the Agent CR, either through the server
+inventory file (recommended) or by patching the Agent CR after registration.
+
+**Via inventory file (BMH import):**
+
+```yaml
+servers:
+  - name: node001
+    bmc_url: "redfish-virtualmedia+https://192.168.1.21:8000/redfish/v1/Systems/<uuid>"
+    bmc_username: "admin"
+    bmc_password: "password"
+    boot_mac: "AA:BB:CC:DD:EE:01"
+    netris_server_name: "server-01"
+    resource_class: "fc430"
+```
+
+The import playbook reads `resource_class` and `netris_server_name` from the
+inventory and applies them as properly formatted Kubernetes labels. See
+[Bare Metal Agent Import](import-agents.md) for the full inventory format.
+
+**Manual patching (debugging or one-off):**
+
+```bash
+oc label agent/<agent-name> -n hardware-inventory \
+  osac.openshift.io/resource_class=fc430 \
+  netris.server/name=server-01
+```
+
+## Verifying Agent Labels
+
+Check that an agent has the required labels before provisioning:
+
+```bash
+# List all agents with their resource class
+oc get agent -n hardware-inventory \
+  -L osac.openshift.io/resource_class \
+  -L osac.openshift.io/clusterorder
+
+# Check a specific agent's labels
+oc get agent <agent-name> -n hardware-inventory -o json | \
+  jq '.metadata.labels'
+
+# Find agents available for a specific resource class (not yet bound)
+oc get agent -n hardware-inventory \
+  -l "osac.openshift.io/resource_class=fc430,!osac.openshift.io/clusterorder"
+```
+
+## Label Lifecycle
+
+```
+1. Server imported (BMH/BCM/NICo playbook)
+   -> Agent CR created with: resource_class, netris.server/name (if Netris)
+
+2. ClusterOrder submitted, provisioning starts
+   -> select_and_label_new_agents adds: clusterorder
+   -> Agent approved for NodePool binding
+
+3. Cluster deleted or agent removed
+   -> detach_and_unlabel_all_removed_agents removes: clusterorder
+   -> Agent returns to the available pool
+```
+
+## Backend-Specific Details
+
+Each import backend has its own documentation covering the full agent import
+workflow:
+
+- [Bare Metal Agent Import (BMH)](import-agents.md) - BareMetalHost-based import with Ironic
+- [BCM Inventory Integration](bcm-inventory-integration.md) - NVIDIA Base Command Manager import
+- [NICo Integration](nico-integration.md) - NVIDIA NICo bare metal provisioning
+- [Netris Integration](netris-integration.md) - Netris network backend (requires `netris.server/name`)

--- a/docs/agent-labels.md
+++ b/docs/agent-labels.md
@@ -6,14 +6,24 @@ reference for those labels.
 
 ## Required Labels
 
-These labels must be present on every Agent CR for CaaS cluster provisioning
-and scale-out. Missing any applicable label causes provisioning to fail
-silently or stall indefinitely.
+### Import-Time Labels
+
+These labels must be present on every Agent CR **at import time** for CaaS
+cluster provisioning and scale-out. Missing any applicable label causes
+provisioning to fail silently or stall indefinitely.
 
 | Label Key | Operator Action | Required For |
 |-----------|-----------------|--------------|
 | `osac.openshift.io/resource_class` | Set via inventory | Agent selection and NodePool matching |
-| `osac.openshift.io/clusterorder` | Automatic (do not set manually) | HyperShift agent-to-NodePool binding |
+
+### Controller-Managed Labels
+
+These labels are set automatically by provisioning automation. Operators
+should **not** set them manually.
+
+| Label Key | Set By | Required For |
+|-----------|--------|--------------|
+| `osac.openshift.io/clusterorder` | `select_and_label_new_agents` | HyperShift agent-to-NodePool binding |
 
 ### `osac.openshift.io/resource_class`
 
@@ -79,8 +89,14 @@ not required for provisioning but may be useful for operations and debugging.
 | Label Key | Set By | Purpose |
 |-----------|--------|---------|
 | `osac.openshift.io/rack` | BCM import | Rack position from BCM inventory |
-| `osac.openshift.io/host_uuid` | Various | Host identification |
 | `osac.openshift.io/managed-by` | Import playbooks | Tracks which import playbook manages the BMH/Agent lifecycle |
+
+> **Note:** `osac.openshift.io/host_uuid` is an **annotation**, not a label,
+> despite the misleading Ansible variable name `agent_host_uuid_label` in
+> `osac_common_labels.yaml`. It is set under `metadata.annotations` by the ESI
+> filter plugin and read from `metadata.annotations` by the manage_agents and
+> cluster_infra roles. To verify it, check `metadata.annotations`, not
+> `metadata.labels`.
 
 ## Invalid Label Keys (Common Mistake)
 
@@ -111,8 +127,9 @@ separating a DNS prefix from the name segment (e.g., `osac.openshift.io/resource
 
 ### Correct Approach
 
-Apply OSAC labels directly on the Agent CR, either through the server
-inventory file (recommended) or by patching the Agent CR after registration.
+Apply import-time OSAC labels directly on the Agent CR, either through the
+server inventory file (recommended) or by patching the Agent CR after
+registration. Do not manually set controller-managed labels like `clusterorder`.
 
 **Via inventory file (BMH import):**
 
@@ -131,7 +148,7 @@ The import playbook reads `resource_class` and `netris_server_name` from the
 inventory and applies them as properly formatted Kubernetes labels. See
 [Bare Metal Agent Import](import-agents.md) for the full inventory format.
 
-**Manual patching (debugging or one-off):**
+**Manual patching (import-time labels only, for debugging or one-off):**
 
 ```bash
 oc label agent/<agent-name> -n hardware-inventory \

--- a/docs/agent-labels.md
+++ b/docs/agent-labels.md
@@ -6,15 +6,14 @@ reference for those labels.
 
 ## Required Labels
 
-These labels must be present on every Agent CR before a CaaS cluster can be
-provisioned. Missing any of them causes provisioning to fail silently or
-stall indefinitely.
+These labels must be present on every Agent CR for CaaS cluster provisioning
+and scale-out. Missing any applicable label causes provisioning to fail
+silently or stall indefinitely.
 
-| Label Key | Set By | Required For |
-|-----------|--------|--------------|
-| `osac.openshift.io/resource_class` | Import playbook (BMH, BCM, or NICo) | Agent selection and NodePool matching |
-| `osac.openshift.io/clusterorder` | Provisioning automation (automatic) | HyperShift agent-to-NodePool binding |
-| `netris.server/name` | Import playbook (Netris backend only) | Netris server cluster creation |
+| Label Key | Operator Action | Required For |
+|-----------|-----------------|--------------|
+| `osac.openshift.io/resource_class` | Set via inventory | Agent selection and NodePool matching |
+| `osac.openshift.io/clusterorder` | Automatic (do not set manually) | HyperShift agent-to-NodePool binding |
 
 ### `osac.openshift.io/resource_class`
 
@@ -48,10 +47,18 @@ Operators do **not** need to set this label manually.
 **If missing:** HyperShift CAPI never selects the agent. The NodePool stays
 at `NoSuitableAgents` indefinitely.
 
+## Backend-Specific Required Labels
+
+These labels are required only when using a specific network backend.
+
+| Label Key | Operator Action | Backend | Required For |
+|-----------|-----------------|---------|--------------|
+| `netris.server/name` | Set via inventory | Netris | Netris server cluster creation |
+
 ### `netris.server/name`
 
 Maps the agent to its corresponding Netris server entry. Only required when
-using the Netris network backend.
+using the Netris network backend. Not needed for NICo, ESI, or other backends.
 
 **Set by:** The BMH import playbook (`playbook_osac_import_agents.yml`) from
 `server.netris_server_name` in the inventory file.
@@ -90,8 +97,9 @@ Keys like these are invalid Kubernetes label keys:
 inventory.agent-install.openshift.io/extra-labels/osac.openshift.io/resource_class=fc430
 ```
 
-The Kubernetes API server rejects the Agent CR mutation entirely because the
-label key `inventory.agent-install.openshift.io/extra-labels/osac.openshift.io/resource_class`
+The Kubernetes API server rejects the resource update (on the BMH, InfraEnv,
+or Agent CR - whichever carries the invalid key) because the label key
+`inventory.agent-install.openshift.io/extra-labels/osac.openshift.io/resource_class`
 contains more than one slash. A valid label key has at most one slash
 separating a DNS prefix from the name segment (e.g., `osac.openshift.io/resource_class`).
 

--- a/docs/bcm-inventory-integration.md
+++ b/docs/bcm-inventory-integration.md
@@ -226,7 +226,8 @@ a server's resources.
 
 Waits for each node to boot the discovery ISO and register as an Agent (up to
 15 minutes per node). Then labels agents with `resource_class` and `rack`
-metadata from BCM.
+metadata from BCM. See [CaaS Agent Binding Labels](agent-labels.md) for the
+full label reference.
 
 ## Removing Nodes
 

--- a/docs/import-agents.md
+++ b/docs/import-agents.md
@@ -53,6 +53,9 @@ coordination between BareMetalHost and Agent CRs:
 - BMAC links the Agent to the BMH via the `agent-install.openshift.io/bmh` label
 - The playbook then labels the Agent with resource class and Netris metadata
 
+For the full list of required and optional Agent CR labels, see
+[CaaS Agent Binding Labels](agent-labels.md).
+
 ## Prerequisites
 
 ### Baremetal Operator with watchAllNamespaces

--- a/docs/netris-integration.md
+++ b/docs/netris-integration.md
@@ -153,6 +153,9 @@ You need `KUBECONFIG` pointing to the hub OpenShift cluster where:
   - `osac.openshift.io/resource_class` — the server's resource class
   - `netris.server/name` — the corresponding Netris server name
 
+  See [CaaS Agent Binding Labels](agent-labels.md) for the full label
+  reference, including common mistakes to avoid.
+
 ### Netris Infrastructure
 
 The following must be in place in your Netris environment before running the

--- a/docs/nico-integration.md
+++ b/docs/nico-integration.md
@@ -317,6 +317,9 @@ NICo agents are **ephemeral** — they are created when instances boot and delet
 - **Detachment**: NodePool scaled down -> HyperShift removes `clusterdeployment-namespace`
 - **Deletion**: Agent CR is deleted after detachment to prevent stale agent conflicts
 
+See [CaaS Agent Binding Labels](agent-labels.md) for the full label
+reference and common mistakes to avoid.
+
 ### Scale-Down Protection
 
 During scale-down, agents without `clusterdeployment-namespace` could be either:


### PR DESCRIPTION
## [OSAC-2124](https://redhat.atlassian.net/browse/OSAC-2124): add CaaS agent binding labels reference documentation

**Jira:** https://redhat.atlassian.net/browse/OSAC-2124

### Summary

CaaS cluster provisioning and scale-out require specific Kubernetes labels on Agent CRs, but no canonical reference existed. Operators following upstream assisted-install examples often apply labels with invalid slash-key formats that are silently rejected by the Kubernetes API server, leaving agents permanently unbound with no clear error.

This PR adds an authoritative `docs/agent-labels.md` reference and cross-links it from all four backend-specific integration docs.

### Changes

- **`docs/agent-labels.md`** (new) - canonical reference covering:
  - Required labels (`resource_class`, `clusterorder`, `netris.server/name`) with failure modes when missing
  - Optional/informational labels (`rack`, `host_uuid`, `managed-by`)
  - Anti-pattern warning for `inventory.agent-install.openshift.io/extra-labels/` slash keys
  - Correct label application examples (inventory file and manual patching)
  - Verification commands for checking agent labels
  - Label lifecycle diagram (import -> provisioning -> deletion)
- **`docs/import-agents.md`** - added cross-link to agent-labels.md
- **`docs/netris-integration.md`** - added cross-link to agent-labels.md
- **`docs/bcm-inventory-integration.md`** - added cross-link to agent-labels.md
- **`docs/nico-integration.md`** - added cross-link to agent-labels.md

### Testing

- **Unit tests:** N/A - documentation only
- **Integration tests:** N/A
- **Validation:** ansible-lint and pre-commit hooks pass

### Acceptance Criteria

- [x] AC-1: Official docs list required/optional agent labels for CaaS cluster create and scale-out
- [x] AC-2: Docs warn against `inventory.agent-install.openshift.io/extra-labels/` slash keys that fail K8s validation
- [x] AC-3: Docs linked from CaaS provisioning sections (osac-aap internal docs; external `osac-project/docs` cross-link requires a follow-up PR)
- [ ] AC-4: (Optional, deferred) Agent label validation at approval time - scoped as "v2 if docs-only sufficient"

### Note

AC-3 is partially satisfied: all osac-aap internal docs link to the new reference. A follow-up PR to `osac-project/docs` is needed to add a cross-link from `architecture/cluster-fulfillment.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a canonical reference describing required and optional CaaS Agent label requirements, including backend-specific labeling and common misconfiguration scenarios.
  * Documented label lifecycle behavior during import/provisioning and removal on cluster deletion, along with verification steps for listing and inspecting agents.
  * Updated inventory import and backend integration guides to cross-reference the label reference for clearer, consistent guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->