### PR TITLE
OSAC-1589: add KubeVirt CaaS cluster template with tenant networking

### DIFF
--- a/collections/ansible_collections/osac/service/roles/extract_template_info/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/extract_template_info/tasks/main.yaml
@@ -21,3 +21,14 @@
     node_requests is not defined
   ansible.builtin.set_fact:
     node_requests: "{{ cluster_order.spec.nodeRequests }}"
+
+- name: Bridge networkAttachments into template parameters
+  when:
+    - cluster_order.spec.networkAttachments is defined
+    - cluster_order.spec.networkAttachments | length > 0
+    - template_parameters.subnet_ref is not defined or template_parameters.subnet_ref | length == 0
+  ansible.builtin.set_fact:
+    template_parameters: >-
+      {{ template_parameters | combine({
+        'subnet_ref': cluster_order.spec.networkAttachments[0].subnetRef
+      }) }}

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/defaults/main.yaml
@@ -3,7 +3,7 @@ ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.22.0-multi
 
 ocp_4_22_kubevirt_worker_cores: 4
 ocp_4_22_kubevirt_worker_memory: "16Gi"
-ocp_4_22_kubevirt_root_volume_size: "50Gi"
+ocp_4_22_kubevirt_root_volume_size: "64Gi"
 ocp_4_22_kubevirt_root_volume_storage_class: ""
 ocp_4_22_kubevirt_base_domain_passthrough: true
 ocp_4_22_kubevirt_subnet_ref: ""

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/defaults/main.yaml
@@ -6,3 +6,5 @@ ocp_4_22_kubevirt_worker_memory: "16Gi"
 ocp_4_22_kubevirt_root_volume_size: "50Gi"
 ocp_4_22_kubevirt_root_volume_storage_class: ""
 ocp_4_22_kubevirt_base_domain_passthrough: true
+ocp_4_22_kubevirt_subnet_ref: ""
+ocp_4_22_kubevirt_subnet_cidr: "10.200.0.0/24"

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/defaults/main.yaml
@@ -1,0 +1,8 @@
+---
+ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.22.0-multi
+
+ocp_4_22_kubevirt_worker_cores: 4
+ocp_4_22_kubevirt_worker_memory: "16Gi"
+ocp_4_22_kubevirt_root_volume_size: "50Gi"
+ocp_4_22_kubevirt_root_volume_storage_class: ""
+ocp_4_22_kubevirt_base_domain_passthrough: true

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/meta/osac.yaml
@@ -49,3 +49,20 @@ parameters:
     type: boolean
     required: false
     default: true
+  - name: subnet_ref
+    title: Subnet Reference
+    description: >
+      Name of the OSAC Subnet to connect worker VMs to. A Secondary
+      Layer2 CUDN is created and worker VMs get an additional network
+      interface on this subnet. If empty, workers use only the default
+      pod network.
+    type: string
+    required: false
+  - name: subnet_cidr
+    title: Subnet CIDR
+    description: >
+      CIDR for the worker VM subnet when creating a new secondary
+      network. Only used when subnet_ref is set.
+    type: string
+    required: false
+    default: "10.200.0.0/24"

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/meta/osac.yaml
@@ -32,7 +32,7 @@ parameters:
       Size of the persistent root volume for each KubeVirt worker VM.
     type: string
     required: false
-    default: "50Gi"
+    default: "64Gi"
   - name: root_volume_storage_class
     title: Root Volume Storage Class
     description: >

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/meta/osac.yaml
@@ -1,0 +1,51 @@
+---
+title: OpenShift 4.22 Cluster (KubeVirt Workers)
+description: >
+  Builds an OpenShift 4.22 cluster with KubeVirt VM-based worker nodes
+  using Hosted Control Planes. Worker nodes run as VMs on the management
+  cluster via OpenShift Virtualization, enabling fast provisioning without
+  dedicated bare metal.
+template_type: cluster
+implementation_strategy: ocp_4_22_kubevirt
+default_node_request:
+  - resourceClass: kubevirt
+    numberOfNodes: 2
+allowed_resource_classes: []
+parameters:
+  - name: worker_cores
+    title: Worker vCPU Cores
+    description: >
+      Number of vCPU cores for each KubeVirt worker VM.
+    type: integer
+    required: false
+    default: 4
+  - name: worker_memory
+    title: Worker Memory
+    description: >
+      Amount of memory for each KubeVirt worker VM (e.g., 8Gi, 16Gi).
+    type: string
+    required: false
+    default: "16Gi"
+  - name: root_volume_size
+    title: Root Volume Size
+    description: >
+      Size of the persistent root volume for each KubeVirt worker VM.
+    type: string
+    required: false
+    default: "50Gi"
+  - name: root_volume_storage_class
+    title: Root Volume Storage Class
+    description: >
+      StorageClass used for the worker VM root volumes. If empty, the
+      cluster default StorageClass is used.
+    type: string
+    required: false
+  - name: base_domain_passthrough
+    title: Base Domain Passthrough
+    description: >
+      When true, the guest cluster base domain is auto-generated as a
+      subdomain of the management cluster's *.apps DNS using wildcard
+      routes. Set to false when configuring a custom base domain.
+    type: boolean
+    required: false
+    default: true

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/create_secondary_network.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/create_secondary_network.yaml
@@ -1,0 +1,67 @@
+---
+# Creates a Secondary Layer2 CUDN for KubeVirt worker VMs.
+# The CUDN auto-creates a NAD in namespaces matching the selector.
+# We label the HostedCluster's control plane namespace so the NAD is
+# created there — multus namespace isolation blocks cross-namespace
+# NAD references on OCP 4.22.
+# Skipped when ocp_4_22_kubevirt_subnet_ref is empty.
+
+- name: Skip secondary network creation when no subnet is configured
+  ansible.builtin.debug:
+    msg: "No subnet_ref configured, workers will use default pod network only"
+  when: ocp_4_22_kubevirt_subnet_ref | length == 0
+
+- name: Create secondary network for KubeVirt workers
+  when: ocp_4_22_kubevirt_subnet_ref | length > 0
+  block:
+    - name: Set secondary network resource names
+      ansible.builtin.set_fact:
+        kubevirt_cudn_name: "{{ ocp_4_22_kubevirt_subnet_ref }}-secondary"
+        kubevirt_cluster_namespace: "clusters-{{ cluster_order.metadata.name }}"
+
+    - name: Create Secondary Layer2 CUDN for worker VM networking
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: k8s.ovn.org/v1
+          kind: ClusterUserDefinedNetwork
+          metadata:
+            name: "{{ kubevirt_cudn_name }}"
+          spec:
+            namespaceSelector:
+              matchLabels:
+                osac.openshift.io/kubevirt-network: "{{ ocp_4_22_kubevirt_subnet_ref }}"
+            network:
+              topology: Layer2
+              layer2:
+                role: Secondary
+                subnets:
+                  - "{{ ocp_4_22_kubevirt_subnet_cidr }}"
+                ipam:
+                  lifecycle: Persistent
+
+    - name: Label HostedCluster namespace for CUDN NAD placement
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: "{{ kubevirt_cluster_namespace }}"
+            labels:
+              osac.openshift.io/kubevirt-network: "{{ ocp_4_22_kubevirt_subnet_ref }}"
+
+    - name: Wait for NAD to be created in HostedCluster namespace
+      kubernetes.core.k8s_info:
+        api_version: k8s.cni.cncf.io/v1
+        kind: NetworkAttachmentDefinition
+        namespace: "{{ kubevirt_cluster_namespace }}"
+        name: "{{ kubevirt_cudn_name }}"
+      register: kubevirt_nad_result
+      until: kubevirt_nad_result.resources | length > 0
+      retries: 12
+      delay: 5
+
+    - name: Set NAD reference for NodePool additionalNetworks
+      ansible.builtin.set_fact:
+        kubevirt_additional_network_ref: "{{ kubevirt_cluster_namespace }}/{{ kubevirt_cudn_name }}"

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/delete.yaml
@@ -14,3 +14,8 @@
     delete_step_external_access_override:
       name: osac.templates.ocp_4_22_kubevirt
       tasks_from: noop.yaml
+
+- name: Clean up secondary network
+  ansible.builtin.include_role:
+    name: osac.templates.ocp_4_22_kubevirt
+    tasks_from: delete_secondary_network.yaml

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/delete.yaml
@@ -1,0 +1,16 @@
+---
+# Delete a KubeVirt-backed cluster.
+# Delegates to ocp_4_17_small delete with cluster_infra and external_access
+# steps replaced by noops (KubeVirt has no bare-metal infra to tear down).
+
+- name: Delete cluster with KubeVirt overrides
+  ansible.builtin.include_role:
+    name: osac.templates.ocp_4_17_small
+    tasks_from: delete
+  vars:
+    delete_step_cluster_infra_override:
+      name: osac.templates.ocp_4_22_kubevirt
+      tasks_from: noop.yaml
+    delete_step_external_access_override:
+      name: osac.templates.ocp_4_22_kubevirt
+      tasks_from: noop.yaml

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/delete_secondary_network.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/delete_secondary_network.yaml
@@ -1,0 +1,18 @@
+---
+# Deletes the Secondary Layer2 CUDN created for KubeVirt worker VMs.
+# Skipped when ocp_4_22_kubevirt_subnet_ref is empty.
+
+- name: Skip secondary network deletion when no subnet is configured
+  ansible.builtin.debug:
+    msg: "No subnet_ref configured, nothing to clean up"
+  when: ocp_4_22_kubevirt_subnet_ref | length == 0
+
+- name: Delete secondary network for KubeVirt workers
+  when: ocp_4_22_kubevirt_subnet_ref | length > 0
+  block:
+    - name: Delete Secondary CUDN
+      kubernetes.core.k8s:
+        state: absent
+        api_version: k8s.ovn.org/v1
+        kind: ClusterUserDefinedNetwork
+        name: "{{ ocp_4_22_kubevirt_subnet_ref }}-secondary"

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/install.yaml
@@ -13,7 +13,14 @@
     ocp_4_22_kubevirt_root_volume_size: "{{ template_parameters.root_volume_size | default(ocp_4_22_kubevirt_root_volume_size) }}"
     ocp_4_22_kubevirt_root_volume_storage_class: "{{ template_parameters.root_volume_storage_class | default(ocp_4_22_kubevirt_root_volume_storage_class) }}"
     ocp_4_22_kubevirt_base_domain_passthrough: "{{ template_parameters.base_domain_passthrough | default(ocp_4_22_kubevirt_base_domain_passthrough) | bool }}"
+    ocp_4_22_kubevirt_subnet_ref: "{{ template_parameters.subnet_ref | default(ocp_4_22_kubevirt_subnet_ref) }}"
+    ocp_4_22_kubevirt_subnet_cidr: "{{ template_parameters.subnet_cidr | default(ocp_4_22_kubevirt_subnet_cidr) }}"
   when: template_parameters is defined
+
+- name: Create secondary network for worker VMs
+  ansible.builtin.include_role:
+    name: osac.templates.ocp_4_22_kubevirt
+    tasks_from: create_secondary_network.yaml
 
 - name: Create cluster with KubeVirt VM workers
   ansible.builtin.include_role:

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/install.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/install.yaml
@@ -1,0 +1,35 @@
+---
+# Entry point: creates an OpenShift cluster with KubeVirt VM workers.
+# Delegates cluster creation to ocp_4_17_small and overrides:
+# - hosted_cluster_modify_definition_hook: sets platform.type to KubeVirt
+# - nodepool_modify_definitions_hook: sets KubeVirt compute/rootVolume
+# - cluster_infra step: noop (no bare-metal provisioning)
+# - external_access step: noop (KubeVirt uses baseDomainPassthrough)
+
+- name: Bridge templateParameters to role variables
+  ansible.builtin.set_fact:
+    ocp_4_22_kubevirt_worker_cores: "{{ template_parameters.worker_cores | default(ocp_4_22_kubevirt_worker_cores) | int }}"
+    ocp_4_22_kubevirt_worker_memory: "{{ template_parameters.worker_memory | default(ocp_4_22_kubevirt_worker_memory) }}"
+    ocp_4_22_kubevirt_root_volume_size: "{{ template_parameters.root_volume_size | default(ocp_4_22_kubevirt_root_volume_size) }}"
+    ocp_4_22_kubevirt_root_volume_storage_class: "{{ template_parameters.root_volume_storage_class | default(ocp_4_22_kubevirt_root_volume_storage_class) }}"
+    ocp_4_22_kubevirt_base_domain_passthrough: "{{ template_parameters.base_domain_passthrough | default(ocp_4_22_kubevirt_base_domain_passthrough) | bool }}"
+  when: template_parameters is defined
+
+- name: Create cluster with KubeVirt VM workers
+  ansible.builtin.include_role:
+    name: osac.templates.ocp_4_17_small
+    tasks_from: install
+  vars:
+    ocp_release_image: "{{ ocp_release_image }}"
+    hosted_cluster_modify_definition_hook:
+      name: osac.templates.ocp_4_22_kubevirt
+      tasks_from: modify_hosted_cluster.yaml
+    nodepool_modify_definitions_hook:
+      name: osac.templates.ocp_4_22_kubevirt
+      tasks_from: modify_nodepools.yaml
+    install_step_cluster_infra_override:
+      name: osac.templates.ocp_4_22_kubevirt
+      tasks_from: noop.yaml
+    install_step_external_access_override:
+      name: osac.templates.ocp_4_22_kubevirt
+      tasks_from: noop.yaml

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/modify_hosted_cluster.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/modify_hosted_cluster.yaml
@@ -1,0 +1,74 @@
+---
+# Hook task: replace Agent platform with KubeVirt in the HostedCluster definition.
+# Called via hosted_cluster_modify_definition_hook after the base definition is built.
+# Mutates the hosted_cluster_definition fact in place.
+
+- name: Look up management cluster apps domain
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: kubevirt_ingress_config
+
+- name: Set management cluster apps domain
+  ansible.builtin.set_fact:
+    kubevirt_mgmt_apps_domain: "{{ kubevirt_ingress_config.resources[0].spec.domain }}"
+
+- name: Build KubeVirt service publishing strategies
+  ansible.builtin.set_fact:
+    kubevirt_services:
+      - service: APIServer
+        servicePublishingStrategy:
+          type: Route
+          route:
+            hostname: "api-{{ hosted_cluster_definition.metadata.name }}.{{ kubevirt_mgmt_apps_domain }}"
+      - service: OAuthServer
+        servicePublishingStrategy:
+          type: Route
+      - service: OIDC
+        servicePublishingStrategy:
+          type: Route
+      - service: Konnectivity
+        servicePublishingStrategy:
+          type: Route
+      - service: Ignition
+        servicePublishingStrategy:
+          type: Route
+
+- name: Set KubeVirt platform on HostedCluster
+  ansible.builtin.set_fact:
+    hosted_cluster_definition: >-
+      {{ hosted_cluster_definition | combine({
+        'spec': hosted_cluster_definition.spec | combine({
+          'platform': {
+            'type': 'KubeVirt',
+            'kubevirt': {
+              'baseDomainPassthrough': ocp_4_22_kubevirt_base_domain_passthrough | bool
+            }
+          },
+          'services': kubevirt_services,
+          'etcd': {
+            'managementType': 'Managed',
+            'managed': {
+              'storage': {
+                'type': 'PersistentVolume',
+                'persistentVolume': {
+                  'size': '4Gi'
+                }
+              }
+            }
+          }
+        })
+      }, recursive=true) }}
+
+- name: Remove dns section when using baseDomainPassthrough
+  ansible.builtin.set_fact:
+    hosted_cluster_definition: >-
+      {{ hosted_cluster_definition | combine({
+        'spec': hosted_cluster_definition.spec
+          | dict2items
+          | rejectattr('key', 'equalto', 'dns')
+          | list
+          | items2dict
+      }, recursive=true) }}
+  when: ocp_4_22_kubevirt_base_domain_passthrough | bool

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/modify_nodepools.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/modify_nodepools.yaml
@@ -5,15 +5,30 @@
 
 - name: Build KubeVirt platform spec for NodePools
   ansible.builtin.set_fact:
-    kubevirt_nodepool_platform:
-      type: KubeVirt
-      kubevirt:
-        compute:
-          cores: "{{ ocp_4_22_kubevirt_worker_cores | int }}"
-          memory: "{{ ocp_4_22_kubevirt_worker_memory }}"
-        rootVolume:
-          type: Persistent
-          persistent: "{{ kubevirt_persistent_spec }}"
+    kubevirt_nodepool_platform: >-
+      {{
+        {
+          'type': 'KubeVirt',
+          'kubevirt': {
+            'compute': {
+              'cores': ocp_4_22_kubevirt_worker_cores | int,
+              'memory': ocp_4_22_kubevirt_worker_memory
+            },
+            'rootVolume': {
+              'type': 'Persistent',
+              'persistent': kubevirt_persistent_spec
+            }
+          }
+        }
+        | combine(
+            (kubevirt_additional_network_ref is defined and kubevirt_additional_network_ref | length > 0)
+            | ternary(
+                {'kubevirt': {'additionalNetworks': [{'name': kubevirt_additional_network_ref}]}},
+                {}
+              ),
+            recursive=true
+          )
+      }}
   vars:
     kubevirt_persistent_spec: >-
       {{

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/modify_nodepools.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/modify_nodepools.yaml
@@ -1,0 +1,32 @@
+---
+# Hook task: replace Agent platform with KubeVirt in NodePool definitions.
+# Called via nodepool_modify_definitions_hook after base definitions are built.
+# Mutates the nodepool_definitions fact in place.
+
+- name: Build KubeVirt platform spec for NodePools
+  ansible.builtin.set_fact:
+    kubevirt_nodepool_platform:
+      type: KubeVirt
+      kubevirt:
+        compute:
+          cores: "{{ ocp_4_22_kubevirt_worker_cores | int }}"
+          memory: "{{ ocp_4_22_kubevirt_worker_memory }}"
+        rootVolume:
+          type: Persistent
+          persistent: "{{ kubevirt_persistent_spec }}"
+  vars:
+    kubevirt_persistent_spec: >-
+      {{
+        {'size': ocp_4_22_kubevirt_root_volume_size}
+        | combine(
+            (ocp_4_22_kubevirt_root_volume_storage_class | length > 0)
+            | ternary({'storageClass': ocp_4_22_kubevirt_root_volume_storage_class}, {})
+          )
+      }}
+
+- name: Set KubeVirt platform on NodePool definitions
+  ansible.builtin.set_fact:
+    nodepool_definitions: >-
+      {{ nodepool_definitions | map('combine', {
+        'spec': {'platform': kubevirt_nodepool_platform, 'management': {'autoRepair': false, 'upgradeType': 'Replace'}}
+      }, recursive=true) | list }}

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/noop.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_22_kubevirt/tasks/noop.yaml
@@ -1,0 +1,2 @@
+---
+# No-op task file for default hooks


### PR DESCRIPTION
## Summary

- Add `ocp_4_22_kubevirt` template role for CaaS clusters with KubeVirt VM-based worker nodes
- Connect KubeVirt worker VMs to tenant subnets via Secondary Layer2 CUDN + NodePool `additionalNetworks`
- Bridge `ClusterOrder.spec.networkAttachments[0].subnetRef` → `template_parameters.subnet_ref` in `extract_template_info`

### Template role (`ocp_4_22_kubevirt`)

Delegates to `ocp_4_17_small` with hooks:
- **modify_hosted_cluster**: sets `platform.type=KubeVirt`, Route services with API hostname lookup, managed etcd
- **modify_nodepools**: sets KubeVirt compute/rootVolume + conditionally adds `additionalNetworks` for tenant subnet
- **create_secondary_network**: creates Secondary Layer2 CUDN, labels the HostedCluster namespace for NAD placement (required due to multus namespace isolation on OCP 4.22)
- **cluster_infra** and **external_access** steps overridden (no bare-metal provisioning needed)
- **delete** flow cleans up the Secondary CUDN after cluster removal

### Key design decisions

- **Secondary CUDN** (not Primary) because HyperShift controls the VM namespace — can't use Primary UDN namespace placement like VMaaS
- **Namespace labeling** for NAD placement — multus on OCP 4.22 has `namespaceIsolation: true`, blocking cross-namespace NAD references. Labeling the HC namespace makes the CUDN controller create the NAD there
- **API hostname required** — MCE 2.17 does not auto-derive `route.hostname` for APIServer Route service; must be set explicitly from `ingresses.config/cluster`

**Depends on:** osac-project/osac-operator#374 (adds `networkAttachments` to ClusterOrder CRD)

## Validation

Validated end-to-end on 3 OCP 4.22 clusters (GCP, MCE 2.17, CNV 4.22):
- ClusterOrder with `networkAttachments: [{subnetRef: tenant-net}]` → pipeline extracts `subnet_ref`
- HostedCluster reaches `Available=True`
- Worker VM runs with both default pod network + secondary tenant interface (multus confirmed)
- Delete flow cleans up all resources (HostedCluster, CUDN, NAD, VM)
- `ansible-lint` passes at production profile

## Test plan

- [ ] `ansible-lint` passes
- [ ] Template creates KubeVirt HostedCluster with `Available=True`
- [ ] Worker VM has secondary network interface when `subnet_ref` is provided
- [ ] Worker VM uses default pod network only when `subnet_ref` is empty
- [ ] Delete flow removes Secondary CUDN and associated NAD
- [ ] Existing templates (ocp_4_17_small, ocp_4_20_ai_maas) are unaffected

Assisted-by: Claude Code <noreply@anthropic.com>