### PR TITLE
NO-ISSUE: remove debug tasks that leak cluster order payload

### DIFF
--- a/playbook_osac_create_hosted_cluster.yml
+++ b/playbook_osac_create_hosted_cluster.yml
@@ -25,17 +25,9 @@
             lookup('community.general.random_string', special=false, numbers=false, upper=false)
           }}
 
-    - name: Cluster order before defaults
-      ansible.builtin.debug:
-        var: cluster_order
-
     - name: Apply default settings
       ansible.builtin.include_role:
         name: osac.service.cluster_settings
-
-    - name: Cluster order after defaults
-      ansible.builtin.debug:
-        var: cluster_order
 
     - name: Extract template info
       ansible.builtin.include_role:


### PR DESCRIPTION
## Summary

- Remove two `ansible.builtin.debug` tasks that printed the full `cluster_order` variable (the raw ClusterOrder CR) to AAP job logs
- The CR can contain pull secrets, SSH keys, and other credentials — dumping it verbatim is a sensitive data leak
- The existing `Display cluster order information` task already safely logs name, working namespace, and template ID

## Jira

N/A

## Test plan

- [x] `ansible-lint` passes (pre-existing violations in role files are unrelated to this change)
- [x] Pre-commit hooks pass
- [x] Removed tasks had no functional role — they were debug-only; safe to drop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal debug output from the hosted cluster creation workflow.
  * Cluster creation behavior and default settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->