### PR TITLE
OSAC-2816: accept list and dict defaults in template parameter validation

### DIFF
--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -80,6 +80,8 @@ TypeMapping: dict[AnsibleArgumentType | type, ProtobufType] = {
     str: ProtobufType.STRING,
     "list": ProtobufType.ANY,
     "dict": ProtobufType.ANY,
+    list: ProtobufType.ANY,
+    dict: ProtobufType.ANY,
     "bool": ProtobufType.BOOL,
     bool: ProtobufType.BOOL,
     "int": ProtobufType.INT,
@@ -163,9 +165,9 @@ class TemplateParameter(Base):
         type to the protobuf type string via the `TypeMapping` table, and then
         storing the actual value in the "value" key.
 
-        Note that we only handle scalar values; an attempt to use something
-        other than a string, bool, float, or int will result in a validation
-        error.
+        Scalar values are mapped to their specific protobuf wrappers
+        (StringValue, BoolValue, etc.) while list and dict values are
+        mapped to google.protobuf.Value (ANY).
 
         [1]: https://raw.githubusercontent.com/osac-project/fulfillment-api/refs/heads/main/openapi/v3/openapi.yaml
         """
@@ -254,7 +256,7 @@ class TemplateParameterDefinition(Base):
     description: str | None = None
     type: str = "string"
     required: bool = False
-    default: str | int | float | bool | None = None
+    default: str | int | float | bool | list[Any] | dict[str, Any] | None = None
     validation: ParameterValidation | None = None
 
 

--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -176,7 +176,8 @@ class TemplateParameter(Base):
                 return ProtobufAnyValue(type=TypeMapping[type(value)], value=value)
             except KeyError as err:
                 raise ValueError(
-                    f"Unsupported default value type: {err}")
+                    f"Unsupported default value type: {err}") from None
+        return None
 
 
 class NodeRequest(Base):

--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -176,7 +176,7 @@ class TemplateParameter(Base):
                 return ProtobufAnyValue(type=TypeMapping[type(value)], value=value)
             except KeyError as err:
                 raise ValueError(
-                    f"Default values must be scalar type, not {err}")
+                    f"Unsupported default value type: {err}")
 
 
 class NodeRequest(Base):


### PR DESCRIPTION
## Summary

The `find_template_roles.py` pydantic filter plugin silently skips `ocp_4_20_ai_maas` during template discovery because its `hardware_profiles` and `external_models` parameters have `default: []`, which the validator rejects.

**How we got here:**
- [OSAC-1818](https://redhat.atlassian.net/browse/OSAC-1818) (Jul 9) added `hardware_profiles` and `external_models` as `type: list` parameters without defaults
- f7707518 (Jul 15, Elad) added `default: []` to both parameters so `publish_templates` could satisfy the [OSAC-1416](https://redhat.atlassian.net/browse/OSAC-1416) `field_definitions` validation that rejects non-editable fields without a default
- But `TemplateParameterDefinition.default` only accepted `str | int | float | bool | None`, so pydantic rejects the list and the entire template is dropped with a warning

**Fix (1 file, 3 changes):**
- Extend `TemplateParameterDefinition.default` type to include `list[Any]` and `dict[str, Any]`
- Add Python `list` and `dict` built-in types to `TypeMapping` → `ProtobufType.ANY` (the string keys `"list"`/`"dict"` already existed but `validate_default` uses `type(value)` which returns the Python type, not the string)
- Update `validate_default` docstring

**Verified:** running the filter locally now produces `ocp_4_20_ai_maas` with correctly serialized defaults:
```json
{"@type": "type.googleapis.com/google.protobuf.Value", "value": []}
```

No fulfillment-service changes needed — `google.protobuf.Any` wrapping `google.protobuf.Value` already supports list/dict natively.

## Test plan

- [x] `python find_template_roles.py --type cluster osac.templates` — `ocp_4_20_ai_maas` appears with correct defaults
- [x] `ansible-lint` passes
- [ ] CI integration tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template parameters now accept list and dictionary values as defaults, alongside existing scalar defaults.
  * Complex YAML default values are mapped and validated consistently when converted for downstream use.

* **Documentation**
  * Updated guidance to clarify how scalar defaults map to specific types, while list/dict defaults are treated generically.  

* **Bug Fixes**
  * Improved validation messaging for unsupported default value types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->