### PR TITLE
OSAC-1382: add east-west Server Cluster operations to Netris template role

### DIFF
--- a/collections/ansible_collections/netris/controller/roles/server_cluster/tasks/create.yaml
+++ b/collections/ansible_collections/netris/controller/roles/server_cluster/tasks/create.yaml
@@ -68,7 +68,7 @@
     _update_body:
       servers: "{{ _server_cluster_servers | default([]) }}"
       tags: "{{ server_cluster_tags | default([]) }}"
-  when: _existing_server_cluster is defined and _existing_server_cluster is not none
+  when: _existing_server_cluster is defined and _existing_server_cluster is not none and _existing_server_cluster | length > 0
 
 - name: Update existing server cluster
   ansible.builtin.uri:
@@ -85,7 +85,7 @@
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _update_resp
   no_log: true
-  when: _existing_server_cluster is defined and _existing_server_cluster is not none
+  when: _existing_server_cluster is defined and _existing_server_cluster is not none and _existing_server_cluster | length > 0
 
 - name: Build create body (base)
   ansible.builtin.set_fact:
@@ -100,20 +100,20 @@
           if (server_cluster_vpc_id is defined and server_cluster_vpc_id)
           else {'id': 0, 'name': 'Create New'}
         }}
-  when: _existing_server_cluster is not defined or _existing_server_cluster is none
+  when: _existing_server_cluster is not defined or _existing_server_cluster is none or _existing_server_cluster | length == 0
 
 - name: Build create body (with template)
   ansible.builtin.set_fact:
     _create_body: "{{ _create_body | default({}) | combine({'srvClusterTemplate': {'id': server_cluster_template_id}}) }}"
   when:
-    - _existing_server_cluster is not defined or _existing_server_cluster is none
+    - _existing_server_cluster is not defined or _existing_server_cluster is none or _existing_server_cluster | length == 0
     - server_cluster_template_id is defined
 
 - name: Build create body (with admin)
   ansible.builtin.set_fact:
     _create_body: "{{ _create_body | default({}) | combine({'admin': {'id': server_cluster_admin_id, 'name': server_cluster_admin_name}}) }}"
   when:
-    - _existing_server_cluster is not defined or _existing_server_cluster is none
+    - _existing_server_cluster is not defined or _existing_server_cluster is none or _existing_server_cluster | length == 0
     - server_cluster_admin_id is defined
     - server_cluster_admin_name is defined
 
@@ -132,17 +132,17 @@
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _create_resp
   no_log: true
-  when: _existing_server_cluster is not defined or _existing_server_cluster is none
+  when: _existing_server_cluster is not defined or _existing_server_cluster is none or _existing_server_cluster | length == 0
 
 - name: Set server_cluster_id from response
   ansible.builtin.set_fact:
     server_cluster_id: >-
       {{
         _existing_server_cluster.id
-        if (_existing_server_cluster is defined and _existing_server_cluster is not none)
+        if (_existing_server_cluster is defined and _existing_server_cluster is not none and _existing_server_cluster | length > 0)
         else (_create_resp.json.data.id | default(_create_resp.json.data))
       }}
-    server_cluster_created: "{{ _existing_server_cluster is not defined or _existing_server_cluster is none }}"
+    server_cluster_created: "{{ _existing_server_cluster is not defined or _existing_server_cluster is none or _existing_server_cluster | length == 0 }}"
 
 - name: Wait for server cluster to be active
   ansible.builtin.uri:

--- a/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/vars/controller.yml
@@ -269,6 +269,30 @@ controller_templates: # noqa: var-naming[no-role-prefix]
     allow_simultaneous: true
     ask_variables_on_launch: true
     verbosity: 0
+  - name: "{{ aap_prefix }}-create-server-cluster"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_create_server_cluster.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
+  - name: "{{ aap_prefix }}-delete-server-cluster"
+    project: "{{ aap_prefix }}"
+    organization: "{{ aap_organization_name }}"
+    job_type: run
+    playbook: "playbook_osac_delete_server_cluster.yml"
+    inventory: "{{ aap_prefix }}-networking-operations"
+    execution_environment: "{{ aap_prefix }}-ee"
+    instance_groups:
+      - "{{ aap_prefix }}-networking-operations-ig"
+    allow_simultaneous: true
+    ask_variables_on_launch: true
+    verbosity: 0
   - name: "{{ aap_prefix }}-import-agents"
     project: "{{ aap_prefix }}"
     organization: "{{ aap_organization_name }}"

--- a/collections/ansible_collections/osac/templates/roles/netris/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/meta/osac.yaml
@@ -3,7 +3,7 @@ title: Netris Network Implementation
 description: >
   Provisions networking resources using Netris Controller API.
   Maps VirtualNetwork to VPC, Subnet to V-Net (L2VPN),
-  SecurityGroup to ACL.
+  SecurityGroup to ACL, ServerCluster to Server Cluster (L3VPN east-west).
 
 template_type: network
 
@@ -14,3 +14,4 @@ capabilities:
   supports_ipv4: true
   supports_ipv6: false
   supports_dual_stack: false
+  supports_east_west: true

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/create_server_cluster.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/create_server_cluster.yaml
@@ -1,0 +1,112 @@
+---
+# ServerCluster maps to a Netris Server Cluster (east-west compute group)
+# Creates a Server Cluster in the specified VPC using the given template,
+# which auto-provisions L3VPN (east-west) and L2VPN (north-south) VNets.
+
+- name: Extract ServerCluster configuration
+  ansible.builtin.set_fact:
+    sc_name: "{{ server_cluster.metadata.name }}"
+    sc_servers: "{{ server_cluster.spec.servers | default([]) }}"
+    sc_site_id: "{{ server_cluster.spec.siteId | default(netris_site_id) }}"
+    sc_tags: "{{ server_cluster.spec.tags | default([]) }}"
+    sc_virtual_network_name: "{{ server_cluster.spec.virtualNetworkName | default('') }}"
+
+- name: Extract optional ServerCluster fields
+  ansible.builtin.set_fact:
+    sc_template_id: "{{ server_cluster.spec.templateId | int }}"
+  when: server_cluster.spec.templateId is defined
+
+- name: Extract optional VPC ID
+  ansible.builtin.set_fact:
+    sc_vpc_id: "{{ server_cluster.spec.vpcId | int }}"
+  when: server_cluster.spec.vpcId is defined
+
+- name: Extract optional admin fields
+  ansible.builtin.set_fact:
+    sc_admin_id: "{{ server_cluster.spec.adminId | default(netris_tenant_id) | int }}"
+    sc_admin_name: "{{ server_cluster.spec.adminName | default(netris_tenant_name) }}"
+  when: server_cluster.spec.adminId is defined or netris_tenant_id is defined
+
+- name: Display ServerCluster information
+  ansible.builtin.debug:
+    msg:
+      - "Creating Netris Server Cluster '{{ sc_name }}'"
+      - "Site ID: {{ sc_site_id }}"
+      - "Servers: {{ sc_servers }}"
+      - "Template ID: {{ sc_template_id | default('not set') }}"
+      - "VPC ID: {{ sc_vpc_id | default('auto-create (new VPC)') }}"
+
+- name: Resolve VPC ID from VirtualNetwork name
+  when:
+    - sc_vpc_id is not defined
+    - sc_virtual_network_name | length > 0
+  block:
+    - name: Ensure Netris auth for VPC lookup
+      ansible.builtin.include_role:
+        name: netris.controller.auth
+      when: netris_session_cookie is not defined
+
+    - name: Look up VPCs from Netris controller
+      ansible.builtin.uri:
+        url: "{{ netris_controller_url }}/api/v2/vpc"
+        method: GET
+        headers:
+          Cookie: "connect.sid={{ netris_session_cookie }}"
+        return_content: true
+        status_code: 200
+        timeout: "{{ netris_timeout | default(30) }}"
+        validate_certs: "{{ netris_validate_certs | default(true) }}"
+      register: _sc_vpc_list_resp
+      no_log: true
+
+    - name: Find VPC ID by VirtualNetwork name
+      ansible.builtin.set_fact:
+        sc_vpc_id: >-
+          {{ ((_sc_vpc_list_resp.json.data | default([]))
+              | selectattr('name', 'equalto', sc_virtual_network_name)
+              | map(attribute='id') | list | first | default('')) }}
+
+    - name: Fail if VPC not found for VirtualNetwork
+      ansible.builtin.fail:
+        msg: "VPC not found for VirtualNetwork '{{ sc_virtual_network_name }}'"
+      when: sc_vpc_id is not defined or sc_vpc_id | string | length == 0
+
+- name: Set required server cluster parameters
+  ansible.builtin.set_fact:
+    server_cluster_name: "{{ sc_name }}"
+    server_cluster_site_id: "{{ sc_site_id | int }}"
+    server_cluster_servers: "{{ sc_servers }}"
+    server_cluster_tags: "{{ sc_tags }}"
+
+- name: Set server cluster template ID
+  ansible.builtin.set_fact:
+    server_cluster_template_id: "{{ sc_template_id | int }}"
+  when: sc_template_id is defined
+
+- name: Set server cluster VPC ID
+  ansible.builtin.set_fact:
+    server_cluster_vpc_id: "{{ sc_vpc_id | int }}"
+  when: sc_vpc_id is defined
+
+- name: Set server cluster admin
+  ansible.builtin.set_fact:
+    server_cluster_admin_id: "{{ sc_admin_id | int }}"
+    server_cluster_admin_name: "{{ sc_admin_name }}"
+  when: sc_admin_id is defined
+
+- name: Clear stale collection role state
+  ansible.builtin.set_fact:
+    _existing_server_cluster: null
+
+- name: Create server cluster in Netris controller
+  ansible.builtin.include_role:
+    name: netris.controller.server_cluster
+    tasks_from: create
+
+- name: Display creation result
+  ansible.builtin.debug:
+    msg: >-
+      Server Cluster '{{ sc_name }}'
+      {{ (server_cluster_created | default(false)) | ternary('created', 'updated') }}
+      (ID: {{ server_cluster_id | default('unknown') }},
+       VPC: {{ server_cluster_vpc_id | default('unknown') }})

--- a/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_server_cluster.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/tasks/delete_server_cluster.yaml
@@ -1,0 +1,24 @@
+---
+# ServerCluster deletion — removes Server Cluster from Netris controller.
+# Netris automatically cleans up auto-created VNets when the cluster is deleted.
+
+- name: Extract ServerCluster configuration
+  ansible.builtin.set_fact:
+    sc_name: "{{ server_cluster.metadata.name }}"
+    sc_site_id: "{{ server_cluster.spec.siteId | default(netris_site_id) }}"
+
+- name: Display ServerCluster deletion info
+  ansible.builtin.debug:
+    msg: "Deleting Netris Server Cluster '{{ sc_name }}' (Site ID: {{ sc_site_id }})"
+
+- name: Delete server cluster from Netris controller
+  ansible.builtin.include_role:
+    name: netris.controller.server_cluster
+    tasks_from: delete
+  vars:
+    server_cluster_name: "{{ sc_name }}"
+    server_cluster_site_id: "{{ sc_site_id | int }}"
+
+- name: Display deletion result
+  ansible.builtin.debug:
+    msg: "Server Cluster '{{ sc_name }}' deletion completed"

--- a/playbook_osac_create_server_cluster.yml
+++ b/playbook_osac_create_server_cluster.yml
@@ -1,0 +1,30 @@
+---
+- name: Create a ServerCluster resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    server_cluster: "{{ ansible_eda.event.payload }}"
+    server_cluster_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations
+         ['osac.openshift.io/implementation-strategy']
+         | default(ansible_eda.event.payload.spec.implementationStrategy, true)
+         | default('netris', true) }}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display ServerCluster information
+      ansible.builtin.debug:
+        msg:
+          - "ServerCluster name: {{ server_cluster_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected ServerCluster role
+      ansible.builtin.include_role:
+        name: "osac.templates.{{ implementation_strategy }}"
+        tasks_from: create_server_cluster

--- a/playbook_osac_delete_server_cluster.yml
+++ b/playbook_osac_delete_server_cluster.yml
@@ -1,0 +1,30 @@
+---
+- name: Delete a ServerCluster resource
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    server_cluster: "{{ ansible_eda.event.payload }}"
+    server_cluster_name: "{{ ansible_eda.event.payload.metadata.name }}"
+    implementation_strategy: >-
+      {{ ansible_eda.event.payload.metadata.annotations
+         ['osac.openshift.io/implementation-strategy']
+         | default(ansible_eda.event.payload.spec.implementationStrategy, true)
+         | default('netris', true) }}
+
+  pre_tasks:
+    - name: Show EDA Event
+      ansible.builtin.debug:
+        var: ansible_eda.event.payload
+
+  tasks:
+    - name: Display ServerCluster information
+      ansible.builtin.debug:
+        msg:
+          - "ServerCluster name: {{ server_cluster_name }}"
+          - "Implementation strategy: {{ implementation_strategy }}"
+
+    - name: Call the selected ServerCluster role
+      ansible.builtin.include_role:
+        name: "osac.templates.{{ implementation_strategy }}"
+        tasks_from: delete_server_cluster


### PR DESCRIPTION
  Summary                                                                                                                                                                                                          
                                                                                                         
  - Add Server Cluster create/delete task files and playbooks for east-west tenant provisioning via Netris
  - When a Server Cluster is created with a template and VPC, Netris auto-provisions L3VPN (east-west) and L2VPN (north-south) VNets with per-tenant VRF isolation
  - Add supports_east_west capability to the Netris NetworkClass metadata                                                                                                                                          
  - Fix Jinja2 native mode bug in netris.controller.server_cluster role where empty selectattr result returns "" instead of None
                                                                                                                                                                                                                   
  Jira                                                                                                    
                                                                                                                                                                                                                   
  [OSAC-1382](https://redhat.atlassian.net/browse/OSAC-1382)                                                                                               
                                                                                                         
  Lab test environment                           
                                                                                                                                                                                                                   
  Tested on zeus12.lab.eng.tlv2.redhat.com using netris-lab with ew_fabric_enable: 1 (dual NS+EW fabric simulation). The lab simulates a full Spectrum-X GPU cluster topology:

  - Netris Controller on K3s (UI at port 9443)                                                           
  - 7 Cumulus Linux switch VMs (2 NS leaves, 2 NS spines, 1 OOB leaf, 1 EW leaf, 1 EW spine)                                                                                                                       
  - 4 GPU server VMs (hgx-00 through hgx-03) dual-homed to NS and EW fabrics
  - 4 softgate VMs for BGP/NAT                                                                                                                                                                                     
  - Server Cluster Template configured: eth1-8 = EW (L3VPN), eth9-10 = NS (L2VPN), eth11 = OOB (L2VPN)    

  Create test                                                                                             
                                                     
  Ran playbook_osac_create_server_cluster.yml with:  
```yaml
  spec:
    siteId: 1
    servers: ["hgx-pod00-su0-h00", "hgx-pod00-su0-h01"]                                                   
    templateId: 1                                    
    adminId: 1                                       
    adminName: "Admin"
```
  Result: Server Cluster created (status: Active), VPC auto-created with unique VNI, 3 VNets auto-provisioned:
  - sc-test-East-West (L3VPN, VXLAN ID=8)
  - sc-test-North-South-in-band-and-storage (L2VPN, VXLAN ID=11)
  - sc-test-OOB-Management (L2VPN, VXLAN ID=14)      

  Delete test                                                   


  Ran playbook_osac_delete_server_cluster.yml — Server Cluster and VNets cleaned up.                      
                                                     
  Tenant isolation verification                      

  Created two Server Clusters (sc-tenant-a with hgx-00+hgx-01, sc-tenant-b with hgx-02+hgx-03) in separate VPCs. Verified:


Test | Result
-- | --
hgx-00 → hgx-01 (same tenant, EW L3VPN) | 2/2 received
hgx-00 → hgx-01 (same tenant, NS L2VPN) | 2/2 received
hgx-00 → hgx-02 (cross-tenant, EW) | 100% loss — blocked
hgx-00 → hgx-02 (cross-tenant, NS) | 100% loss — blocked

                                                     
  Test plan                                                                                               

  - [x] ansible-lint passes (0 failures, production profile)                                              
  - [x] Playbook syntax check passes                 
  - [x] Create playbook tested against netris-lab — Server Cluster + VPC + VNets provisioned
  - [x] Delete playbook tested — cleanup verified
  - [x] Tenant isolation verified — same-tenant flows, cross-tenant blocked                               
  - [ ] Integration tests (tested manually, no molecule tests yet)
