### PR TITLE
OSAC-2912, OSAC-2948: Fix ExternalIPPool playbooks and UDN EndpointSlice routing

### DIFF
--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_external_ip.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/tasks/attach_external_ip.yaml
@@ -233,6 +233,57 @@
           'osac-eip-{{ external_ip_name }}' in metallb-system has been restored
           if it had been deleted. Check the preceding error for details.
 
+# Workaround for upstream OVN-Kubernetes bug: the EndpointSlice mirror
+# controller labels mirrored slices with k8s.ovn.org/service-name but omits
+# the standard kubernetes.io/service-name label that MetalLB requires.
+# Without this label MetalLB ignores the UDN EndpointSlice and routes to the
+# infrastructure-locked cluster-network IP where nothing is listening.
+- name: Check if VM namespace has primary UDN
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: v1
+    kind: Namespace
+    name: "{{ attach_vm_namespace }}"
+  register: vm_namespace_info
+
+- name: Set primary UDN flag
+  ansible.builtin.set_fact:
+    has_primary_udn: >-
+      {{ vm_namespace_info.resources | length > 0
+         and 'k8s.ovn.org/primary-user-defined-network'
+             in (vm_namespace_info.resources[0].metadata.labels | default({})) }}
+
+- name: Wait for mirrored EndpointSlice in UDN namespace
+  kubernetes.core.k8s_info:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: discovery.k8s.io/v1
+    kind: EndpointSlice
+    namespace: "{{ attach_vm_namespace }}"
+    label_selectors:
+      - "endpointslice.kubernetes.io/managed-by=endpointslice-mirror-controller.k8s.ovn.org"
+      - "k8s.ovn.org/service-name=osac-eip-{{ external_ip_name }}-ingress"
+  register: mirrored_eps
+  retries: 12
+  delay: 5
+  until: mirrored_eps.resources | length > 0
+  when: has_primary_udn | bool
+
+- name: Add standard service-name label to mirrored EndpointSlice
+  kubernetes.core.k8s:
+    kubeconfig: "{{ remote_cluster_kubeconfig | default(omit) }}"
+    api_version: discovery.k8s.io/v1
+    kind: EndpointSlice
+    name: "{{ mirrored_eps.resources[0].metadata.name }}"
+    namespace: "{{ attach_vm_namespace }}"
+    state: present
+    definition:
+      metadata:
+        labels:
+          kubernetes.io/service-name: "osac-eip-{{ external_ip_name }}-ingress"
+  when:
+    - has_primary_udn | bool
+    - mirrored_eps.resources | length > 0
+
 # Annotate the ComputeInstance CR with the assigned external IP.
 - name: Annotate ComputeInstance with external-ip-address
   kubernetes.core.k8s:

--- a/playbook_osac_create_external_ip_pool.yml
+++ b/playbook_osac_create_external_ip_pool.yml
@@ -6,7 +6,9 @@
   vars:
     external_ip_pool: "{{ ansible_eda.event.payload }}"
     external_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
-    implementation_strategy: "{{ ansible_eda.event.payload.spec.implementationStrategy }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations
+         ['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:

--- a/playbook_osac_delete_external_ip_pool.yml
+++ b/playbook_osac_delete_external_ip_pool.yml
@@ -6,7 +6,9 @@
   vars:
     external_ip_pool: "{{ ansible_eda.event.payload }}"
     external_ip_pool_name: "{{ ansible_eda.event.payload.metadata.name }}"
-    implementation_strategy: "{{ ansible_eda.event.payload.spec.implementationStrategy }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations
+         ['osac.openshift.io/implementation-strategy'] }}
     template_parameters: {}
 
   pre_tasks:


### PR DESCRIPTION
[OSAC-2912](https://redhat.atlassian.net/browse/OSAC-2912): The create/delete ExternalIPPool playbooks referenced spec.implementationStrategy which is OUTPUT_ONLY and absent from the event payload, causing the AAP job to fail. Switch to reading the implementation strategy from the osac.openshift.io/implementation-strategy annotation, matching all other ExternalIP playbooks.

[OSAC-2948](https://redhat.atlassian.net/browse/OSAC-2948): In UDN namespaces, OVN-K's EndpointSlice mirror controller labels mirrored slices with k8s.ovn.org/service-name but omits the standard kubernetes.io/service-name label. MetalLB ignores the mirrored slice and routes traffic to the infrastructure-locked cluster-network IP. Add a workaround in metallb_l2 attach_external_ip that detects UDN namespaces, waits for the mirrored EndpointSlice, and adds the standard label so MetalLB routes correctly.

Assisted-by: Claude Code <noreply@anthropic.com>