### PR TITLE
OSAC-3138: fix stale references in AI agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Guide for AI agents working on osac-aap — Ansible Automation Platform roles an
 osac-aap contains Ansible collections that provision and manage OSAC infrastructure. Backends are added over time — the lists below are examples, not exhaustive:
 - **Network backends**: e.g. CUDN, Netris, OpenStack, MetalLB
 - **Compute backends**: e.g. OpenShift Virtualization (KubeVirt)
-- **Cluster provisioning**: e.g. OpenShift 4.17, 4.20 templates
+- **Cluster provisioning**: e.g. OpenShift 4.20 templates
 - **Storage backends**: e.g. VAST
 - **Bare metal provisioning**: e.g. OpenStack Ironic (via the ESI collection), Metal3, NICo
 
@@ -37,7 +37,7 @@ source .venv/bin/activate  # or prefix commands with `uv run`
 ### Collections Management
 
 Collections live in two directories:
-- `collections/ansible_collections/osac/` — Local OSAC collections (service, templates, workflows, config_as_code, esi, steps, test_overrides)
+- `collections/ansible_collections/` — Local collections across multiple namespaces: `osac.*` (service, templates, workflows, config_as_code, esi, steps, test_overrides), `agentless_net.*`, `ci.*`, `dns.*`, `netris.*`, `nico.*`
 - `vendor/` — Vendored upstream collections
 
 Re-vendor after updating `collections/requirements.yml`:
@@ -60,6 +60,8 @@ osac-aap/
 │   ├── osac/config_as_code/        # AAP configuration as code
 │   ├── osac/esi/                   # Elastic Secure Infrastructure
 │   ├── osac/steps/                 # Workflow step definitions
+│   ├── osac/test_overrides/        # Test template overrides
+│   ├── ci/                         # CI workflow steps
 │   ├── netris/                     # Netris network backend
 │   ├── nico/                       # NVIDIA NICo bare metal backend
 │   ├── dns/                        # DNS management
@@ -166,6 +168,7 @@ allowed_resource_classes: []
 **Clusters:**
 - `ocp_small` — Standard OpenShift cluster template
 - `ocp_4_20_ai_maas` — OpenShift 4.20 with AI/MaaS
+- `ocp_4_20_small_nico` — OpenShift 4.20 with NICo networking
 - `ocp_ci_small` — CI cluster template
 
 **Storage:**
@@ -173,7 +176,7 @@ allowed_resource_classes: []
 
 **Bare Metal:**
 - `bm_host_agent_provisioning` / `bm_host_agent_deprovisioning`
-- `bm_host_metal3_provisioning`
+- `bm_host_provisioning` — Dispatches to Metal3 or OpenStack Ironic
 - `bm_private_network` / `bm_host_private_network`
 
 ### Service Roles (osac.service)
@@ -193,6 +196,7 @@ Shared utilities imported by template roles:
 - `manage_agents` — Agent management utilities
 - `metallb_ingress` — MetalLB ingress setup
 - `nmstate_config` — Network configuration with nmstate
+- `openstack_bm_node` — OpenStack bare metal node preflight and preparation
 - `publish_templates` — Registers template metadata as NetworkClass/ComputeClass
 - `retrieve_kubeconfig` — Kubeconfig retrieval
 - `storage_provider` — Storage provider utilities
@@ -230,13 +234,18 @@ Test fixtures: `tests/integration/fixtures/` contains sample CRs (ClusterOrder, 
 
 ### CI Workflows
 
-**`.github/workflows/tests.yml`:**
-- `ansible-lint` — Lints all playbooks and roles
-- `integration-tests` — Full test suite with kind cluster (storage tests conditionally enabled via `STORAGE_TESTS_ENABLED=true` environment variable in CI)
+**`.github/workflows/ansible-lint.yml`:**
+- Dedicated ansible-lint validation on PRs
+
+**`.github/workflows/integration-tests.yml`:**
+- Full test suite with kind cluster (storage tests conditionally enabled via `STORAGE_TESTS_ENABLED=true` environment variable in CI)
 
 **`.github/workflows/e2e-vmaas-full-install.yml`:**
 - End-to-end VMaaS installation testing
-- Trigger: PR comment `/ok-to-test` (requires org membership for fork PRs)
+- Triggers: `pull_request`, scheduled (every 12h), `workflow_dispatch`
+
+**`.github/workflows/e2e-bmaas-full-install.yml`:**
+- End-to-end BM-as-a-Service installation testing
 
 **`.github/workflows/pre-commit.yaml`:**
 - Runs all pre-commit hooks on PRs
@@ -244,9 +253,18 @@ Test fixtures: `tests/integration/fixtures/` contains sample CRs (ClusterOrder, 
 **`.github/workflows/helm-lint.yaml`:**
 - Validates Helm chart syntax
 
-**Execution environment container build:**
-- Container images are built from `execution-environment/execution-environment.yaml`
-- CI validates the build definition and produces images for AAP deployment
+**`.github/workflows/execution-environment.yml`:**
+- Container images built from `execution-environment/execution-environment.yaml`
+- Validates the build definition and produces images for AAP deployment
+
+**`.github/workflows/publish-charts.yaml`:**
+- Publishes Helm charts on release tags
+
+**`.github/workflows/ok-to-test-label-cleanup.yml`:**
+- Removes `ok-to-test` label on new pushes to PRs
+
+**`.github/workflows/slash-command.yml`:**
+- Handles slash commands in PR comments
 
 ## Building
 
@@ -352,11 +370,11 @@ Note: Use `Assisted-by`, not `Co-Authored-By` (Red Hat attribution standard).
 ### CI Checks
 
 All PRs must pass:
-1. `pre-commit` — All pre-commit hooks
-2. `ansible-lint` — Playbook and role linting
-3. `integration-tests` — Full test suite with kind cluster
-4. `helm-lint` — Helm chart validation
-5. Execution environment container image build validation
+1. `pre-commit` — All pre-commit hooks (`pre-commit.yaml`)
+2. `ansible-lint` — Playbook and role linting (`ansible-lint.yml`)
+3. `integration-tests` — Full test suite with kind cluster (`integration-tests.yml`)
+4. `helm-lint` — Helm chart validation (`helm-lint.yaml`)
+5. `execution-environment` — Container image build validation (`execution-environment.yml`)
 
 ### Review Process
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,7 +369,7 @@ Note: Use `Assisted-by`, not `Co-Authored-By` (Red Hat attribution standard).
 
 ### CI Checks
 
-All PRs must pass:
+All PRs must pass (docs-only PRs — `*.md`, `docs/` — skip checks 1-3 via `paths-ignore`):
 1. `pre-commit` — All pre-commit hooks (`pre-commit.yaml`)
 2. `ansible-lint` — Playbook and role linting (`ansible-lint.yml`)
 3. `integration-tests` — Full test suite with kind cluster (`integration-tests.yml`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,77 +4,18 @@
 
 ## Project Overview
 
-The osac-aap repository contains Ansible automation for provisioning OSAC (Open Sovereign AI Cloud) infrastructure resources. It integrates with Ansible Automation Platform (AAP) and provides playbooks, collections, template roles, and Config-as-Code. This repository was created by merging osac-templates into osac-aap.
-
-## Critical Rules
-
-- **Use FQCN** for all modules: `ansible.builtin.debug`, not `debug`
-- **Add `name:` to every task** — ansible-lint enforces this
-- **Use underscores** in role names and `implementation_strategy`, never hyphens
-- **Always include `osac.service.common`** to get `remote_cluster_kubeconfig` before creating K8s resources on remote clusters
-- **Run `ansible-lint`** before committing
-
-## Repository Structure
-
-```text
-osac-aap/
-├── playbook_osac_*.yml                    # Top-level playbooks (AAP job templates)
-├── collections/ansible_collections/
-│   ├── osac.service/                      # Core service roles (common utilities)
-│   ├── osac.templates/                    # Infrastructure templates
-│   ├── osac.workflows/                    # Multi-step workflows
-│   └── osac.config_as_code/              # AAP configuration
-├── vendor/                                # Vendored Ansible collections
-├── tests/                                 # Integration test suites
-├── samples/                               # Example configurations
-└── pyproject.toml                         # Python dependencies (uv)
-```
-
-### Collections
-
-| Collection | Purpose | Key Roles |
-|------------|---------|-----------|
-| **osac.service** | Core utilities | `common`, `finalizer`, `lease`, `wait_for`, `publish_templates`, `tenant_storage_class` |
-| **osac.templates** | Infrastructure provisioning | `cudn_net` (networking), `metallb_l2` (PublicIPPool), `ocp_virt_vm` (VMs), `ocp_4_17_small` (clusters) |
-| **osac.workflows** | Multi-step playbooks | Cluster create/delete, compute instance lifecycle |
-| **osac.config_as_code** | AAP configuration | Job templates, inventories, credentials |
-
-## Quick Reference Commands
-
-```bash
-# Setup
-uv sync --all-groups && source .venv/bin/activate
-
-# Lint
-ansible-lint
-
-# Test playbook syntax
-ansible-playbook --syntax-check playbook_osac_create_subnet.yml
-
-# Test playbook locally
-ansible-playbook playbook_osac_create_subnet.yml -e @samples/subnet_payload.json
-
-# Re-vendor collections (after updating collections/requirements.yml)
-rm -rf vendor && ansible-galaxy collection install -r collections/requirements.yml
-```
+Ansible automation for OSAC infrastructure provisioning. See `AGENTS.md` for complete collection reference, development commands, linting configuration, CI workflows, and PR checklist.
 
 ## Detailed Rules (auto-loaded from `.claude/rules/`)
 
 - **`playbook-patterns.md`** — Playbook naming, template roles, service roles, standard patterns, variable flow
 - **`networking-cudn.md`** — CUDN networking implementation details (VirtualNetwork, Subnet, SecurityGroup)
 
-## Creating a New Template Role
-
-1. Create role at `collections/ansible_collections/osac/templates/roles/<name>/`
-2. Add `meta/osac.yaml` with `implementation_strategy`, `template_type`, `capabilities`
-3. Create task files: `tasks/create_<resource>.yaml`, `tasks/delete_<resource>.yaml`
-4. Run `playbook_osac_config_as_code.yml` to register and publish NetworkClass
-
 ## Common Pitfalls
 
 1. **venv not activated** — `ansible-playbook: command not found` → `source .venv/bin/activate` or `uv run`
 2. **Stale vendored collections** — re-vendor after updating `collections/requirements.yml`
-3. **Implementation strategy mismatch** — role dir name, `meta/osac.yaml`, and CR annotation must all match (use underscores)
+3. **Implementation strategy mismatch** — for new roles, role dir name, `meta/osac.yaml`, and CR annotation must all match (use underscores). See `AGENTS.md` for existing exceptions (`metallb_l2`, `vast_storage`)
 4. **Missing remote kubeconfig** — always include `osac.service.common` with `tasks_from: get_remote_cluster_kubeconfig`
 5. **Namespace label syntax** — `k8s.ovn.org/primary-user-defined-network: ""` (empty string, not missing value)
 
@@ -91,24 +32,6 @@ rm -rf vendor && ansible-galaxy collection install -r collections/requirements.y
 2. osac-aap: Run config-as-code to publish NetworkClass
 3. fulfillment-service: NetworkClass auto-discovered in API
 4. Users: Create VirtualNetwork with new `networkClass`
-
-## Development Workflow
-
-```bash
-# Before committing
-ansible-lint
-ansible-playbook --syntax-check playbook_osac_create_subnet.yml
-
-# Commit format
-git commit -s -m "MGMT-XXXXX: description of change"
-```
-
-### PR Checklist
-
-- [ ] `ansible-lint` passes
-- [ ] `meta/osac.yaml` updated for template role changes
-- [ ] Cross-repo dependencies documented in PR description
-- [ ] Playbook tested locally or against AAP
 
 ## Links
 


### PR DESCRIPTION
## Summary
- Fix stale role/workflow references in AGENTS.md after upstream renames (`bm_host_metal3_provisioning` → `bm_host_provisioning`, `tests.yml` → `ansible-lint.yml` + `integration-tests.yml`)
- Add missing items: `ocp_4_20_small_nico`, `openstack_bm_node`, `ci/` namespace, 5 undocumented CI workflows
- Fix e2e-vmaas trigger description to match actual workflow config
- Slim CLAUDE.md to Claude-specific entry point, removing sections now covered by AGENTS.md

## Test plan
- [x] Verified all 16 template roles, 21 service roles, 6 collection namespaces, and 10 CI workflows match actual repo contents
- [x] Confirmed no content duplication between AGENTS.md and CLAUDE.md
- [x] Checked no Claude-specific content was lost in CLAUDE.md slimdown

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository guidance to reflect the current layout, collections, template roles, and CI workflows.
  * Clarified required CI checks and documented additional operational workflows.
  * Streamlined contributor guidance and removed outdated development workflow and checklist content.
  * Updated OpenShift template references and service role documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->