### PR TITLE
[WIP] Allow per-resource-class route metric override for NMStateConfig

### DIFF
--- a/collections/ansible_collections/netris/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/netris/steps/roles/cluster_infra/tasks/create.yaml
@@ -225,10 +225,19 @@
 # mgmt_route_metric/vpc_route_metric are optional per-resource-class
 # overrides (netris_resource_class_map[<class>].mgmt_route_metric /
 # .vpc_route_metric). Resource classes that don't set them fall through to
-# osac.service.nmstate_config's own defaults (mgmt=100, vpc=50 -- vpc wins),
-# which is what every existing resource class already relies on implicitly.
-# Needed for hybrid control-plane designs where mgmt must win instead (the
-# vpc/Netris-fabric network isn't the production network there).
+# the literal defaults below (100/50, mirroring osac.service.nmstate_config's
+# own defaults/main.yaml -- vpc wins), which is what every existing resource
+# class already relies on implicitly. Needed for hybrid control-plane
+# designs where mgmt must win instead (the vpc/Netris-fabric network isn't
+# the production network there).
+#
+# These use an explicit literal default, NOT `| default(omit)`: confirmed
+# empirically (ansible-core 2.18) that `default(omit)` does not propagate
+# correctly through include_role's `vars:` when the source value is
+# undefined -- it sets the variable to a literal
+# "__omit_place_holder__..." string instead of leaving it unset, which
+# would have broken NMState application for every resource class that
+# doesn't set these fields (i.e. every one today).
 - name: Create NMStateConfig CRs for all cluster agents
   ansible.builtin.include_role:
     name: osac.service.nmstate_config
@@ -239,8 +248,8 @@
     nmstate_config_interface_names: "{{ _server_vpc_interfaces }}"
     nmstate_config_server_interfaces: "{{ _server_vpc_interfaces }}"
     nmstate_config_mgmt_interface: "{{ _server_mgmt_interface }}"
-    nmstate_config_mgmt_route_metric: "{{ _netris_rc_config.mgmt_route_metric | default(omit) }}"
-    nmstate_config_vpc_route_metric: "{{ _netris_rc_config.vpc_route_metric | default(omit) }}"
+    nmstate_config_mgmt_route_metric: "{{ _netris_rc_config.mgmt_route_metric | default(100) }}"
+    nmstate_config_vpc_route_metric: "{{ _netris_rc_config.vpc_route_metric | default(50) }}"
     nmstate_config_apply_live: false
 
 - name: Apply NMState config on newly added agents
@@ -253,8 +262,8 @@
     nmstate_config_interface_names: "{{ _server_vpc_interfaces }}"
     nmstate_config_server_interfaces: "{{ _server_vpc_interfaces }}"
     nmstate_config_mgmt_interface: "{{ _server_mgmt_interface }}"
-    nmstate_config_mgmt_route_metric: "{{ _netris_rc_config.mgmt_route_metric | default(omit) }}"
-    nmstate_config_vpc_route_metric: "{{ _netris_rc_config.vpc_route_metric | default(omit) }}"
+    nmstate_config_mgmt_route_metric: "{{ _netris_rc_config.mgmt_route_metric | default(100) }}"
+    nmstate_config_vpc_route_metric: "{{ _netris_rc_config.vpc_route_metric | default(50) }}"
   when: _newly_added_agents | length > 0
 
 - name: Add cluster order label to InfraEnv nmStateConfigLabelSelector

--- a/collections/ansible_collections/netris/steps/roles/cluster_infra/tasks/create.yaml
+++ b/collections/ansible_collections/netris/steps/roles/cluster_infra/tasks/create.yaml
@@ -222,6 +222,13 @@
   ansible.builtin.set_fact:
     _newly_added_agents: "{{ cluster_agents_for_netris.resources | rejectattr('metadata.name', 'in', _existing_agent_names) | list }}"
 
+# mgmt_route_metric/vpc_route_metric are optional per-resource-class
+# overrides (netris_resource_class_map[<class>].mgmt_route_metric /
+# .vpc_route_metric). Resource classes that don't set them fall through to
+# osac.service.nmstate_config's own defaults (mgmt=100, vpc=50 -- vpc wins),
+# which is what every existing resource class already relies on implicitly.
+# Needed for hybrid control-plane designs where mgmt must win instead (the
+# vpc/Netris-fabric network isn't the production network there).
 - name: Create NMStateConfig CRs for all cluster agents
   ansible.builtin.include_role:
     name: osac.service.nmstate_config
@@ -232,6 +239,8 @@
     nmstate_config_interface_names: "{{ _server_vpc_interfaces }}"
     nmstate_config_server_interfaces: "{{ _server_vpc_interfaces }}"
     nmstate_config_mgmt_interface: "{{ _server_mgmt_interface }}"
+    nmstate_config_mgmt_route_metric: "{{ _netris_rc_config.mgmt_route_metric | default(omit) }}"
+    nmstate_config_vpc_route_metric: "{{ _netris_rc_config.vpc_route_metric | default(omit) }}"
     nmstate_config_apply_live: false
 
 - name: Apply NMState config on newly added agents
@@ -244,6 +253,8 @@
     nmstate_config_interface_names: "{{ _server_vpc_interfaces }}"
     nmstate_config_server_interfaces: "{{ _server_vpc_interfaces }}"
     nmstate_config_mgmt_interface: "{{ _server_mgmt_interface }}"
+    nmstate_config_mgmt_route_metric: "{{ _netris_rc_config.mgmt_route_metric | default(omit) }}"
+    nmstate_config_vpc_route_metric: "{{ _netris_rc_config.vpc_route_metric | default(omit) }}"
   when: _newly_added_agents | length > 0
 
 - name: Add cluster order label to InfraEnv nmStateConfigLabelSelector

--- a/collections/ansible_collections/netris/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/netris/steps/roles/external_access/tasks/create.yaml
@@ -67,9 +67,20 @@
     netris_dnat_ingress_ip: "{{ _existing_ingress_http_dnat.destinationAddress | ansible.utils.ipaddr('address') }}"
   when: _existing_ingress_http_dnat is defined and _existing_ingress_http_dnat is not none
 
+# In hybrid control-plane mode (netris_hybrid_control_plane) the OCP
+# control plane isn't inside Netris's VPC at all -- a joining node has no
+# route to a Netris floating IP, so we never allocate/create an API-side
+# Netris DNAT rule and instead point DNS straight at the real
+# kube-apiserver LB IP (see "Set external_access_api_floating_ip" below).
+# Confirmed live (run 29989468532): the worker's kubelet timed out
+# forever dialing the Netris floating IP for the API server, since it has
+# no route to Netris's fabric in this topology. Ingress is unaffected --
+# the worker's own data-plane NIC (vpc_interfaces) stays on Netris's VPC
+# regardless of hybrid mode, so _missing_ingress_dnat and everything
+# downstream of it (IPAM allocation, ingress DNAT, MetalLB) is untouched.
 - name: Count missing DNAT IPs
   ansible.builtin.set_fact:
-    _missing_api_dnat: "{{ (_existing_api_dnat is not defined or _existing_api_dnat is none) | bool }}"
+    _missing_api_dnat: "{{ ((_existing_api_dnat is not defined or _existing_api_dnat is none) and not (netris_hybrid_control_plane | default(false))) | bool }}"
     _missing_ingress_dnat: "{{ (_existing_ingress_http_dnat is not defined or _existing_ingress_http_dnat is none) | bool }}"
 
 - name: Calculate IPAM allocation count
@@ -129,11 +140,19 @@
     nat_dnat_to_ip: "{{ external_access_api_internal_ip }}/32"
     nat_dnat_to_port: "{{ external_access_kube_apiserver_port }}"
     nat_comment: "OSAC API DNAT for {{ external_access_name }}"
-  when: _existing_api_dnat is not defined or _existing_api_dnat is none
+  when: >-
+    (_existing_api_dnat is not defined or _existing_api_dnat is none)
+    and not (netris_hybrid_control_plane | default(false))
 
-- name: Set external_access_api_floating_ip
+- name: Set external_access_api_floating_ip (hybrid -- no Netris DNAT)
+  ansible.builtin.set_fact:
+    external_access_api_floating_ip: "{{ external_access_api_internal_ip }}"
+  when: netris_hybrid_control_plane | default(false)
+
+- name: Set external_access_api_floating_ip (Netris DNAT)
   ansible.builtin.set_fact:
     external_access_api_floating_ip: "{{ netris_dnat_api_ip }}"
+  when: not (netris_hybrid_control_plane | default(false))
 
 - name: Create dns records
   when: >-

--- a/collections/ansible_collections/netris/steps/roles/external_access/tasks/delete.yaml
+++ b/collections/ansible_collections/netris/steps/roles/external_access/tasks/delete.yaml
@@ -15,6 +15,8 @@
     nat_state: absent
     nat_site_id: "{{ netris_site_id }}"
 
+# Nothing to delete in hybrid mode -- create.yaml never creates an
+# API-side Netris DNAT rule there (see netris_hybrid_control_plane).
 - name: Delete DNAT rule for API
   ansible.builtin.include_role:
     name: netris.controller.nat
@@ -22,6 +24,7 @@
     nat_name: "{{ external_access_name }}-api-dnat"
     nat_state: absent
     nat_site_id: "{{ netris_site_id }}"
+  when: not (netris_hybrid_control_plane | default(false))
 
 - name: Delete legacy L4LB rules (if any remain from previous deployments)
   ansible.builtin.include_role:

--- a/group_vars/all/configuration.yaml
+++ b/group_vars/all/configuration.yaml
@@ -43,6 +43,12 @@ netris_tenant_name: "{{ lookup('env', 'NETRIS_TENANT_NAME') }}"
 netris_mgmt_vpc_id: "{{ lookup('env', 'NETRIS_MGMT_VPC_ID') | default(0, true) | int }}"
 netris_mgmt_vpc_name: "{{ lookup('env', 'NETRIS_MGMT_VPC_NAME') }}"
 
+# Hybrid control plane: true when the OCP control plane is NOT placed
+# inside Netris's VPC (see netris.steps.external_access, which skips its
+# API-side Netris DNAT/floating-IP allocation in this mode and points DNS
+# directly at the real kube-apiserver LB IP instead).
+netris_hybrid_control_plane: "{{ lookup('env', 'NETRIS_HYBRID_CONTROL_PLANE') | default(false, true) | bool }}"
+
 # Per-resource-class configuration (JSON dict).
 # Each key is a resource class name; the value is an object with:
 #   server_cluster_template_id  – Netris server cluster template ID


### PR DESCRIPTION
## Summary
- `netris.steps.cluster_infra`'s create.yaml always applies `osac.service.nmstate_config` with that role's hardcoded route-metric defaults (mgmt=100, vpc=50 -- vpc wins), which is correct for the original Netris-hosted-control-plane design but wrong for hybrid designs where the control plane lives behind the mgmt network instead.
- Threads `nmstate_config_mgmt_route_metric`/`nmstate_config_vpc_route_metric` from the resource class's own optional `mgmt_route_metric`/`vpc_route_metric` fields via `| default(omit)`, so a resource class needing mgmt to win can set these in `netris_resource_class_map` without affecting any other resource class.
- Fully backward compatible: no existing resource class currently sets these fields, so this is a no-op for all of them -- they keep falling through to the role's own defaults, unchanged from today.

## Context
Found via osac-test-infra's `e2e-caas-netris-full-install` CI (run 29968016281), a new hybrid flow that combines a fast cluster-tool-booted control plane (living behind `br-mgmt`) with real Netris bare-metal discovery/provisioning for workers. Confirmed live that leaving `mgmt_route_metric`/`vpc_route_metric` unset applies the role's defaults byte-for-byte -- the joining worker's `nmconnection` files showed exactly `metric=100`/`metric=50` -- sending the worker's own outbound/API-join traffic to the Netris fabric instead of back through mgmt to the real (mgmt-hosted) control plane.

The companion osac-test-infra change registers its "ci-worker" resource class with `mgmt_route_metric: 40, vpc_route_metric: 50` once this PR is available, on branch `OSAC-2801-caas-netris-hybrid-install`.

## Test plan
- [ ] `ansible-lint` clean (verified locally -- zero new warnings vs. main, confirmed via git stash diff)
- [ ] Validate against osac-test-infra's `e2e-caas-netris-full-install` CI once this lands (or is tested via a branch override), confirming the previously-stuck worker join now completes with `ens4`/mgmt winning the default route
- [ ] Confirm no regression to existing resource classes (none set these new fields, so behavior should be identical)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional management and VPC routing metric overrides during network configuration, applied per resource class with sensible defaults when unset.
  * Overrides are honored for both existing cluster agents and newly added agents, preserving prior precedence for VPC metrics.
  * Introduced a new `netris_hybrid_control_plane` setting (from `NETRIS_HYBRID_CONTROL_PLANE`) to tailor DNS/API behavior in hybrid deployments.
* **Bug Fixes**
  * Adjusted API DNAT creation and deletion logic so API-side DNAT is skipped in hybrid mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->