### PR TITLE
fix: support list/dict defaults in template parameter discovery

### DIFF
--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -79,7 +79,9 @@ TypeMapping: dict[AnsibleArgumentType | type, ProtobufType] = {
     "str": ProtobufType.STRING,
     str: ProtobufType.STRING,
     "list": ProtobufType.ANY,
+    list: ProtobufType.ANY,
     "dict": ProtobufType.ANY,
+    dict: ProtobufType.ANY,
     "bool": ProtobufType.BOOL,
     bool: ProtobufType.BOOL,
     "int": ProtobufType.INT,
@@ -254,7 +256,7 @@ class TemplateParameterDefinition(Base):
     description: str | None = None
     type: str = "string"
     required: bool = False
-    default: str | int | float | bool | None = None
+    default: str | int | float | bool | list | dict | None = None
     validation: ParameterValidation | None = None
 
 

--- a/collections/ansible_collections/osac/service/roles/enumerate_templates/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/enumerate_templates/tests/test.yml
@@ -118,6 +118,61 @@
       when: test_discover_all | default(false) | bool
 
 # ──────────────────────────────────────────────────────────────
+# Test 5: List defaults -- ocp_4_20_ai_maas has parameters with default: []
+# Expected: template is discovered without validation errors, list defaults
+# are serialized as google.protobuf.Value (ProtobufType.ANY)
+# ──────────────────────────────────────────────────────────────
+- name: "Test enumerate_templates -- list defaults (ocp_4_20_ai_maas)"
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run enumerate_templates role with default collection
+      ansible.builtin.include_role:
+        name: osac.service.enumerate_templates
+      vars:
+        osac_template_collections:
+          - osac.templates
+      when: test_list_defaults | default(false) | bool
+
+    - name: Verify ocp_4_20_ai_maas is discovered despite list defaults
+      ansible.builtin.assert:
+        that:
+          - osac_cluster_templates | selectattr('id', 'equalto', 'osac.templates.ocp_4_20_ai_maas') | list | length == 1
+        fail_msg: >-
+          ocp_4_20_ai_maas not found — list defaults (default: []) likely caused
+          a pydantic validation error and the template was silently skipped.
+          Found: {{ osac_cluster_templates | map(attribute='id') | list }}
+        success_msg: "ocp_4_20_ai_maas discovered successfully"
+      when: test_list_defaults | default(false) | bool
+
+    - name: Get ocp_4_20_ai_maas template
+      ansible.builtin.set_fact:
+        maas_template: >-
+          {{ osac_cluster_templates | selectattr('id', 'equalto', 'osac.templates.ocp_4_20_ai_maas') | first }}
+      when: test_list_defaults | default(false) | bool
+
+    - name: Verify hardware_profiles parameter has list default serialized as protobuf Any
+      ansible.builtin.assert:
+        that:
+          - maas_template.parameters | selectattr('name', 'equalto', 'hardware_profiles') | list | length == 1
+          - (maas_template.parameters | selectattr('name', 'equalto', 'hardware_profiles') | first).default['@type'] == 'type.googleapis.com/google.protobuf.Value'
+          - (maas_template.parameters | selectattr('name', 'equalto', 'hardware_profiles') | first).default.value == []
+        fail_msg: "hardware_profiles default not serialized correctly"
+        success_msg: "hardware_profiles list default correctly serialized as google.protobuf.Value"
+      when: test_list_defaults | default(false) | bool
+
+    - name: Verify external_models parameter has list default serialized as protobuf Any
+      ansible.builtin.assert:
+        that:
+          - maas_template.parameters | selectattr('name', 'equalto', 'external_models') | list | length == 1
+          - (maas_template.parameters | selectattr('name', 'equalto', 'external_models') | first).default['@type'] == 'type.googleapis.com/google.protobuf.Value'
+          - (maas_template.parameters | selectattr('name', 'equalto', 'external_models') | first).default.value == []
+        fail_msg: "external_models default not serialized correctly"
+        success_msg: "external_models list default correctly serialized as google.protobuf.Value"
+      when: test_list_defaults | default(false) | bool
+
+# ──────────────────────────────────────────────────────────────
 # Test 2: Nonexistent collection -- should return empty lists
 # Expected: role succeeds, all lists are empty
 # ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- \`TypeMapping\` had string keys (\`"list"\`, \`"dict"\`) for Ansible arg type names but was missing the Python runtime type keys (\`list\`, \`dict\`). \`validate_default\` calls \`TypeMapping[type(value)]\` — when \`value = []\`, \`type([])\` is Python's \`list\`, not the string \`"list"\`, causing a \`KeyError\` and silently skipping the entire template.
- Updated \`TemplateParameterDefinition.default\` to accept \`list | dict\` so pydantic doesn't reject these values before the validator runs.
- Adds a regression test verifying \`ocp_4_20_ai_maas\` (which has \`hardware_profiles\` and \`external_models\` with \`default: []\`) is correctly discovered and serialized as \`google.protobuf.Value\`.

## Jira
N/A

## Test plan
- [x] New \`test_list_defaults\` test passes locally
- [x] Verified \`osac-publish-templates\` job now registers \`osac.templates.ocp_4_20_ai_maas\` in the deployed cluster (was silently skipped before)
- [x] \`ansible-lint\` passes (0 failures)
- [x] Existing \`test_discover_all\` test unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template parameters now support list and dictionary default values.
  * Empty list defaults are correctly preserved when templates are discovered and serialized.
  * Improved handling of flexible parameter types through generic value mapping.

* **Tests**
  * Added coverage for template discovery with empty list defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->