### PR TITLE
OSAC-1684: Add scan-workflow-logs listener

### DIFF
--- a/.github/workflows/scan-workflow-logs.yml
+++ b/.github/workflows/scan-workflow-logs.yml
@@ -1,0 +1,323 @@
+---
+name: Scan workflow logs
+
+# Mirrors osac-test-infra's own scan-workflow-logs.yml so this repo's own e2e
+# runs also get immediate post-run credential scanning: workflow_run can't
+# cross repos, so each repo that calls the reusable e2e workflows needs its
+# own listener. The actual scanning logic is NOT duplicated -- this just
+# invokes osac-test-infra's shared composite actions cross-repo. Keep the
+# `workflows:` list in sync with whatever this repo's own e2e-calling
+# workflow(s) are named (see osac-test-infra's
+# audit-workflow-logs.yml / discover-audit-runs.sh for how to check for drift).
+#
+# This -- and the equivalent copy in every other repo that calls the
+# reusable e2e workflows -- becomes unnecessary once the planned monorepo
+# migration lands and everything is one repo.
+#
+# Fires for any conclusion including cancelled -- earlier jobs may already
+# have printed secrets before cancel.
+on:
+  workflow_run:  # zizmor: ignore[dangerous-triggers] -- no PR-head checkout; only trusted SHA-pinned/local composite actions; untrusted event data via env:, never interpolated into run: bodies.
+    workflows:
+      - E2E VMaaS Full Install
+      - E2E BMaaS Full Install
+    types: [completed]
+
+concurrency:
+  group: scan-workflow-logs-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+# Deny-by-default at the workflow level, so a future job added to this file
+# without its own explicit `permissions:` block gets nothing rather than a
+# broad implicit GITHUB_TOKEN scope -- the job below already sets its own
+# least-privilege block regardless, this is just the safety net for later.
+permissions: {}
+
+jobs:
+  scan-logs:
+    name: Scan and purge run logs
+    runs-on: osac-ci
+    timeout-minutes: 15
+    permissions:
+      # Fetching and deleting the completed run's logs needs actions:write.
+      actions: write  # fetch/delete completed run's logs
+      pull-requests: write  # comment leak findings on the triggering PR
+    steps:
+      - name: Scan and purge run logs
+        id: scan
+        uses: osac-project/osac-test-infra/.github/actions/scan-and-purge-logs@b1f29a958073a6271b37ce45f2093f07ba31b8fa  # main
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Comment on an associated open PR when leaks were found. Schedule /
+      # dispatch / no-PR runs skip quietly. Body uses sanitized findings
+      # only (Rule / File / Line) -- never secret values.
+      # md_cell is inlined (mirrors have no checkout / no md-cell.jq); keep
+      # transforms in sync with osac-test-infra .github/scripts/md-cell.jq.
+      - name: Comment on PR if leaks found
+        if: always() && steps.scan.outputs.leaks-found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          E2E_RUN_ID: ${{ github.event.workflow_run.id }}
+          E2E_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          E2E_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          # Often empty on workflow_run (esp. fork PRs) -- fallback below.
+          PR_FROM_EVENT: ${{ github.event.workflow_run.pull_requests[0].number }}
+          FINDINGS_COUNT: ${{ steps.scan.outputs.findings-count }}
+          PURGE_OK: ${{ steps.scan.outputs.purge-ok }}
+          OUTPUT_DIR: ${{ steps.scan.outputs.output-dir }}
+          SCAN_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Resolve exactly one open PR for this e2e head SHA. Paginate the
+          # commit→PRs API so a truncated first page cannot hide siblings.
+          # Event PR number alone is not enough (stale/closed/ambiguous).
+          PR_NUMBER=""
+          # Do not `|| echo '[]'` after jq: with pipefail, gh failure can make
+          # jq already emit [] and then echo append a second [], breaking jq.
+          if ! OPEN_PRS_JSON=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/pulls" \
+            --jq '.[] | select(.state == "open") | .number' 2>/dev/null \
+            | jq -s 'unique'); then
+            echo "::warning::Unable to resolve an open PR for ${HEAD_SHA} (${HEAD_BRANCH}); skipping PR comment."
+            exit 0
+          fi
+          OPEN_PR_COUNT=$(jq 'length' <<<"${OPEN_PRS_JSON}")
+          if [[ "${OPEN_PR_COUNT}" -eq 1 ]]; then
+            PR_NUMBER=$(jq -r '.[0]' <<<"${OPEN_PRS_JSON}")
+          elif [[ "${OPEN_PR_COUNT}" -gt 1 ]]; then
+            echo "Ambiguous: ${OPEN_PR_COUNT} open PRs for ${HEAD_SHA} (${HEAD_BRANCH}) -- skipping PR comment."
+            exit 0
+          else
+            echo "No open PR associated with ${HEAD_SHA} (${HEAD_BRANCH}) -- skipping PR comment."
+            exit 0
+          fi
+          if [[ -n "${PR_FROM_EVENT}" && "${PR_FROM_EVENT}" != "null" \
+            && "${PR_FROM_EVENT}" != "${PR_NUMBER}" ]]; then
+            echo "Note: workflow_run event PR #${PR_FROM_EVENT} differs from unique open PR #${PR_NUMBER} for ${HEAD_SHA}; commenting on #${PR_NUMBER}."
+          fi
+
+          # Same transforms as osac-test-infra .github/scripts/md-cell.jq
+          md_cell() {
+            printf '%s' "${1}" | jq -Rrs '
+              gsub("[\r\n]"; " ")
+              | gsub("&"; "&amp;")
+              | gsub("<"; "&lt;")
+              | gsub(">"; "&gt;")
+              | gsub("\\|"; "\\|")
+            '
+          }
+
+          E2E_NAME_SAFE=$(md_cell "${E2E_NAME}")
+
+          BODY_FILE="${RUNNER_TEMP}/pr-leak-comment.md"
+          {
+            echo "### :rotating_light: Credential leak scan found secrets in e2e run logs/artifacts"
+            echo ""
+            echo "**Workflow:** ${E2E_NAME_SAFE}"
+            echo "**E2E run:** [${E2E_RUN_ID}](${E2E_RUN_URL})"
+            echo "**Scan run:** [Scan workflow logs](${SCAN_RUN_URL})"
+            echo "**Findings:** ${FINDINGS_COUNT}"
+            echo ""
+            if [[ "${PURGE_OK}" == "true" ]]; then
+              echo "Tainted raw logs and/or artifacts for that e2e run were deleted to close the exposure window."
+            else
+              echo ":warning: **Purge incomplete** -- raw logs and/or artifacts may still be on GitHub. Check the scan run and delete manually if needed."
+            fi
+            echo ""
+            echo "Rotate any credential(s) below that are real (not test/dev-only values)."
+            echo ""
+            echo "| Rule | File | Line |"
+            echo "|---|---|---|"
+            if [[ -f "${OUTPUT_DIR}/findings.json" ]]; then
+              jq -r '
+                def cell:
+                  tostring
+                  | gsub("[\r\n]"; " ")
+                  | gsub("&"; "&amp;")
+                  | gsub("<"; "&lt;")
+                  | gsub(">"; "&gt;")
+                  | gsub("\\|"; "\\|");
+                .[] | "| \(.RuleID | cell) | \(.File | cell) | \(.StartLine | cell) |"
+              ' "${OUTPUT_DIR}/findings.json"
+            else
+              echo "| _(findings.json missing)_ | | |"
+            fi
+          } > "${BODY_FILE}"
+
+          # Comment is best-effort -- scan/purge already succeeded; a
+          # transient API error or closed-PR race must not fail the job.
+          if gh pr comment "${PR_NUMBER}" -R "${REPO}" --body-file "${BODY_FILE}"; then
+            echo "Commented on PR #${PR_NUMBER}."
+          else
+            echo "::warning::Failed to comment on PR #${PR_NUMBER} -- leak was still detected; see scan job summary/Slack for purge status."
+          fi
+
+      # --- Secret bootstrap (inline — must not run PR-controlled code) ---
+      # Fetched only if actually needed for the Slack notification below, so
+      # a Vault/AppRole outage can never block the scan/purge above -- that's
+      # the security-critical part and must run regardless. `outcome ==
+      # 'failure'` (not just the leaks-found/scan-ok outputs) covers the case
+      # where the composite action fails so hard it never sets either output.
+      #
+      # Compute the shared alert predicate once so AppRole/Vault/payload/notify
+      # cannot drift if the trigger logic changes.
+      - name: Determine alert condition
+        if: always()
+        id: should-alert
+        env:
+          SCAN_OUTCOME: ${{ steps.scan.outcome }}
+          LEAKS_FOUND: ${{ steps.scan.outputs.leaks-found }}
+          SCAN_OK: ${{ steps.scan.outputs.scan-ok }}
+        run: |
+          set -euo pipefail
+          # Alert on cancelled/skipped/missing outputs too -- only a fully
+          # successful scan with an explicit scan-ok=true is quiet.
+          if [[ "${SCAN_OUTCOME}" != "success" || "${LEAKS_FOUND}" == "true" || "${SCAN_OK}" != "true" ]]; then
+            echo "value=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "value=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Read AppRole credentials
+        if: always() && steps.should-alert.outputs.value == 'true'
+        id: approle
+        run: |
+          set -euo pipefail
+          APPROLE_DIR="${HOME}/.vault-server/.approle"
+          ROLE_ID=$(cat "${APPROLE_DIR}/role-id")
+          SECRET_ID=$(cat "${APPROLE_DIR}/secret-id")
+          if [[ -z "${ROLE_ID}" || -z "${SECRET_ID}" ]]; then
+            echo "::error::AppRole credentials missing or empty in ${APPROLE_DIR}"
+            exit 1
+          fi
+          echo "role-id=${ROLE_ID}" >> "${GITHUB_OUTPUT}"
+          echo "::add-mask::${SECRET_ID}"
+          echo "secret-id=${SECRET_ID}" >> "${GITHUB_OUTPUT}"
+
+      - name: Retrieve Slack webhook from Vault
+        if: >
+          always() &&
+          steps.should-alert.outputs.value == 'true' &&
+          steps.approle.outcome == 'success'
+        id: vault
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc  # v4
+        with:
+          url: http://127.0.0.1:8200
+          method: approle
+          roleId: ${{ steps.approle.outputs.role-id }}
+          secretId: ${{ steps.approle.outputs.secret-id }}
+          exportEnv: false
+          secrets: |
+            secret/data/osac/e2e/slack-webhook-url url | SLACK_WEBHOOK_URL
+
+      # always(): a bare boolean condition implicitly ANDs with success(), so
+      # without this, a hard failure in the scan/purge step above -- exactly
+      # the failure most worth alerting on -- would skip this notification.
+      # steps.scan.outputs.purge-ok isn't listed in the condition itself --
+      # it can only be 'false' when leaks-found is already 'true' (purge
+      # only ever runs after a leak is found), so that's already covered;
+      # it's surfaced in the message below instead, prioritized ahead of
+      # the plain "detected" message since it needs more urgent action.
+      #
+      # Credential-only findings (leaks found, scan completed, raw logs
+      # purged) use status=warning, not failure: today's e2e logs still
+      # commonly contain secrets we have not finished scrubbing, and
+      # treating those as FAILED blocks blessing otherwise-green PRs.
+      # Real problems -- purge failed, scan failed, or the scan action
+      # itself hard-failed -- stay failure.
+      #
+      # Resolve status/failed-step in bash (not nested GH expressions) so
+      # branch precedence stays auditable. Order matters: purge-ok=false
+      # covers both "leak found but delete failed" and "scan failed after
+      # fetch" (raw content remains). leaks-found + non-success outcome
+      # must beat the generic outcome!=success branch.
+      - name: Resolve Slack notification payload
+        if: always() && steps.should-alert.outputs.value == 'true'
+        id: slack-payload
+        env:
+          LEAKS_FOUND: ${{ steps.scan.outputs.leaks-found }}
+          SCAN_OK: ${{ steps.scan.outputs.scan-ok }}
+          PURGE_OK: ${{ steps.scan.outputs.purge-ok }}
+          SCAN_OUTCOME: ${{ steps.scan.outcome }}
+          FINDINGS_COUNT: ${{ steps.scan.outputs.findings-count }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${LEAKS_FOUND}" == "true" && "${SCAN_OUTCOME}" == "success" && "${SCAN_OK}" == "true" && "${PURGE_OK}" == "true" ]]; then
+            status=warning
+          else
+            status=failure
+          fi
+
+          if [[ "${LEAKS_FOUND}" == "true" && "${SCAN_OK}" == "true" && "${PURGE_OK}" == "false" ]]; then
+            failed_step='Credential(s) detected, but raw logs/artifacts could not be fully deleted -- exposure window is still open, immediate remediation required'
+          elif [[ "${SCAN_OK}" == "false" && "${PURGE_OK}" == "false" ]]; then
+            failed_step='Scan failed after content was fetched -- raw logs/artifacts may still be on GitHub, check run logs'
+          elif [[ "${LEAKS_FOUND}" == "true" && "${SCAN_OUTCOME}" != "success" ]]; then
+            failed_step="Credential(s) detected in run logs/artifacts (${FINDINGS_COUNT} finding(s)); scan action did not complete -- see run logs"
+          elif [[ "${SCAN_OUTCOME}" != "success" ]]; then
+            failed_step='Scan/purge action did not complete -- see run logs'
+          elif [[ "${LEAKS_FOUND}" == "true" ]]; then
+            failed_step="Credential(s) detected in run logs/artifacts (${FINDINGS_COUNT} finding(s))"
+          else
+            failed_step='Could not fully scan run logs/artifacts for leaked credentials'
+          fi
+
+          {
+            echo "status=${status}"
+            echo "failed-step<<EOF"
+            echo "${failed_step}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      # Require vault success so an AppRole/Vault outage does not re-fail the
+      # job via curl on an empty webhook after scan/purge already finished.
+      - name: Notify Slack on leak or scan failure
+        id: notify-slack
+        if: >
+          always() &&
+          steps.should-alert.outputs.value == 'true' &&
+          steps.vault.outcome == 'success' &&
+          steps.slack-payload.outcome == 'success'
+        uses: osac-project/osac-test-infra/.github/actions/notify-slack@b1f29a958073a6271b37ce45f2093f07ba31b8fa  # main
+        with:
+          status: ${{ steps.slack-payload.outputs.status }}
+          workflow-name: ${{ github.event.workflow_run.name }}
+          failed-step: ${{ steps.slack-payload.outputs.failed-step }}
+          slack-webhook-url: ${{ steps.vault.outputs.SLACK_WEBHOOK_URL }}
+          workflow-url: ${{ github.event.workflow_run.html_url }}
+          branch-name: ${{ github.event.workflow_run.head_branch }}
+          commit-sha: ${{ github.event.workflow_run.head_sha }}
+
+      # Vault/payload/notify failure: keep the security-relevant event visible
+      # via annotation + job summary so it is not silent.
+      - name: Surface alert when Slack notify unavailable
+        if: >
+          always() &&
+          steps.should-alert.outputs.value == 'true' &&
+          (steps.vault.outcome != 'success' ||
+           steps.slack-payload.outcome != 'success' ||
+           steps.notify-slack.outcome != 'success')
+        env:
+          FAILED_STEP: ${{ steps.slack-payload.outputs.failed-step }}
+          VAULT_OUTCOME: ${{ steps.vault.outcome }}
+          PAYLOAD_OUTCOME: ${{ steps.slack-payload.outcome }}
+          NOTIFY_OUTCOME: ${{ steps.notify-slack.outcome }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+          alert="${FAILED_STEP:-scan/leak alert condition met}"
+          reason="Slack notification unavailable (vault=${VAULT_OUTCOME}, slack-payload=${PAYLOAD_OUTCOME}, notify-slack=${NOTIFY_OUTCOME})"
+          echo "::error::${reason}. Underlying alert: ${alert}. Run: ${WORKFLOW_URL}"
+          {
+            echo "## Slack notify unavailable"
+            echo ""
+            echo "- **Reason:** ${reason}"
+            echo "- **Alert:** ${alert}"
+            echo "- **Upstream run:** ${WORKFLOW_URL}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/scan-workflow-logs.yml
+++ b/.github/workflows/scan-workflow-logs.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Scan and purge run logs
         id: scan
-        uses: osac-project/osac-test-infra/.github/actions/scan-and-purge-logs@b1f29a958073a6271b37ce45f2093f07ba31b8fa  # main
+        uses: osac-project/osac-test-infra/.github/actions/scan-and-purge-logs@9d3ac6ce2cac0233afc529b5798e8e9e818dba4e  # main
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -175,6 +175,14 @@ jobs:
           SCAN_OK: ${{ steps.scan.outputs.scan-ok }}
         run: |
           set -euo pipefail
+          # TEMP (post osac-test-infra#262 / OSAC-1684): mute Slack while e2e
+          # logs still commonly leak. Scan/purge + PR comments stay enabled
+          # (they run before this step). Keep should-alert.value accurate so
+          # job summary / annotations still surface the condition. Set
+          # MUTE_SLACK_ALERTS=false to re-enable Slack. Mirror of
+          # osac-test-infra PR #280.
+          MUTE_SLACK_ALERTS=true
+          echo "muted=${MUTE_SLACK_ALERTS}" >> "${GITHUB_OUTPUT}"
           # Alert on cancelled/skipped/missing outputs too -- only a fully
           # successful scan with an explicit scan-ok=true is quiet.
           if [[ "${SCAN_OUTCOME}" != "success" || "${LEAKS_FOUND}" == "true" || "${SCAN_OK}" != "true" ]]; then
@@ -182,9 +190,15 @@ jobs:
           else
             echo "value=false" >> "${GITHUB_OUTPUT}"
           fi
+          if [[ "${MUTE_SLACK_ALERTS}" == "true" ]]; then
+            echo "Slack alerts temporarily muted (MUTE_SLACK_ALERTS=true); scan/purge + PR comments unchanged"
+          fi
 
       - name: Read AppRole credentials
-        if: always() && steps.should-alert.outputs.value == 'true'
+        if: >
+          always() &&
+          steps.should-alert.outputs.value == 'true' &&
+          steps.should-alert.outputs.muted != 'true'
         id: approle
         run: |
           set -euo pipefail
@@ -203,6 +217,7 @@ jobs:
         if: >
           always() &&
           steps.should-alert.outputs.value == 'true' &&
+          steps.should-alert.outputs.muted != 'true' &&
           steps.approle.outcome == 'success'
         id: vault
         uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc  # v4
@@ -282,9 +297,10 @@ jobs:
         if: >
           always() &&
           steps.should-alert.outputs.value == 'true' &&
+          steps.should-alert.outputs.muted != 'true' &&
           steps.vault.outcome == 'success' &&
           steps.slack-payload.outcome == 'success'
-        uses: osac-project/osac-test-infra/.github/actions/notify-slack@b1f29a958073a6271b37ce45f2093f07ba31b8fa  # main
+        uses: osac-project/osac-test-infra/.github/actions/notify-slack@9d3ac6ce2cac0233afc529b5798e8e9e818dba4e  # main
         with:
           status: ${{ steps.slack-payload.outputs.status }}
           workflow-name: ${{ github.event.workflow_run.name }}
@@ -295,11 +311,14 @@ jobs:
           commit-sha: ${{ github.event.workflow_run.head_sha }}
 
       # Vault/payload/notify failure: keep the security-relevant event visible
-      # via annotation + job summary so it is not silent.
+      # via annotation + job summary so it is not silent. Skip when Slack is
+      # intentionally muted -- the muted-summary step below covers that case
+      # without pretending Vault/notify failed.
       - name: Surface alert when Slack notify unavailable
         if: >
           always() &&
           steps.should-alert.outputs.value == 'true' &&
+          steps.should-alert.outputs.muted != 'true' &&
           (steps.vault.outcome != 'success' ||
            steps.slack-payload.outcome != 'success' ||
            steps.notify-slack.outcome != 'success')
@@ -320,4 +339,26 @@ jobs:
             echo "- **Reason:** ${reason}"
             echo "- **Alert:** ${alert}"
             echo "- **Upstream run:** ${WORKFLOW_URL}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      # TEMP mute path: still record the alert in the job summary so a muted
+      # Slack channel does not also hide the condition from Actions UI.
+      - name: Surface alert while Slack muted
+        if: >
+          always() &&
+          steps.should-alert.outputs.value == 'true' &&
+          steps.should-alert.outputs.muted == 'true'
+        env:
+          FAILED_STEP: ${{ steps.slack-payload.outputs.failed-step }}
+          WORKFLOW_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -euo pipefail
+          alert="${FAILED_STEP:-scan/leak alert condition met}"
+          echo "::notice::Slack muted (TEMP post osac-test-infra#262); alert still recorded: ${alert}. Run: ${WORKFLOW_URL}"
+          {
+            echo "## Slack muted (temporary)"
+            echo ""
+            echo "- **Alert:** ${alert}"
+            echo "- **Upstream run:** ${WORKFLOW_URL}"
+            echo "- **Re-enable:** set \`MUTE_SLACK_ALERTS=false\` in \`scan-workflow-logs.yml\`"
           } >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Summary
- Mirrors the `osac-test-infra` `scan-workflow-logs` listener via the cross-repo composite action.
- Listens for **E2E VMaaS Full Install** and **E2E BMaaS Full Install**.
- Comments sanitized findings on the triggering PR.
- **Temporarily mutes Slack** (`MUTE_SLACK_ALERTS=true`, same as [osac-test-infra#280](https://github.com/osac-project/osac-test-infra/pull/280)) so merge does not flood the channel while e2e logs still commonly leak. Job summary / `::notice::` still records alerts.
- Cross-repo actions SHA-pinned to post-#280 `osac-test-infra` `main` (`9d3ac6c`).

## Test plan
- [ ] Confirm workflow triggers on completed VMaaS/BMaaS Full Install runs (including cancelled)
- [ ] Confirm AppRole/Vault/Notify Slack are skipped when muted
- [ ] Confirm job summary shows **Slack muted (temporary)** on a leak/failure
- [ ] Confirm scan/purge still runs; PR comment still posts when an open PR exists