### PR TITLE
OSAC-2024: guard DNS wait on supported base domains

### DIFF
--- a/collections/ansible_collections/netris/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/netris/steps/roles/external_access/tasks/create.yaml
@@ -157,6 +157,8 @@
       addr: "{{ netris_dnat_ingress_ip }}"
 
 - name: Wait for DNS records
+  when: >-
+    external_access_base_domain in external_access_supported_base_domains | default([])
   ansible.builtin.include_role:
     name: osac.service.wait_for
     tasks_from: wait_for_dns

--- a/collections/ansible_collections/netris/steps/roles/external_access/tasks/delete.yaml
+++ b/collections/ansible_collections/netris/steps/roles/external_access/tasks/delete.yaml
@@ -48,7 +48,8 @@
     - "{{ external_access_name }}-api"
 
 - name: Delete dns records
-  when: external_access_base_domain is defined
+  when: >-
+    external_access_base_domain in external_access_supported_base_domains | default([])
   ansible.builtin.include_role:
     name: dns.api.dns
     tasks_from: delete

--- a/collections/ansible_collections/nico/steps/roles/external_access/tasks/delete.yaml
+++ b/collections/ansible_collections/nico/steps/roles/external_access/tasks/delete.yaml
@@ -27,6 +27,8 @@
       data: "{{ ip_registry_info.resources[0].data | dict2items | rejectattr('value', 'equalto', external_access_name) | items2dict }}"
 
 - name: Delete dns records
+  when: >-
+    external_access_base_domain in external_access_supported_base_domains | default([])
   ansible.builtin.include_role:
     name: dns.api.dns
     tasks_from: delete

--- a/collections/ansible_collections/osac/steps/roles/external_access/tasks/create.yaml
+++ b/collections/ansible_collections/osac/steps/roles/external_access/tasks/create.yaml
@@ -88,6 +88,8 @@
       addr: "{{ external_access_ingress_floating_ip }}"
 
 - name: Wait for DNS records
+  when: >-
+    external_access_base_domain in external_access_supported_base_domains | default([])
   ansible.builtin.include_role:
     name: osac.service.wait_for
     tasks_from: wait_for_dns

--- a/collections/ansible_collections/osac/steps/roles/external_access/tasks/delete.yaml
+++ b/collections/ansible_collections/osac/steps/roles/external_access/tasks/delete.yaml
@@ -9,6 +9,8 @@
     - "{{ external_access_name }}-ingress"
 
 - name: Delete dns records
+  when: >-
+    external_access_base_domain in external_access_supported_base_domains | default([])
   ansible.builtin.include_role:
     name: dns.api.dns
     tasks_from: delete


### PR DESCRIPTION
## Problem

The "Wait for DNS records" task in the `external_access` role runs unconditionally, regardless of whether the base domain is in the supported list. When the domain is not supported, the DNS record is never created and the wait times out — causing the AAP job to fail with a timeout error.

## Fix

Add a `when:` guard to the "Wait for DNS records" task in both `osac` and `netris` step collections:

```yaml
when: >-
  external_access_base_domain in external_access_supported_base_domains | default([])
```

This mirrors the existing guard already present in the other `external_access` step collections.

## Depends on

`osac-operator` fix: https://github.com/osac-project/osac-operator/pull/383

The operator fix prevents `ClusterOrder.Status.Phase` from being set to `Failed` when an ancillary AAP job fails but the HostedCluster is already healthy. Both fixes together fully address [OSAC-2024](https://redhat.atlassian.net/browse/OSAC-2024): this PR eliminates the spurious DNS wait timeout; the operator PR ensures that if it does happen, phase stays Progressing rather than going to terminal Failed.

## Testing

- `ansible-lint` passes (pre-existing `var-naming[no-role-prefix]` violations are not introduced by this fix)
- Fix mirrors the identical guard already present and working in other step collections

## Risk Assessment

LOW — 2-line `when:` guard addition. No role logic changes, no variable additions. The guard uses variables already consumed by sibling tasks in the same role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated external access DNS behavior so DNS creation wait runs only when the selected base domain is included in supported base domains.
  * Ensured DNS A record deletion is likewise conditional, preventing unnecessary delete/wait actions when DNS support isn’t configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->