### PR TITLE
OSAC-870: Add CaaS E2E caller workflow

### DIFF
--- a/.github/workflows/e2e-caas-full-install.yml
+++ b/.github/workflows/e2e-caas-full-install.yml
@@ -1,0 +1,74 @@
+---
+name: E2E CaaS Full Install
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      test-suite:
+        description: "Test suite (caas, or empty for all)"
+        required: false
+        default: "caas"
+      test-filter:
+        description: "pytest -k filter"
+        required: false
+        default: ""
+      test-infra-ref:
+        description: "Branch/ref of osac-test-infra"
+        required: false
+        default: "main"
+
+concurrency:
+  group: e2e-caas-full-install-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      should-run: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4.0.2
+        if: github.event_name == 'pull_request'
+        id: filter
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '**'
+              - '!OWNERS'
+              - '!LICENSE'
+              - '!*.md'
+              - '!docs/**'
+
+  e2e-caas-full-install:
+    needs: changes
+    if: needs.changes.outputs.should-run == 'true'
+    uses: osac-project/osac-test-infra/.github/workflows/e2e-caas-full-install.yml@main
+    with:
+      test-suite: ${{ inputs.test-suite || 'caas' }}
+      test-filter: ${{ inputs.test-filter || '' }}
+      component-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      component-ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      component-image-key: aap.bootstrap.image
+      component-build-type: ansible-builder
+      component-containerfile: execution-environment/execution-environment.yaml
+      fork-pr-author-association: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.author_association || '' }}
+      fork-pr-author: ${{ github.event.pull_request.head.repo.fork && github.event.pull_request.user.login || '' }}
+      pr-number: ${{ github.event.pull_request.number }}
+      test-infra-repository: osac-project/osac-test-infra
+      test-infra-ref: ${{ inputs.test-infra-ref || 'main' }}
+
+  e2e:
+    if: always()
+    needs: [changes, e2e-caas-full-install]
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## [OSAC-870](https://redhat.atlassian.net/browse/OSAC-870): Add CaaS E2E caller workflow

**Jira:** https://redhat.atlassian.net/browse/OSAC-870

### Summary

Adds a cross-repo caller workflow that invokes the reusable CaaS E2E workflow in
osac-test-infra. Same pattern as the BMaaS presubmit jobs.

### Related PRs

- osac-project/fulfillment-service — CaaS E2E caller
- osac-project/osac-operator — CaaS E2E caller
- osac-project/osac-aap — CaaS E2E caller
- osac-project/osac-installer — CaaS E2E caller

### Testing

- [ ] Trigger `workflow_dispatch` from the branch to validate the workflow runs

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated end-to-end testing for pull requests and manually triggered runs.
  * Added options to select the test suite, filter tests, and choose the test infrastructure revision.
  * Added concurrency controls to cancel outdated pull request test runs.

* **Bug Fixes**
  * Added a status gate that surfaces failed or canceled end-to-end test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->