### PR TITLE
OSAC-2920: Add BMaaS E2E caller workflow

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -1,0 +1,73 @@
+---
+name: E2E BMaaS Full Install
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      test-suite:
+        description: "Test suite (bmaas, or empty for all)"
+        required: false
+        default: "bmaas"
+      test-filter:
+        description: "pytest -k filter"
+        required: false
+        default: ""
+      test-infra-ref:
+        description: "Branch/ref of osac-test-infra"
+        required: false
+        default: "main"
+
+concurrency:
+  group: e2e-bmaas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!OWNERS'
+              - '!LICENSE'
+              - '!*.md'
+              - '!docs/**'
+
+  e2e-bmaas-full-install:
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-bmaas-full-install.yml@main
+    with:
+      test-suite: ${{ inputs.test-suite || 'bmaas' }}
+      test-filter: ${{ inputs.test-filter || '' }}
+      component-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      component-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      component-image-key: aap.bootstrap.image
+      component-build-type: ansible-builder
+      component-containerfile: execution-environment/execution-environment.yaml
+      fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
+      fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
+      pr-number: ${{ github.event.pull_request.number }}
+      test-infra-repository: osac-project/osac-test-infra
+      test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+
+  e2e:
+    if: always()
+    needs: [changes, e2e-bmaas-full-install]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## [OSAC-2920](https://redhat.atlassian.net/browse/OSAC-2920): Add BMaaS E2E caller workflow

**Jira:** https://redhat.atlassian.net/browse/OSAC-2920

### Summary

Adds a cross-repo caller workflow that invokes the reusable BMaaS E2E workflow in
osac-test-infra. On PRs, builds the osac-aap execution environment image from the PR
branch via ansible-builder and injects it via the `aap.bootstrap.image` Helm value
path, then runs the BMaaS E2E test suite against a live cluster with the PR's code
deployed.

### Changes

- Add `.github/workflows/e2e-bmaas-full-install.yml` mirroring the existing VMaaS E2E caller
- Triggers: `pull_request`, `workflow_dispatch`
- Uses `ansible-builder` build type with `execution-environment/execution-environment.yaml`
- Path filtering via `dorny/paths-filter` to skip docs-only PRs
- Fork PR authorization support
- Status gate `e2e` job for branch protection

### Related PRs

- osac-project/fulfillment-service#940
- osac-project/osac-operator#370
- osac-project/bare-metal-fulfillment-operator#71
- osac-project/osac-installer#450

### Acceptance Criteria

- [x] Repos that can affect bare metal provisioning should at least optionally be able to run the BMaaS E2E tests