### PR TITLE
OSAC-3155: disable draft mode for AI bot PRs

### DIFF
--- a/.ai-bot/config.yaml
+++ b/.ai-bot/config.yaml
@@ -18,7 +18,7 @@ validation_commands:
 
 # Pull request creation settings.
 pr:
-  draft: true
+  draft: false
   title_prefix: "[AI]"
   labels:
     - ai-pr


### PR DESCRIPTION
## Summary
- Changes `draft: true` → `draft: false` in `.ai-bot/config.yaml`
- Bugs Buddy PRs will now be created as ready for review instead of drafts

Ref: [OSAC-3155](https://redhat.atlassian.net/browse/OSAC-3155)