### PR TITLE
NO-ISSUE: fix docs-only e2e skip with predicate-quantifier every

### DIFF
--- a/.github/workflows/e2e-bmaas-full-install.yml
+++ b/.github/workflows/e2e-bmaas-full-install.yml
@@ -38,6 +38,7 @@ jobs:
         if: github.event_name == 'pull_request'
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'

--- a/.github/workflows/e2e-vmaas-full-install.yml
+++ b/.github/workflows/e2e-vmaas-full-install.yml
@@ -40,6 +40,7 @@ jobs:
         if: github.event_name == 'pull_request'
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'


### PR DESCRIPTION
The negation-based filter used the default 'some' quantifier, which returns true if ANY pattern matches — so '**' always matched and negations like '!OWNERS' were ignored.

Adding predicate-quantifier: 'every' requires ALL patterns to match each file: a code file passes all five patterns, but OWNERS fails '!OWNERS', README.md fails '!*.md', etc.

Assisted-by: Claude Code <noreply@anthropic.com>