### PR TITLE
Fix: add no_log to netris.controller tasks leaking secrets

### DIFF
--- a/collections/ansible_collections/netris/controller/roles/ebgp/tasks/read.yaml
+++ b/collections/ansible_collections/netris/controller/roles/ebgp/tasks/read.yaml
@@ -14,6 +14,7 @@
     timeout: "{{ netris_timeout }}"
     status_code: 200
   register: _ebgp_resp
+  no_log: true
 
 - name: Set E-BGP facts
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/netris/controller/roles/general/tasks/read.yaml
+++ b/collections/ansible_collections/netris/controller/roles/general/tasks/read.yaml
@@ -14,6 +14,7 @@
     timeout: "{{ netris_timeout }}"
     status_code: 200
   register: _general_resp
+  no_log: true
 
 - name: Set general facts
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/netris/controller/roles/inventory/tasks/read.yaml
+++ b/collections/ansible_collections/netris/controller/roles/inventory/tasks/read.yaml
@@ -14,6 +14,7 @@
     timeout: "{{ netris_timeout }}"
     status_code: 200
   register: _inventory_resp
+  no_log: true
 
 - name: Set inventory facts
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/netris/controller/roles/l4lb/tasks/create.yaml
+++ b/collections/ansible_collections/netris/controller/roles/l4lb/tasks/create.yaml
@@ -33,6 +33,7 @@
     status_code: [200, 201]
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _l4lb_create_resp
+  no_log: true
 
 - name: Set l4lb_id from create response
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/netris/controller/roles/license/tasks/apply.yaml
+++ b/collections/ansible_collections/netris/controller/roles/license/tasks/apply.yaml
@@ -14,12 +14,14 @@
     timeout: "{{ netris_timeout }}"
     status_code: [200, 400, 404]
   register: _license_check
+  no_log: true
 
 - name: Read license key file
   when: not (_license_check.json.isSuccess | default(false))
   ansible.builtin.slurp:
     src: "{{ license_key_file }}"
   register: _license_key_raw
+  no_log: true
 
 - name: Apply license key
   when: not (_license_check.json.isSuccess | default(false))
@@ -36,6 +38,7 @@
     timeout: "{{ netris_timeout }}"
     status_code: [200, 400]
   register: _license_apply_resp
+  no_log: true
 
 - name: Set license facts
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/netris/controller/roles/license/tasks/read.yaml
+++ b/collections/ansible_collections/netris/controller/roles/license/tasks/read.yaml
@@ -14,6 +14,7 @@
     timeout: "{{ netris_timeout }}"
     status_code: [200, 400, 404]
   register: _license_resp
+  no_log: true
 
 - name: Set license facts
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/netris/controller/roles/nat/tasks/create.yaml
+++ b/collections/ansible_collections/netris/controller/roles/nat/tasks/create.yaml
@@ -81,6 +81,7 @@
     timeout: "{{ netris_timeout | default(30) }}"
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _nat_create_resp
+  no_log: true
   when: _existing_nat is not defined or _existing_nat is none
 
 - name: Set nat facts from create response

--- a/collections/ansible_collections/netris/controller/roles/server_cluster/tasks/create.yaml
+++ b/collections/ansible_collections/netris/controller/roles/server_cluster/tasks/create.yaml
@@ -43,6 +43,7 @@
     timeout: "{{ netris_timeout | default(30) }}"
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _inv_resp
+  no_log: true
 
 - name: Build servers list from inventory
   ansible.builtin.set_fact:
@@ -130,6 +131,7 @@
     timeout: "{{ netris_timeout | default(30) }}"
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _create_resp
+  no_log: true
   when: _existing_server_cluster is not defined or _existing_server_cluster is none
 
 - name: Set server_cluster_id from response
@@ -153,6 +155,7 @@
     timeout: "{{ netris_timeout | default(30) }}"
     validate_certs: "{{ netris_validate_certs | default(true) }}"
   register: _state_resp
+  no_log: true
   until: _state_resp.json is mapping and ((_state_resp.json.data | default({}))['status'] | default({}))['label'] | default('') == 'Active'
   retries: 30
   delay: 10

--- a/collections/ansible_collections/netris/controller/roles/server_cluster/tasks/delete.yaml
+++ b/collections/ansible_collections/netris/controller/roles/server_cluster/tasks/delete.yaml
@@ -30,6 +30,7 @@
       Cookie: "connect.sid={{ netris_session_cookie }}"
     status_code: [200, 204]
     validate_certs: "{{ netris_validate_certs | default(true) }}"
+  no_log: true
 
 - name: Set server_cluster_id (deleted)
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary
A CI artifact secret-exposure audit found the Netris Enterprise license key and `connect.sid` session cookie fully dumped in plaintext into `osac-ephemeral-runner.log` on every `e2e-caas-netris*` CI run. Root cause: `ansible.builtin.uri` tasks that send the `Cookie: connect.sid=...` header (and, in the license role, the raw license key in the request body/file read) are missing `no_log: true`, so ansible's verbose logging leaks the full header/body.

`roles/auth/tasks/main.yaml` already sets `no_log: true` correctly on its login/cookie-extraction tasks — this PR brings the rest of the collection up to that same convention, since the pattern was applied inconsistently per-task rather than role-wide.

## Changes
Added `no_log: true` to the following previously-unprotected tasks (all send the `Cookie` header, the license key body, or read the raw license key file):
- `roles/license/tasks/apply.yaml` — "Check current license" (GET), "Read license key file" (`ansible.builtin.slurp`, registers the base64-encoded raw license key), "Apply license key" (PUT — the exact task that leaked the license key)
- `roles/license/tasks/read.yaml` — "Get license status"
- `roles/general/tasks/read.yaml` — "Get general settings"
- `roles/ebgp/tasks/read.yaml` — "Get E-BGP sessions"
- `roles/inventory/tasks/read.yaml` — "Get inventory"
- `roles/nat/tasks/create.yaml` — "Create NAT rule"
- `roles/server_cluster/tasks/create.yaml` — "Get Netris inventory servers", "Create new server cluster", "Wait for server cluster to be active"
- `roles/server_cluster/tasks/delete.yaml` — "Delete server cluster"
- `roles/l4lb/tasks/create.yaml` — "Create L4LB"

`vpc`, `auth`, and `server_cluster_template` roles were already fully covered and needed no change.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on all modified files — all valid
- [x] `ansible-lint` run against all modified files — no new findings introduced (pre-existing `var-naming` warnings only, unrelated to this change)
- [ ] osac-test-infra will pull this fix via `make vendor-update` in a follow-up PR and a real CI dispatch will confirm `osac-ephemeral-runner.log` no longer contains `connect.sid=` or the license key body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Sensitive API requests and responses are now excluded from Ansible logs across E-BGP, inventory, general settings, licensing, load balancing, NAT, and server-cluster operations.
  * Improved protection for credentials, session data, request details, and returned API content during create, read, update, delete, and status-check operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
