### PR TITLE
OSAC-1992: read tier definitions and backend credentials from AAP extra_vars

### DIFF
--- a/.claude/rules/playbook-patterns.md
+++ b/.claude/rules/playbook-patterns.md
@@ -47,6 +47,32 @@ AAP job templates: `osac-{action}-{resource}`
 3. Dynamically includes the appropriate role from `osac.templates`
 4. Role performs actual provisioning (creates K8s resources, updates CR)
 
+### Show EDA Event and Sensitive `payload.spec` Fields
+
+The bare `debug: var: ansible_eda.event.payload` shown above is safe as long as
+nothing in `payload.spec` is a secret. Some CR specs are not — e.g.
+`blockEncryptionPassphrase` on Tenant/ClusterOrder/ComputeInstance CRs. Before
+adding this debug task to a new or existing playbook, check whether the
+playbook also reads a sensitive field out of `payload.spec`; if it does, use
+the shared, centralized task instead of debugging the whole object:
+
+```yaml
+  pre_tasks:
+    - name: Show EDA Event metadata
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
+      vars:
+        eda_event_extra_fields:
+          template_id: "{{ ansible_eda.event.payload.spec.templateID | default('unknown') }}"
+```
+
+This logs `kind`/`metadata.name`/`metadata.namespace`/`metadata.uid` plus any
+additional non-sensitive fields passed via `eda_event_extra_fields` — never
+source an `eda_event_extra_fields` value from `payload.spec` without first
+confirming it isn't a secret. See
+`collections/ansible_collections/osac/service/roles/common/tasks/show_eda_event_metadata.yaml`.
+
 ## Template Roles
 
 Live in `collections/ansible_collections/osac/templates/roles/`. Each must have `meta/osac.yaml`:

--- a/collections/ansible_collections/osac/config_as_code/roles/aap/templates/compute-instance-operations-ig.j2
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/templates/compute-instance-operations-ig.j2
@@ -44,10 +44,6 @@ spec:
             name: storage-operations-ig
             optional: true
       env:
-        - name: OSAC_STORAGE_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         - name: OSAC_COMPUTE_INSTANCE_OPERATIONS_NAMESPACE_DEFAULT
           valueFrom:
             fieldRef:

--- a/collections/ansible_collections/osac/config_as_code/roles/aap/templates/storage-operations-ig.j2
+++ b/collections/ansible_collections/osac/config_as_code/roles/aap/templates/storage-operations-ig.j2
@@ -34,11 +34,6 @@ spec:
         - configMapRef:
             name: storage-operations-ig
             optional: true
-      env:
-        - name: OSAC_STORAGE_CONFIG_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
   volumes:
     - name: kube-api-access
       projected:

--- a/collections/ansible_collections/osac/service/roles/common/tasks/show_eda_event_metadata.yaml
+++ b/collections/ansible_collections/osac/service/roles/common/tasks/show_eda_event_metadata.yaml
@@ -1,0 +1,25 @@
+---
+# Centralized, redacted replacement for `debug: var: ansible_eda.event.payload`.
+# Use this instead of debugging the whole payload object whenever the calling
+# playbook also reads a sensitive field out of payload.spec (e.g.
+# blockEncryptionPassphrase) -- the whole-object debug prints secrets in
+# cleartext to the job log, which the runner then tails on failure.
+#
+# Always logs: payload kind, metadata.name, metadata.namespace, metadata.uid.
+#
+# Optional caller var:
+#   eda_event_extra_fields — dict of additional non-sensitive key/value pairs
+#                            to include (e.g. tenant_annotation, template_id).
+#                            Never source a value from payload.spec here
+#                            without confirming it isn't a secret first.
+- name: Show EDA Event metadata
+  ansible.builtin.debug:
+    msg: >-
+      {{
+        {
+          'kind': ansible_eda.event.payload.kind | default('unknown'),
+          'name': ansible_eda.event.payload.metadata.name | default('unknown'),
+          'namespace': ansible_eda.event.payload.metadata.namespace | default('unknown'),
+          'uid': ansible_eda.event.payload.metadata.uid | default('unknown'),
+        } | combine(eda_event_extra_fields | default({}))
+      }}

--- a/collections/ansible_collections/osac/service/roles/common/tasks/show_eda_event_metadata.yaml
+++ b/collections/ansible_collections/osac/service/roles/common/tasks/show_eda_event_metadata.yaml
@@ -9,17 +9,41 @@
 #
 # Optional caller var:
 #   eda_event_extra_fields — dict of additional non-sensitive key/value pairs
-#                            to include (e.g. tenant_annotation, template_id).
-#                            Never source a value from payload.spec here
-#                            without confirming it isn't a secret first.
+#                            to include. Keys are restricted to the allowlist
+#                            below, and the fixed kind/name/namespace/uid
+#                            fields always win on conflict -- this task is
+#                            the single redaction boundary for
+#                            ansible_eda.event.payload, so a new field must
+#                            be deliberately added to the allowlist here, not
+#                            silently accepted from any caller. Never add a
+#                            key whose value could be sourced from
+#                            payload.spec without confirming it isn't a
+#                            secret first.
+- name: Validate eda_event_extra_fields keys are on the allowlist
+  ansible.builtin.fail:
+    msg: >-
+      eda_event_extra_fields contains a key not on the allowlist:
+      {{ (eda_event_extra_fields | default({}) | list) | difference(_eda_event_extra_fields_allowlist) }}.
+      Add it to _eda_event_extra_fields_allowlist in show_eda_event_metadata.yaml
+      first -- this task is the single redaction boundary for
+      ansible_eda.event.payload, and new fields must be deliberately approved.
+  vars:
+    _eda_event_extra_fields_allowlist:
+      - tenant_annotation
+      - template_id
+  when: >-
+    (eda_event_extra_fields | default({}) | list)
+    | difference(_eda_event_extra_fields_allowlist) | length > 0
+
 - name: Show EDA Event metadata
   ansible.builtin.debug:
     msg: >-
       {{
-        {
-          'kind': ansible_eda.event.payload.kind | default('unknown'),
-          'name': ansible_eda.event.payload.metadata.name | default('unknown'),
-          'namespace': ansible_eda.event.payload.metadata.namespace | default('unknown'),
-          'uid': ansible_eda.event.payload.metadata.uid | default('unknown'),
-        } | combine(eda_event_extra_fields | default({}))
+        (eda_event_extra_fields | default({}))
+        | combine({
+            'kind': ansible_eda.event.payload.kind | default('unknown'),
+            'name': ansible_eda.event.payload.metadata.name | default('unknown'),
+            'namespace': ansible_eda.event.payload.metadata.namespace | default('unknown'),
+            'uid': ansible_eda.event.payload.metadata.uid | default('unknown'),
+          })
       }}

--- a/collections/ansible_collections/osac/service/roles/storage_provider/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/meta/argument_specs.yaml
@@ -12,12 +12,14 @@ argument_specs:
         required: true
         description: >
           List of storage tier definitions. Each tier declares its name, protocol,
-          provider, and optional QoS/quota settings. The dispatcher groups tiers
-          by provider and dispatches to each provider's template role with the
-          filtered tier subset.
+          provider, backend_id, and optional QoS/quota settings. qos_policy is
+          defaulted by this role when a tier doesn't specify one. The dispatcher
+          groups tiers by provider and dispatches to each provider's template
+          role with the filtered tier subset.
           Example: [{name: default, protocol: nfs, provider: vast,
-          qos_policy: default-qos,
-          qos_limits: {static_limits: {max_reads_bw_mbps: 100, max_writes_bw_mbps: 100}}}]
+          backend_id: be-001,
+          qos_limits: {static_limits: {max_reads_bw_mbps: 100, max_writes_bw_mbps: 100}},
+          quota: 500}]
       storage_provider_action:
         type: str
         required: true

--- a/collections/ansible_collections/osac/service/roles/storage_provider/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/meta/argument_specs.yaml
@@ -13,7 +13,8 @@ argument_specs:
         description: >
           List of storage tier definitions. Each tier declares its name, protocol,
           provider, backend_id, and optional QoS/quota settings. qos_policy is
-          defaulted by this role when a tier doesn't specify one. The dispatcher
+          always derived by this role from the tier name — any caller-supplied
+          qos_policy value is ignored and discarded, never used. The dispatcher
           groups tiers by provider and dispatches to each provider's template
           role with the filtered tier subset.
           Example: [{name: default, protocol: nfs, provider: vast,
@@ -43,13 +44,6 @@ argument_specs:
         description: >
           Passphrase for block encryption. Passed from the Tenant CR event payload.
           When empty, block StorageClasses are created without host encryption.
-      storage_provider_snapshots_enabled:
-        type: bool
-        required: false
-        default: true
-        description: >
-          Create a VolumeSnapshotClass alongside the StorageClass for K8s-native
-          snapshot support. Skipped if the VolumeSnapshot CRD is not installed.
       storage_provider_backend_connections:
         type: dict
         required: false

--- a/collections/ansible_collections/osac/service/roles/storage_provider/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/meta/argument_specs.yaml
@@ -19,7 +19,7 @@ argument_specs:
           Example: [{name: default, protocol: nfs, provider: vast,
           backend_id: be-001,
           qos_limits: {static_limits: {max_reads_bw_mbps: 100, max_writes_bw_mbps: 100}},
-          quota: 500}]
+          quota_bytes: 536870912000}]
       storage_provider_action:
         type: str
         required: true

--- a/collections/ansible_collections/osac/service/roles/storage_provider/meta/argument_specs.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/meta/argument_specs.yaml
@@ -48,3 +48,15 @@ argument_specs:
         description: >
           Create a VolumeSnapshotClass alongside the StorageClass for K8s-native
           snapshot support. Skipped if the VolumeSnapshot CRD is not installed.
+      storage_provider_backend_connections:
+        type: dict
+        required: false
+        default: {}
+        no_log: true
+        description: >
+          Backend connection details (endpoint, username, password), keyed by backend_id,
+          as resolved by osac-operator from the Tier API. Each provider's own
+          credential-sourcing logic looks up the entry for the backend_id(s) present in
+          its dispatched tier subset. Optional because teardown_cluster_storage never
+          needs backend connection details (it only touches cluster-side K8s resources).
+          Example: {be-001: {endpoint: vast.example.com:443, username: admin, password: "***"}}

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
@@ -22,19 +22,7 @@
 - name: "Compute filtered tiers for current provider"
   ansible.builtin.set_fact:
     _computed_provider_tiers: >-
-      {{ (_storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list)
-         | selectattr('name', 'in', _requested_tiers) | list
-         if (_requested_tiers is defined and _requested_tiers | length > 0)
-         else (_storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list) }}
-
-- name: "Fail if requested tier filter produced no matches"
-  when: >-
-    _requested_tiers is defined and _requested_tiers | length > 0 and
-    _computed_provider_tiers | length == 0
-  ansible.builtin.fail:
-    msg: >-
-      None of the requested tiers ({{ _requested_tiers | join(', ') }}) match
-      provider '{{ _current_provider }}' tiers. Check storage_tier_definitions configuration.
+      {{ _storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list }}
 
 - name: "Dispatch provider storage action with remote kubeconfig routing"
   module_defaults:

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
@@ -7,7 +7,7 @@
 #   _dispatch_action   — task file to invoke (setup, ensure_storage_class, teardown_cluster_storage, teardown_backend)
 #
 # Uses from play scope:
-#   storage_provider_tiers              — full tier list (filtered here per provider)
+#   _storage_provider_tiers              — full tier list, qos_policy-defaulted (filtered here per provider)
 #   _cluster_name                        — optional target cluster name override (for volume
 #                                          naming); ensure_storage_class self-discovers it from
 #                                          the target cluster's Infrastructure object when unset
@@ -19,10 +19,10 @@
 - name: "Compute filtered tiers for current provider"
   ansible.builtin.set_fact:
     _computed_provider_tiers: >-
-      {{ (storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list)
+      {{ (_storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list)
          | selectattr('name', 'in', _requested_tiers) | list
          if (_requested_tiers is defined and _requested_tiers | length > 0)
-         else (storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list) }}
+         else (_storage_provider_tiers | selectattr('provider', 'equalto', _current_provider) | list) }}
 
 - name: "Fail if requested tier filter produced no matches"
   when: >-

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
@@ -8,6 +8,9 @@
 #
 # Uses from play scope:
 #   _storage_provider_tiers              — full tier list, qos_policy-defaulted (filtered here per provider)
+#   storage_provider_backend_connections — backend connection details keyed by backend_id,
+#                                          passed through unfiltered (each provider role looks
+#                                          up its own dispatched tiers' backend_id(s) from it)
 #   _cluster_name                        — optional target cluster name override (for volume
 #                                          naming); ensure_storage_class self-discovers it from
 #                                          the target cluster's Infrastructure object when unset
@@ -49,6 +52,7 @@
         public: true
       vars:
         _provider_tiers: "{{ _computed_provider_tiers }}"
+        _provider_backend_connections: "{{ storage_provider_backend_connections }}"
 
 - name: "Accumulate tenant config after dispatch (setup only)"
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tasks/_dispatch_provider.yaml
@@ -34,7 +34,7 @@
   ansible.builtin.fail:
     msg: >-
       None of the requested tiers ({{ _requested_tiers | join(', ') }}) match
-      provider '{{ _current_provider }}' tiers. Check STORAGE_TIERS configuration.
+      provider '{{ _current_provider }}' tiers. Check storage_tier_definitions configuration.
 
 - name: "Dispatch provider storage action with remote kubeconfig routing"
   module_defaults:

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
@@ -61,12 +61,27 @@
   loop: "{{ storage_provider_tiers }}"
   when: item.protocol | length == 0
 
+# Defaulted here (not by each calling playbook) so every caller gets the same
+# qos_policy naming without duplicating the derivation logic per playbook.
+# Written to a role-internal fact, not storage_provider_tiers itself: role/include_role
+# params outrank set_fact for the lifetime of the role invocation, so reassigning
+# storage_provider_tiers here would silently keep the caller-supplied, un-defaulted value.
+- name: Default qos_policy for tiers that do not specify one
+  ansible.builtin.set_fact:
+    _storage_provider_tiers: >-
+      {% set _tiers = [] -%}
+      {% for _tier in storage_provider_tiers -%}
+      {% set _ = _tiers.append(_tier if _tier.qos_policy is defined
+                                else (_tier | combine({'qos_policy': _tier.name + '-qos'}))) -%}
+      {% endfor -%}
+      {{ _tiers }}
+
 - name: Validate qos_policy is a valid DNS label when specified
   ansible.builtin.fail:
     msg: >-
       Tier '{{ item.name }}' has an invalid qos_policy: '{{ item.qos_policy }}'.
       Must be a non-empty string matching DNS label rules (1-63 chars, lowercase alphanumeric and hyphens).
-  loop: "{{ storage_provider_tiers }}"
+  loop: "{{ _storage_provider_tiers }}"
   loop_control:
     label: "{{ item.name }}"
   when:
@@ -92,7 +107,7 @@
 
 - name: Extract unique providers from tier list
   ansible.builtin.set_fact:
-    _unique_providers: "{{ storage_provider_tiers | map(attribute='provider') | unique | sort | list }}"
+    _unique_providers: "{{ _storage_provider_tiers | map(attribute='provider') | unique | sort | list }}"
 
 - name: Set dispatch action
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
@@ -35,6 +35,28 @@
   loop: "{{ storage_provider_tiers }}"
   when: item.name is not defined or not (item.name | regex_search('^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$'))
 
+# A tier name can be a valid 1-63 char DNS label on its own yet still be unusable: tiers
+# with configured qos_limits get a derived qos_policy of '<name>-qos' below, which must
+# ALSO be a valid (<=63 char) DNS label. Caught here, at the same point as the other
+# tier-name checks, rather than surfacing later as a confusing failure on the derived
+# value. Mirrors the has-QoS-limits condition in the derivation step below — must be
+# kept in sync with it.
+- name: Validate QoS-enabled tier names leave room for the derived '-qos' suffix
+  ansible.builtin.fail:
+    msg: >-
+      Tier name '{{ item.name }}' is {{ item.name | length }} characters. Tiers with
+      configured qos_limits get a derived qos_policy of '{{ item.name }}-qos', which must
+      also be a valid DNS label (max 63 characters) — so tier names with QoS limits
+      configured are capped at 59 characters (63 minus the 4-character '-qos' suffix).
+  loop: "{{ storage_provider_tiers }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: >-
+    (item.name | length > 59) and
+    (item.qos_limits is defined and item.qos_limits.static_limits is defined and
+     ((item.qos_limits.static_limits.max_reads_bw_mbps | default(0) | int) > 0 or
+      (item.qos_limits.static_limits.max_writes_bw_mbps | default(0) | int) > 0))
+
 - name: Validate tier names are unique across the entire list
   ansible.builtin.fail:
     msg: >-

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
@@ -61,19 +61,24 @@
   loop: "{{ storage_provider_tiers }}"
   when: item.protocol | length == 0
 
-# Defaulted here (not by each calling playbook) so every caller gets the same
-# qos_policy naming without duplicating the derivation logic per playbook.
+# qos_policy is entirely system-derived — any caller-supplied value is ignored and
+# discarded, never inspected or preserved, consistent with how every other field not
+# in this role's schema is treated (storage_provider_tiers has no elements:/options:
+# schema, so unrecognized tier fields are already silently ignored rather than
+# rejected; qos_policy previously broke that pattern by preserving a caller's value
+# as-is). This is what guarantees every caller actually gets consistent naming, rather
+# than merely being true by convention as long as no caller happens to set it.
+#
 # Written to a role-internal fact, not storage_provider_tiers itself: role/include_role
 # params outrank set_fact for the lifetime of the role invocation, so reassigning
-# storage_provider_tiers here would silently keep the caller-supplied, un-defaulted value.
+# storage_provider_tiers here would silently keep the caller-supplied, un-derived value.
 #
-# Only defaulted for tiers with a configured (non-zero) qos_limits — a tier with no
-# read/write bandwidth limits is treated as "no QoS enforcement wanted" and left
-# without a qos_policy, same as today's behavior when a caller omits qos_policy
-# entirely. The Tier API always sends a qos_limits block (defaulting to zero when
-# unconfigured), so zero-in-both-directions is the only "opt out" signal available
-# without a dedicated field on the tier definition.
-- name: Default qos_policy for tiers with configured QoS limits that do not specify one
+# Only derived for tiers with a configured (non-zero) qos_limits — a tier with no
+# read/write bandwidth limits is treated as "no QoS enforcement wanted" and ends up
+# with no qos_policy at all, even if the caller supplied one. The Tier API always sends
+# a qos_limits block (defaulting to zero when unconfigured), so zero-in-both-directions
+# is the only "opt out" signal available without a dedicated field on the tier definition.
+- name: Derive qos_policy for tiers with configured QoS limits, discarding any caller-supplied value
   ansible.builtin.set_fact:
     _storage_provider_tiers: >-
       {% set _tiers = [] -%}
@@ -81,14 +86,15 @@
       {% set _has_qos_limits = (_tier.qos_limits is defined and _tier.qos_limits.static_limits is defined and
            ((_tier.qos_limits.static_limits.max_reads_bw_mbps | default(0) | int) > 0 or
             (_tier.qos_limits.static_limits.max_writes_bw_mbps | default(0) | int) > 0)) -%}
+      {% set _tier_without_qos_policy = _tier | dict2items | rejectattr('key', 'equalto', 'qos_policy') | items2dict -%}
       {% set _ = _tiers.append(
-           _tier if (_tier.qos_policy is defined or not _has_qos_limits)
-           else (_tier | combine({'qos_policy': _tier.name + '-qos'}))
+           (_tier_without_qos_policy | combine({'qos_policy': _tier.name + '-qos'})) if _has_qos_limits
+           else _tier_without_qos_policy
          ) -%}
       {% endfor -%}
       {{ _tiers }}
 
-- name: Validate qos_policy is a valid DNS label when specified
+- name: Validate derived qos_policy is a valid DNS label
   ansible.builtin.fail:
     msg: >-
       Tier '{{ item.name }}' has an invalid qos_policy: '{{ item.qos_policy }}'.

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tasks/main.yaml
@@ -66,13 +66,25 @@
 # Written to a role-internal fact, not storage_provider_tiers itself: role/include_role
 # params outrank set_fact for the lifetime of the role invocation, so reassigning
 # storage_provider_tiers here would silently keep the caller-supplied, un-defaulted value.
-- name: Default qos_policy for tiers that do not specify one
+#
+# Only defaulted for tiers with a configured (non-zero) qos_limits — a tier with no
+# read/write bandwidth limits is treated as "no QoS enforcement wanted" and left
+# without a qos_policy, same as today's behavior when a caller omits qos_policy
+# entirely. The Tier API always sends a qos_limits block (defaulting to zero when
+# unconfigured), so zero-in-both-directions is the only "opt out" signal available
+# without a dedicated field on the tier definition.
+- name: Default qos_policy for tiers with configured QoS limits that do not specify one
   ansible.builtin.set_fact:
     _storage_provider_tiers: >-
       {% set _tiers = [] -%}
       {% for _tier in storage_provider_tiers -%}
-      {% set _ = _tiers.append(_tier if _tier.qos_policy is defined
-                                else (_tier | combine({'qos_policy': _tier.name + '-qos'}))) -%}
+      {% set _has_qos_limits = (_tier.qos_limits is defined and _tier.qos_limits.static_limits is defined and
+           ((_tier.qos_limits.static_limits.max_reads_bw_mbps | default(0) | int) > 0 or
+            (_tier.qos_limits.static_limits.max_writes_bw_mbps | default(0) | int) > 0)) -%}
+      {% set _ = _tiers.append(
+           _tier if (_tier.qos_policy is defined or not _has_qos_limits)
+           else (_tier | combine({'qos_policy': _tier.name + '-qos'}))
+         ) -%}
       {% endfor -%}
       {{ _tiers }}
 

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
@@ -425,3 +425,84 @@
               - "'non-empty string' in ansible_failed_result.msg"
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
             success_msg: "Role correctly rejected invalid input"
+
+# ──────────────────────────────────────────────────────────────
+# Test 13: Tier with no qos_policy gets a derived one that exceeds DNS label length -- error path
+# Expected: role fails with the qos_policy DNS label validation message, proving the
+# "Default qos_policy for tiers that do not specify one" step actually ran and that its
+# output feeds the existing qos_policy validation (OSAC-1992: tiers from
+# ansible_eda.event.storage_tier_definitions never carry qos_policy -- the role derives it).
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- derived qos_policy exceeds DNS label length (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run derived-qos_policy-too-long failure test
+      block:
+        - name: Attempt with a 60-char tier name (no explicit qos_policy) whose derived name-qos exceeds 63 chars
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                protocol: nfs
+                provider: vast
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when the derived qos_policy exceeds the DNS label length limit"
+
+      rescue:
+        - name: Verify role failed with expected qos_policy DNS label message
+          ansible.builtin.assert:
+            that:
+              - >-
+                'invalid qos_policy' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                and '-qos' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly derived and rejected an over-length qos_policy"
+
+# ──────────────────────────────────────────────────────────────
+# Test 14: Explicit qos_policy is validated as-is, not silently replaced by a derived one -- error path
+# Expected: role fails referencing the caller's own invalid value, proving the defaulting
+# step's `is defined` check preserves an explicit qos_policy instead of overwriting it.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- explicit invalid qos_policy is not overwritten by defaulting (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run explicit-invalid-qos_policy failure test
+      block:
+        - name: Attempt with an explicit, invalid qos_policy (expected to fail on the caller's own value)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: nfs
+                provider: vast
+                qos_policy: "Invalid Policy!"
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when an explicit qos_policy is invalid"
+
+      rescue:
+        - name: Verify role failed referencing the caller's own qos_policy value
+          ansible.builtin.assert:
+            that:
+              - >-
+                'invalid qos_policy' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                and 'Invalid Policy!' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected the caller's explicit qos_policy rather than silently deriving a replacement"

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
@@ -176,6 +176,7 @@
               - osac_storage_provider_failures[0].reason == 'unsupported_protocol'
               - "'default' in osac_storage_provider_failures[0].tiers"
               - "'unsupported protocol' in (osac_storage_provider_failures[0].message | lower)"
+              - osac_storage_provider_failures[0].backend_ids == []
             fail_msg: >-
               osac_storage_provider_failures was not set as expected:
               {{ osac_storage_provider_failures | default('undefined') }}
@@ -446,61 +447,23 @@
             success_msg: "Role correctly derived and rejected an over-length qos_policy"
 
 # ──────────────────────────────────────────────────────────────
-# Test 14: Explicit qos_policy is validated as-is, not silently replaced by a derived one -- error path
-# Expected: role fails referencing the caller's own invalid value, proving the defaulting
-# step's `is defined` check preserves an explicit qos_policy instead of overwriting it.
+# Test 14: Explicit qos_policy is ignored; derivation always overwrites it -- error path
+# Expected: role fails on the DERIVED qos_policy's DNS-label length, not the caller's short,
+# well-formed supplied value -- proving the caller's value was discarded entirely and
+# derivation ran unconditionally (OSAC-1992 follow-up: closes the gap where an unvalidated
+# override could produce inconsistent naming across callers, or let a caller's qos_policy
+# silently pass through unused). Uses the same 60-char tier name construction as Test 13 --
+# if a bug ever used the caller's value instead of deriving, this test would pass with no
+# DNS-label failure at all, since "short" alone is well within the length limit.
 # ──────────────────────────────────────────────────────────────
-- name: Test storage_provider -- explicit invalid qos_policy is not overwritten by defaulting (should fail)
+- name: Test storage_provider -- explicit qos_policy is ignored, derivation still runs (should fail)
   hosts: localhost
   gather_facts: false
 
   tasks:
-    - name: Run explicit-invalid-qos_policy failure test
+    - name: Run explicit-qos_policy-ignored test
       block:
-        - name: Attempt with an explicit, invalid qos_policy (expected to fail on the caller's own value)
-          ansible.builtin.include_role:
-            name: osac.service.storage_provider
-          vars:
-            storage_provider_tiers:
-              - name: default
-                protocol: nfs
-                provider: vast
-                qos_policy: "Invalid Policy!"
-            storage_provider_action: setup
-            tenant_name: "tenant-acme"
-            tenant_namespace: "osac-tenants"
-
-        - name: This task should not be reached -- role should have failed
-          ansible.builtin.fail:
-            msg: "Role did not fail as expected when an explicit qos_policy is invalid"
-
-      rescue:
-        - name: Verify role failed referencing the caller's own qos_policy value
-          ansible.builtin.assert:
-            that:
-              - >-
-                'invalid qos_policy' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
-                and 'Invalid Policy!' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
-                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
-            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
-            success_msg: "Role correctly rejected the caller's explicit qos_policy rather than silently deriving a replacement"
-
-# ──────────────────────────────────────────────────────────────
-# Test 15: Tier without configured qos_limits opts out of qos_policy defaulting
-# Expected: role does NOT fail on qos_policy validation, proving no qos_policy was
-# derived for a tier with no read/write bandwidth limits configured. Uses a 60-char
-# tier name that WOULD fail DNS-label validation if a qos_policy were derived (same
-# construction as Test 13) -- if this test ever starts failing with an "invalid
-# qos_policy" message, the opt-out has regressed.
-# ──────────────────────────────────────────────────────────────
-- name: Test storage_provider -- tier without qos_limits opts out of qos_policy defaulting
-  hosts: localhost
-  gather_facts: false
-
-  tasks:
-    - name: Run qos-limits-opt-out test
-      block:
-        - name: Attempt with a 60-char tier name and no qos_limits (expected to fail at dispatch, not qos_policy validation)
+        - name: Attempt with a 60-char tier name, qos_limits, and a short explicit qos_policy
           ansible.builtin.include_role:
             name: osac.service.storage_provider
           vars:
@@ -508,6 +471,57 @@
               - name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 protocol: nfs
                 provider: vast
+                qos_policy: "short"
+                qos_limits:
+                  static_limits:
+                    max_reads_bw_mbps: 100
+                    max_writes_bw_mbps: 100
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected -- the caller's explicit qos_policy may have been used instead of derived"
+
+      rescue:
+        - name: Verify role failed on the derived qos_policy, not the caller's supplied value
+          ansible.builtin.assert:
+            that:
+              - >-
+                'invalid qos_policy' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                and '-qos' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                and 'short' not in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly ignored the caller's qos_policy and derived its own, which then failed DNS-label validation as expected"
+
+# ──────────────────────────────────────────────────────────────
+# Test 15: Tier without configured qos_limits opts out of qos_policy entirely, even if
+# the caller supplied one -- ignored, not validated
+# Expected: role does NOT fail on qos_policy validation, proving no qos_policy survives for a
+# tier with no read/write bandwidth limits configured -- even a deliberately invalid
+# caller-supplied qos_policy is stripped without ever being format-checked. Uses a 60-char
+# tier name that WOULD fail DNS-label validation if a qos_policy were derived (same
+# construction as Test 13/14) -- if this test ever starts failing with an "invalid qos_policy"
+# message, the opt-out has regressed.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- tier without qos_limits discards qos_policy entirely, even if supplied
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run qos-limits-opt-out test
+      block:
+        - name: Attempt with a 60-char tier name, no qos_limits, and an invalid explicit qos_policy (expected to fail at dispatch, not qos_policy validation)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                protocol: nfs
+                provider: vast
+                qos_policy: "Invalid Policy!"
             storage_provider_action: setup
             tenant_name: "tenant-acme"
             tenant_namespace: "osac-tenants"
@@ -524,9 +538,10 @@
                 'invalid qos_policy' not in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
                 and 'invalid qos_policy' not in (ansible_failed_result.msg | default(''))
             fail_msg: >-
-              Expected no qos_policy validation failure for a tier with no qos_limits.
+              Expected no qos_policy validation failure for a tier with no qos_limits, even
+              though the caller supplied a deliberately invalid qos_policy.
               Got: {{ ansible_failed_result.msg | default('unknown error') }}
-            success_msg: "Tier without qos_limits correctly opted out of qos_policy defaulting"
+            success_msg: "Tier without qos_limits correctly discarded the caller's qos_policy without validating it"
 
 # ──────────────────────────────────────────────────────────────
 # Test 16: VAST tiers dispatched together reference different backend_ids -- error path
@@ -589,6 +604,7 @@
               - "'silver' in osac_storage_provider_failures[0].tiers"
               - "'be-001' in osac_storage_provider_failures[0].backend_ids"
               - "'be-002' in osac_storage_provider_failures[0].backend_ids"
+              - "'expected exactly one backend_id' in (osac_storage_provider_failures[0].message | lower)"
             fail_msg: >-
               osac_storage_provider_failures was not set as expected:
               {{ osac_storage_provider_failures | default('undefined') }}
@@ -641,6 +657,7 @@
               - osac_storage_provider_failures[0].reason == 'unresolved_backend_connection'
               - "'default' in osac_storage_provider_failures[0].tiers"
               - "'be-999' in osac_storage_provider_failures[0].backend_ids"
+              - "\"No entry for backend_id 'be-999'\" in osac_storage_provider_failures[0].message"
             fail_msg: >-
               osac_storage_provider_failures was not set as expected:
               {{ osac_storage_provider_failures | default('undefined') }}
@@ -697,6 +714,7 @@
               - osac_storage_provider_failures[0].reason == 'incomplete_backend_connection'
               - "'default' in osac_storage_provider_failures[0].tiers"
               - "'be-001' in osac_storage_provider_failures[0].backend_ids"
+              - "'is missing one or more of' in osac_storage_provider_failures[0].message"
             fail_msg: >-
               osac_storage_provider_failures was not set as expected:
               {{ osac_storage_provider_failures | default('undefined') }}
@@ -761,3 +779,155 @@
               osac_storage_provider_failures did not correctly record both simultaneously-failing tiers:
               {{ osac_storage_provider_failures | default('undefined') }}
             success_msg: "Structured failure artifact correctly recorded both tiers and deduped the shared backend_id"
+
+# ──────────────────────────────────────────────────────────────
+# Test 20: VAST tier dispatched without a backend_id -- error path
+# Expected: role fails because VAST credential resolution requires every dispatched tier to
+# reference a backend_id, and emits a structured osac_storage_provider_failures artifact
+# consistent with its sibling backend-connection checks (OSAC-1992 follow-up).
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- VAST tier missing backend_id (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run missing-backend_id failure test
+      block:
+        - name: Attempt with a VAST tier that has no backend_id (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: nfs
+                provider: vast
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when the tier has no backend_id"
+
+      rescue:
+        - name: Verify role failed for missing backend_id
+          ansible.builtin.assert:
+            that:
+              - >-
+                'has no backend_id' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected a tier with no backend_id"
+
+        - name: Verify structured failure artifact was emitted for missing backend_id
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'missing_backend_id'
+              - "'default' in osac_storage_provider_failures[0].tiers"
+              - "'has no backend_id' in (osac_storage_provider_failures[0].message | lower)"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded the missing backend_id"
+
+# ──────────────────────────────────────────────────────────────
+# Test 21: Invalid protocol dispatched via ensure_storage_class -- error path
+# Expected: role fails with the same structured unsupported_protocol artifact as Test 4,
+# proving the closed-set protocol check (factored into _validate_tier_protocols.yaml) is
+# also enforced on the ensure_storage_class action -- the dominant action for cluster-storage
+# reconcile, which previously had no protocol validation of its own at all.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- invalid protocol via ensure_storage_class (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run invalid-protocol-via-ensure_storage_class failure test
+      block:
+        - name: Attempt with invalid protocol 'ftp' via the ensure_storage_class action (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: ftp
+                provider: vast
+            storage_provider_action: ensure_storage_class
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when protocol is invalid via ensure_storage_class"
+
+      rescue:
+        - name: Verify role failed for invalid protocol via ensure_storage_class
+          ansible.builtin.assert:
+            that:
+              - >-
+                'unsupported protocol' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') | lower)
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected invalid protocol via ensure_storage_class"
+
+        - name: Verify structured failure artifact was emitted for unsupported protocol via ensure_storage_class
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'unsupported_protocol'
+              - "'default' in osac_storage_provider_failures[0].tiers"
+              - "'unsupported protocol' in (osac_storage_provider_failures[0].message | lower)"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded the unsupported protocol via ensure_storage_class"
+
+# ──────────────────────────────────────────────────────────────
+# Test 22: Empty-string protocol (the real UNSPECIFIED shape from osac-operator) -- error path
+# Expected: role fails at the dispatcher-level required-fields check (main.yaml), NOT at the
+# unsupported_protocol structured-failure check -- proving the one bad-protocol value that can
+# actually reach AAP in production today (fulfillment-service silently accepts
+# STORAGE_PROTOCOL_UNSPECIFIED at Create and Update; osac-operator maps it to protocol: "" and
+# passes it through unconditionally) is caught cleanly before dispatch ever reaches
+# action-specific protocol validation. Dispatched via ensure_storage_class -- the action Test 21
+# proves now enforces the closed-set check -- to confirm the empty-string case is intercepted
+# even earlier than that, at the dispatcher level.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- empty-string protocol from UNSPECIFIED (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run empty-protocol failure test
+      block:
+        - name: Attempt with an otherwise-valid tier whose protocol is an empty string (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: ""
+                provider: vast
+                backend_id: be-001
+                quota_bytes: 536870912000
+            storage_provider_action: ensure_storage_class
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when protocol is an empty string"
+
+      rescue:
+        - name: Verify role failed at the dispatcher-level required-fields check, not the unsupported_protocol check
+          ansible.builtin.assert:
+            that:
+              - >-
+                'must have' in (ansible_failed_result.msg | default(''))
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+              - "'unsupported protocol' not in (ansible_failed_result.msg | default('') | lower)"
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected the empty-string protocol at the dispatcher level, not the unsupported_protocol check"

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
@@ -448,6 +448,10 @@
               - name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 protocol: nfs
                 provider: vast
+                qos_limits:
+                  static_limits:
+                    max_reads_bw_mbps: 100
+                    max_writes_bw_mbps: 100
             storage_provider_action: setup
             tenant_name: "tenant-acme"
             tenant_namespace: "osac-tenants"
@@ -506,3 +510,46 @@
                 or 'One or more items failed' in (ansible_failed_result.msg | default(''))
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
             success_msg: "Role correctly rejected the caller's explicit qos_policy rather than silently deriving a replacement"
+
+# ──────────────────────────────────────────────────────────────
+# Test 15: Tier without configured qos_limits opts out of qos_policy defaulting
+# Expected: role does NOT fail on qos_policy validation, proving no qos_policy was
+# derived for a tier with no read/write bandwidth limits configured. Uses a 60-char
+# tier name that WOULD fail DNS-label validation if a qos_policy were derived (same
+# construction as Test 13) -- if this test ever starts failing with an "invalid
+# qos_policy" message, the opt-out has regressed.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- tier without qos_limits opts out of qos_policy defaulting
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run qos-limits-opt-out test
+      block:
+        - name: Attempt with a 60-char tier name and no qos_limits (expected to fail at dispatch, not qos_policy validation)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                protocol: nfs
+                provider: vast
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: Validation passed (dispatch outcome is not under test)
+          ansible.builtin.debug:
+            msg: "Validation passed -- dispatch was attempted"
+
+      rescue:
+        - name: Verify failure is from dispatch, not qos_policy validation
+          ansible.builtin.assert:
+            that:
+              - >-
+                'invalid qos_policy' not in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
+                and 'invalid qos_policy' not in (ansible_failed_result.msg | default(''))
+            fail_msg: >-
+              Expected no qos_policy validation failure for a tier with no qos_limits.
+              Got: {{ ansible_failed_result.msg | default('unknown error') }}
+            success_msg: "Tier without qos_limits correctly opted out of qos_policy defaulting"

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
@@ -1,7 +1,14 @@
 ---
 # Unit tests for osac.service.storage_provider dispatcher validation logic.
-# All scenarios run in a single invocation -- no flags needed.
 # Tests verify validation ONLY; they do not dispatch to actual provider roles.
+#
+# A single invocation halts after "Test storage_provider -- invalid provider (should fail)":
+# ansible-core raises a runner-level ERROR! when include_role targets a genuinely-missing role
+# name, which aborts the ansible-playbook process even though that scenario's own rescue block
+# already passed. Run in two invocations to exercise every scenario:
+#   ansible-playbook collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+#   ansible-playbook --start-at-task "Attempt with invalid action 'destroy' (expected to fail)" \
+#     collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
 
 # ──────────────────────────────────────────────────────────────
 # Test 1: Valid single tier passes all validation
@@ -160,6 +167,19 @@
                 or 'One or more items failed' in (ansible_failed_result.msg | default(''))
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
             success_msg: "Role correctly rejected invalid protocol"
+
+        - name: Verify structured failure artifact was emitted for unsupported protocol
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'unsupported_protocol'
+              - "'default' in osac_storage_provider_failures[0].tiers"
+              - "'unsupported protocol' in (osac_storage_provider_failures[0].message | lower)"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded the unsupported protocol"
 
 # ──────────────────────────────────────────────────────────────
 # Test 5: Invalid provider -- error path
@@ -507,3 +527,237 @@
               Expected no qos_policy validation failure for a tier with no qos_limits.
               Got: {{ ansible_failed_result.msg | default('unknown error') }}
             success_msg: "Tier without qos_limits correctly opted out of qos_policy defaulting"
+
+# ──────────────────────────────────────────────────────────────
+# Test 16: VAST tiers dispatched together reference different backend_ids -- error path
+# Expected: role fails because VAST credential resolution supports exactly one backend_id
+# per role invocation (OSAC-1992 Task 6), and emits a structured osac_storage_provider_failures
+# artifact identifying both tiers and both backend_ids involved.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- VAST tiers reference multiple backend_ids (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run ambiguous-backend-association failure test
+      block:
+        - name: Attempt with two VAST tiers pointing at different backend_ids (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: gold
+                protocol: nfs
+                provider: vast
+                backend_id: be-001
+              - name: silver
+                protocol: nfs
+                provider: vast
+                backend_id: be-002
+            storage_provider_backend_connections:
+              be-001:
+                endpoint: vast-1.example.com
+                username: admin
+                password: secret
+              be-002:
+                endpoint: vast-2.example.com
+                username: admin
+                password: secret
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when VAST tiers reference multiple backend_ids"
+
+      rescue:
+        - name: Verify role failed for ambiguous backend association
+          ansible.builtin.assert:
+            that:
+              - "'Expected exactly one backend_id' in (ansible_failed_result.msg | default(''))"
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected tiers referencing multiple backend_ids"
+
+        - name: Verify structured failure artifact was emitted for ambiguous backend association
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'ambiguous_backend_association'
+              - "'gold' in osac_storage_provider_failures[0].tiers"
+              - "'silver' in osac_storage_provider_failures[0].tiers"
+              - "'be-001' in osac_storage_provider_failures[0].backend_ids"
+              - "'be-002' in osac_storage_provider_failures[0].backend_ids"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded both tiers and backend_ids"
+
+# ──────────────────────────────────────────────────────────────
+# Test 17: VAST tier's backend_id has no entry in storage_backend_connections -- error path
+# Expected: role fails because osac-operator did not resolve connection details for the
+# referenced backend_id (e.g. the StorageBackend was deleted while still referenced by a
+# StorageTier), and emits a structured osac_storage_provider_failures artifact.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- VAST tier's backend_id has no connection entry (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run unresolved-backend-connection failure test
+      block:
+        - name: Attempt with a VAST tier whose backend_id is absent from storage_backend_connections (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: nfs
+                provider: vast
+                backend_id: be-999
+            storage_provider_backend_connections: {}
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when the tier's backend_id has no connection entry"
+
+      rescue:
+        - name: Verify role failed for unresolved backend connection
+          ansible.builtin.assert:
+            that:
+              - "\"No entry for backend_id 'be-999'\" in (ansible_failed_result.msg | default(''))"
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected a tier whose backend_id has no connection entry"
+
+        - name: Verify structured failure artifact was emitted for unresolved backend connection
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'unresolved_backend_connection'
+              - "'default' in osac_storage_provider_failures[0].tiers"
+              - "'be-999' in osac_storage_provider_failures[0].backend_ids"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded the unresolved backend_id"
+
+# ──────────────────────────────────────────────────────────────
+# Test 18: Resolved VAST backend connection is missing a required credential field -- error path
+# Expected: role fails because the connection entry resolved for the tier's backend_id is
+# incomplete (e.g. a StorageBackend updated to blank out a credential), and emits a
+# structured osac_storage_provider_failures artifact.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- VAST backend connection missing required fields (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run incomplete-backend-connection failure test
+      block:
+        - name: Attempt with a resolved backend connection missing a password (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: default
+                protocol: nfs
+                provider: vast
+                backend_id: be-001
+            storage_provider_backend_connections:
+              be-001:
+                endpoint: vast.example.com
+                username: admin
+                password: ""
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when the resolved backend connection is missing a password"
+
+      rescue:
+        - name: Verify role failed for incomplete backend connection
+          ansible.builtin.assert:
+            that:
+              - "'is missing one or more of' in (ansible_failed_result.msg | default(''))"
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected an incomplete backend connection"
+
+        - name: Verify structured failure artifact was emitted for incomplete backend connection
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'incomplete_backend_connection'
+              - "'default' in osac_storage_provider_failures[0].tiers"
+              - "'be-001' in osac_storage_provider_failures[0].backend_ids"
+            fail_msg: >-
+              osac_storage_provider_failures was not set as expected:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded the incomplete backend connection"
+
+# ──────────────────────────────────────────────────────────────
+# Test 19: Two tiers sharing a backend_id both have unsupported protocols -- error path
+# Expected: role fails on the loop task for both tiers simultaneously (Ansible loops evaluate
+# every item rather than stopping at the first failure), and the structured
+# osac_storage_provider_failures artifact records both tier names while deduping their shared
+# backend_id to a single entry.
+# ──────────────────────────────────────────────────────────────
+- name: Test storage_provider -- two tiers simultaneously fail protocol validation (should fail)
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Run simultaneous-protocol-failure test
+      block:
+        - name: Attempt with two tiers sharing a backend_id, both using an unsupported protocol (expected to fail)
+          ansible.builtin.include_role:
+            name: osac.service.storage_provider
+          vars:
+            storage_provider_tiers:
+              - name: gold
+                protocol: ftp
+                provider: vast
+                backend_id: be-001
+              - name: silver
+                protocol: ftp
+                provider: vast
+                backend_id: be-001
+            storage_provider_action: setup
+            tenant_name: "tenant-acme"
+            tenant_namespace: "osac-tenants"
+
+        - name: This task should not be reached -- role should have failed
+          ansible.builtin.fail:
+            msg: "Role did not fail as expected when two tiers both use an unsupported protocol"
+
+      rescue:
+        - name: Verify role failed for both tiers with unsupported protocols
+          ansible.builtin.assert:
+            that:
+              - >-
+                'unsupported protocol' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' ') | lower)
+                or 'One or more items failed' in (ansible_failed_result.msg | default(''))
+            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
+            success_msg: "Role correctly rejected both tiers with unsupported protocols"
+
+        - name: Verify structured failure artifact records both simultaneously-failing tiers
+          ansible.builtin.assert:
+            that:
+              - osac_storage_provider_failures is defined
+              - osac_storage_provider_failures | length > 0
+              - osac_storage_provider_failures[0].reason == 'unsupported_protocol'
+              - "'gold' in osac_storage_provider_failures[0].tiers"
+              - "'silver' in osac_storage_provider_failures[0].tiers"
+              - osac_storage_provider_failures[0].tiers | length == 2
+              - osac_storage_provider_failures[0].backend_ids == ['be-001']
+            fail_msg: >-
+              osac_storage_provider_failures did not correctly record both simultaneously-failing tiers:
+              {{ osac_storage_provider_failures | default('undefined') }}
+            success_msg: "Structured failure artifact correctly recorded both tiers and deduped the shared backend_id"

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
@@ -50,8 +50,6 @@
                 'not a valid DNS label' not in (ansible_failed_result.msg | default(''))
               - >-
                 'duplicate tier names' not in (ansible_failed_result.msg | default(''))
-              - >-
-                'exceeds the maximum' not in (ansible_failed_result.msg | default(''))
             fail_msg: >-
               Validation failed unexpectedly: {{ ansible_failed_result.msg | default('unknown error') }}
             success_msg: "Validation passed -- dispatch failed as expected in unit test context"
@@ -309,50 +307,6 @@
               - >-
                 'not a valid DNS label' in (ansible_failed_result.results | default([]) | map(attribute='msg') | join(' '))
                 or 'One or more items failed' in (ansible_failed_result.msg | default(''))
-            fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
-            success_msg: "Role correctly rejected invalid input"
-
-# ──────────────────────────────────────────────────────────────
-# Test 10: Tier count exceeds maximum -- error path
-# Expected: role fails with exceeds-maximum message
-# ──────────────────────────────────────────────────────────────
-- name: Test storage_provider -- tier count exceeds max (should fail)
-  hosts: localhost
-  gather_facts: false
-
-  tasks:
-    - name: Run tier-count-exceeds-max failure test
-      block:
-        - name: Attempt with 3 tiers but max_tiers set to 2 (expected to fail)
-          ansible.builtin.include_role:
-            name: osac.service.storage_provider
-          vars:
-            storage_provider_tiers:
-              - name: tier-a
-                protocol: nfs
-                provider: vast
-              - name: tier-b
-                protocol: nfs
-                provider: vast
-              - name: tier-c
-                protocol: block
-                provider: vast
-            storage_provider_max_tiers: 2
-            storage_provider_action: setup
-            tenant_name: "tenant-acme"
-            tenant_namespace: "osac-tenants"
-
-        - name: This task should not be reached -- role should have failed
-          ansible.builtin.fail:
-            msg: "Role did not fail as expected when tier count exceeds maximum"
-
-      rescue:
-        - name: Verify role failed with expected exceeds-maximum message
-          ansible.builtin.assert:
-            that:
-              - "'exceeds the maximum' in ansible_failed_result.msg"
-              - "'3' in ansible_failed_result.msg"
-              - "'2' in ansible_failed_result.msg"
             fail_msg: "Role failed but with unexpected message: {{ ansible_failed_result.msg | default('unknown') }}"
             success_msg: "Role correctly rejected invalid input"
 

--- a/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
+++ b/collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml
@@ -1,6 +1,6 @@
 ---
 # Unit tests for osac.service.storage_provider dispatcher validation logic.
-# All 12 scenarios run in a single invocation -- no flags needed.
+# All scenarios run in a single invocation -- no flags needed.
 # Tests verify validation ONLY; they do not dispatch to actual provider roles.
 
 # ──────────────────────────────────────────────────────────────

--- a/collections/ansible_collections/osac/templates/README.md
+++ b/collections/ansible_collections/osac/templates/README.md
@@ -168,8 +168,9 @@ See roles/ocp_virt_vm for more examples
 
 ### Creating a New Storage Provider Role
 
-Storage provider roles use a tier-based dispatch model: deployments define storage tiers
-via `STORAGE_TIERS` JSON, each tier declares its provider, and the service-layer dispatcher
+Storage provider roles use a tier-based dispatch model: osac-operator resolves storage tiers
+from the Tier API and passes them via the `ansible_eda.event.storage_tier_definitions`
+extra_var, each tier declares its provider, and the service-layer dispatcher
 (`osac.service.storage_provider`) groups tiers by provider and dispatches to each provider's
 template role with the filtered tier subset.
 
@@ -223,16 +224,18 @@ When implemented, `hcp_data_plane` will support provisioning multiple StorageCla
 into the guest HCP cluster (e.g., separate tiers for databases and general workloads).
 Currently, all CaaS targets return an explicit "not yet implemented" error.
 
-**Configuration:** Storage tiers are configured via the `STORAGE_TIERS` env var in the
-`storage-operations-ig` ConfigMap:
+**Configuration:** Storage tiers arrive via the `ansible_eda.event.storage_tier_definitions`
+extra_var, populated by osac-operator from the Tier API:
 ```json
 [
-  {"name": "default", "protocol": "nfs", "provider": "vast", "qos_policy": "default-qos",
+  {"name": "default", "protocol": "nfs", "provider": "vast", "backend_id": "be-001",
    "qos_limits": {"static_limits": {"max_reads_bw_mbps": 100, "max_writes_bw_mbps": 100}}},
-  {"name": "high-performance", "protocol": "block", "provider": "vast", "qos_policy": "perf-qos",
-   "qos_limits": {"static_limits": {"max_reads_bw_mbps": 500, "max_writes_bw_mbps": 500}}}
+  {"name": "high-performance", "protocol": "block", "provider": "vast", "backend_id": "be-001",
+   "qos_limits": {"static_limits": {"max_reads_bw_mbps": 500, "max_writes_bw_mbps": 500}}, "quota_bytes": 500}
 ]
 ```
+Backend connection details (endpoint, username, password) are resolved separately and
+passed via the `storage_provider_backend_connections` extra_var, keyed by `backend_id`.
 
 **Tier fields:**
 
@@ -241,9 +244,10 @@ Currently, all CaaS targets return an explicit "not yet implemented" error.
 | `name` | yes | DNS-label tier name (used in StorageClass naming) |
 | `protocol` | yes | `nfs` or `block` |
 | `provider` | yes | Provider name (e.g., `vast`) |
-| `qos_policy` | no | QoS policy name (creates STATIC mode policy on VMS) |
-| `qos_limits` | no | Dict merged into QoS POST body (e.g., `static_limits`, `static_total_limits`) |
-| `quota` | no | Hard quota in bytes for the tier's view |
+| `backend_id` | provider-dependent | Key into `storage_provider_backend_connections` for this tier's backend credentials (required by providers that resolve credentials this way, e.g. VAST) |
+| `qos_policy` | no | QoS policy name (creates STATIC mode policy on VMS). If omitted and `qos_limits` is set, the dispatcher derives one from the tier name |
+| `qos_limits` | no | Dict merged into QoS POST body (e.g., `static_limits`, `static_total_limits`). A tier with no `qos_limits` opts out of `qos_policy` defaulting |
+| `quota_bytes` | no | Hard quota in bytes for the tier's view |
 
 **QoS limits:** When `qos_policy` is specified, the role creates a QoS policy via REST API
 (`POST /api/qospolicies/`). The `qos_limits` dict is merged directly into the POST body, so

--- a/collections/ansible_collections/osac/templates/README.md
+++ b/collections/ansible_collections/osac/templates/README.md
@@ -245,14 +245,15 @@ passed via the `storage_provider_backend_connections` extra_var, keyed by `backe
 | `protocol` | yes | `nfs` or `block` |
 | `provider` | yes | Provider name (e.g., `vast`) |
 | `backend_id` | provider-dependent | Key into `storage_provider_backend_connections` for this tier's backend credentials (required by providers that resolve credentials this way, e.g. VAST) |
-| `qos_policy` | no | QoS policy name (creates STATIC mode policy on VMS). If omitted and `qos_limits` is set, the dispatcher derives one from the tier name |
-| `qos_limits` | no | Dict merged into QoS POST body (e.g., `static_limits`, `static_total_limits`). A tier opts out of `qos_policy` defaulting unless `qos_limits.static_limits` sets a positive `max_reads_bw_mbps` or `max_writes_bw_mbps` |
+| `qos_policy` | n/a — derived, ignored if set by the caller | QoS policy name (creates STATIC mode policy on VMS), always derived from the tier name (`<name>-qos`). Any caller-supplied value is discarded, never used |
+| `qos_limits` | no | Dict merged into QoS POST body (e.g., `static_limits`, `static_total_limits`). A tier opts out of `qos_policy` derivation unless `qos_limits.static_limits` sets a positive `max_reads_bw_mbps` or `max_writes_bw_mbps` |
 | `quota_bytes` | no | Hard quota in bytes for the tier's view |
 
-**QoS limits:** When `qos_policy` is specified, the role creates a QoS policy via REST API
-(`POST /api/qospolicies/`). The `qos_limits` dict is merged directly into the POST body, so
-its keys must match VMS API fields. Real VMS rejects STATIC mode without at least one limit —
-always include `qos_limits.static_limits` when specifying `qos_policy`.
+**QoS limits:** When a tier has a derived `qos_policy` (see above), the role creates a QoS
+policy via REST API (`POST /api/qospolicies/`). The `qos_limits` dict is merged directly into
+the POST body, so its keys must match VMS API fields. Real VMS rejects STATIC mode without at
+least one limit — always include `qos_limits.static_limits` for a tier that should get QoS
+enforcement.
 
 **Dispatcher pattern:** `osac.service.storage_provider` validates inputs (tier list,
 provider allowlist, protocol allowlist, provisioning target enum, max tier count) then

--- a/collections/ansible_collections/osac/templates/README.md
+++ b/collections/ansible_collections/osac/templates/README.md
@@ -211,7 +211,9 @@ template role with the filtered tier subset.
 5. **Credential isolation:** Admin credentials (e.g., VAST VMS admin) must NEVER
    appear in tenant-namespace K8s Secrets. Provider roles must create per-tenant
    data-plane credentials and use only those in CSI Secrets. Admin credentials
-   remain in the AAP-namespace IG Secret, injected via env vars.
+   arrive via the `storage_provider_backend_connections` extra_var (resolved by
+   osac-operator from the Tier API and keyed by `backend_id`) — there is no
+   env-var or K8s Secret fallback for admin credentials.
 
 6. **Provisioning targets:** Each provider handles both VMaaS and CaaS provisioning
    targets via the `_provisioning_target` parameter. Currently supported: `vmaas`.

--- a/collections/ansible_collections/osac/templates/README.md
+++ b/collections/ansible_collections/osac/templates/README.md
@@ -246,7 +246,7 @@ passed via the `storage_provider_backend_connections` extra_var, keyed by `backe
 | `provider` | yes | Provider name (e.g., `vast`) |
 | `backend_id` | provider-dependent | Key into `storage_provider_backend_connections` for this tier's backend credentials (required by providers that resolve credentials this way, e.g. VAST) |
 | `qos_policy` | no | QoS policy name (creates STATIC mode policy on VMS). If omitted and `qos_limits` is set, the dispatcher derives one from the tier name |
-| `qos_limits` | no | Dict merged into QoS POST body (e.g., `static_limits`, `static_total_limits`). A tier with no `qos_limits` opts out of `qos_policy` defaulting |
+| `qos_limits` | no | Dict merged into QoS POST body (e.g., `static_limits`, `static_total_limits`). A tier opts out of `qos_policy` defaulting unless `qos_limits.static_limits` sets a positive `max_reads_bw_mbps` or `max_writes_bw_mbps` |
 | `quota_bytes` | no | Hard quota in bytes for the tier's view |
 
 **QoS limits:** When `qos_policy` is specified, the role creates a QoS policy via REST API

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/defaults/main.yaml
@@ -11,9 +11,16 @@ vast_storage_csi_provisioner_map:
 # K8s Secret on hub cluster that stores per-tenant VAST config
 vast_storage_tenant_config_secret_prefix: "vast-tenant-config-"
 
-# Namespace for hub-cluster config secrets — set via OSAC_STORAGE_CONFIG_NAMESPACE env var
-# in the storage-operations-ig pod spec (downward API metadata.namespace).
-vast_storage_config_namespace: "{{ lookup('env', 'OSAC_STORAGE_CONFIG_NAMESPACE') | default('osac-system', true) }}"
+# Namespace for hub-cluster config secrets. Resolution order:
+#   1. OSAC_STORAGE_CONFIG_NAMESPACE env var — explicit override via the storage-operations-ig
+#      ConfigMap, only needed if the config namespace differs from the IG pod's own namespace.
+#   2. The IG pod's own namespace, read from the standard K8s-mounted service account file —
+#      always accurate for wherever the pod actually runs, no per-deployment config needed.
+#   3. "osac-system" — last-resort fallback for local/test execution outside a pod.
+vast_storage_config_namespace: >-
+  {{ lookup('env', 'OSAC_STORAGE_CONFIG_NAMESPACE')
+     | default(lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/namespace', errors='ignore'), true)
+     | default('osac-system', true) }}
 
 # TLS certificate validation for VAST VMS API calls.
 vast_storage_validate_certs: "{{ lookup('env', 'VAST_VALIDATE_CERTS') | default('true', true) | bool }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/_validate_tier_protocols.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/_validate_tier_protocols.yaml
@@ -1,0 +1,46 @@
+---
+# Shared protocol validation, included by both setup.yaml and ensure_storage_class.yaml
+# so the two action entry points can't drift out of sync on which protocols are allowed.
+# Requires: _provider_tiers (set by the caller).
+
+- name: Validate tier protocols are supported by VAST provider
+  block:
+    - name: Fail if tier protocol is unsupported
+      ansible.builtin.fail:
+        msg: >-
+          Tier '{{ item.name }}' has unsupported protocol '{{ item.protocol }}'.
+          VAST provider supports: nfs, block.
+      loop: "{{ _provider_tiers }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: item.protocol not in ['nfs', 'block']
+  rescue:
+    # Ansible loops evaluate every item rather than stopping at the first failure, so
+    # ansible_failed_result.results may contain more than one failed tier here.
+    - name: Build structured failure artifact for unsupported protocol
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: >-
+          {% set _tiers = [] -%}
+          {% set _backend_ids = [] -%}
+          {% set _messages = [] -%}
+          {% for _r in (ansible_failed_result.results | default([])) -%}
+          {% if _r.failed | default(false) -%}
+          {% set _ = _tiers.append(_r.item.name) -%}
+          {% set _bid = _r.item.backend_id | default('') -%}
+          {% if (_bid | length > 0) and (_bid not in _backend_ids) -%}
+          {% set _ = _backend_ids.append(_bid) -%}
+          {% endif -%}
+          {% set _ = _messages.append(_r.msg | default('')) -%}
+          {% endif -%}
+          {% endfor -%}
+          {{ [{'reason': 'unsupported_protocol', 'tiers': _tiers, 'backend_ids': _backend_ids, 'message': _messages | join(' ')}] }}
+
+    - name: Emit structured failure artifact for unsupported protocol
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
+
+    - name: Re-raise the original protocol validation failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_quotas.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/create_quotas.yaml
@@ -1,6 +1,6 @@
 ---
 # Creates per-tier VAST quotas using the vendored vastdata.vms.quotas module.
-# Only creates quotas for tiers that define a quota field.
+# Only creates quotas for tiers that define a quota_bytes field.
 # Idempotent: the module handles create-or-update via state: present.
 #
 # Requires in scope:
@@ -10,16 +10,16 @@
 #   _vast_tenant_uid_hash   — first 8 hex chars of SHA256(tenant_uid)
 #   tenant_name             — play-level var
 
-- name: Create VAST quota per tier (when quota specified)
-  when: _provider_tiers | selectattr('quota', 'defined') | list | length > 0
+- name: Create VAST quota per tier (when quota_bytes specified)
+  when: _provider_tiers | selectattr('quota_bytes', 'defined') | list | length > 0
   vastdata.vms.quotas:
     vms: "{{ _vast_vms_conn }}"
     name: "quota-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}-{{ item.name }}"
     path: "/osac-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}/{{ item.name }}"
     tenant_id: "{{ _vast_tenant_id }}"
-    hard_limit: "{{ item.quota }}"
+    hard_limit: "{{ item.quota_bytes }}"
     state: present
-  loop: "{{ _provider_tiers | selectattr('quota', 'defined') | list }}"
+  loop: "{{ _provider_tiers | selectattr('quota_bytes', 'defined') | list }}"
   loop_control:
     label: "quota-{{ tenant_name }}-{{ _vast_tenant_uid_hash }}-{{ item.name }}"
   no_log: true

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -12,6 +12,9 @@
     fail_msg: >-
       _provider_tiers must be provided by the service role dispatcher.
 
+- name: Validate tier protocols are supported by VAST provider
+  ansible.builtin.include_tasks: _validate_tier_protocols.yaml
+
 - name: Compute unique protocols from tiers
   ansible.builtin.set_fact:
     _vast_required_protocols: "{{ _provider_tiers | map(attribute='protocol') | unique | sort | list }}"
@@ -307,17 +310,18 @@
         label: "vast-{{ item.protocol }}-{{ tenant_name }}-{{ item.name }}"
 
     - name: Check if VolumeSnapshot CRD is installed
-      when: storage_provider_snapshots_enabled | default(true)
       kubernetes.core.k8s_info:
         api_version: apiextensions.k8s.io/v1
         kind: CustomResourceDefinition
         name: volumesnapshotclasses.snapshot.storage.k8s.io
       register: _vast_vsc_crd_check
 
+    - name: Set snapshot support fact from live CRD check
+      ansible.builtin.set_fact:
+        _vast_snapshot_crd_available: "{{ _vast_vsc_crd_check.resources | default([]) | length > 0 }}"
+
     - name: Create VolumeSnapshotClass per tier
-      when: >-
-        (storage_provider_snapshots_enabled | default(true)) and
-        (_vast_vsc_crd_check.resources | default([]) | length > 0)
+      when: _vast_snapshot_crd_available
       kubernetes.core.k8s:
         state: present
         definition:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -321,7 +321,9 @@
         _vast_snapshot_crd_available: "{{ _vast_vsc_crd_check.resources | default([]) | length > 0 }}"
 
     - name: Create VolumeSnapshotClass per tier
-      when: _vast_snapshot_crd_available
+      when:
+        - _vast_snapshot_crd_available | bool
+        - storage_provider_snapshots_enabled | default(true) | bool
       kubernetes.core.k8s:
         state: present
         definition:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -103,7 +103,7 @@
     # These are created here (not just in setup) so JIT tiers get their backing
     # VMS resources. Uses admin creds for VMS API access.
 
-    - name: Resolve VAST admin credentials from env vars
+    - name: Resolve VAST admin credentials from storage_backend_connections
       ansible.builtin.include_tasks: read_credentials.yaml
 
     - name: Build VMS connection from admin credentials

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/ensure_storage_class.yaml
@@ -12,7 +12,7 @@
     fail_msg: >-
       _provider_tiers must be provided by the service role dispatcher.
 
-- name: Validate tier protocols are supported by VAST provider
+- name: Include shared tier protocol validation
   ansible.builtin.include_tasks: _validate_tier_protocols.yaml
 
 - name: Compute unique protocols from tiers

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_credentials.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_credentials.yaml
@@ -22,36 +22,98 @@
   ansible.builtin.set_fact:
     _vast_backend_ids: "{{ _provider_tiers | map(attribute='backend_id') | unique | list }}"
 
-- name: Fail if the dispatched tiers reference zero or multiple backend_ids
-  ansible.builtin.fail:
-    msg: >-
-      Expected exactly one backend_id across the dispatched VAST tiers, got
-      {{ _vast_backend_ids | length }}: {{ _vast_backend_ids | to_json }}.
-      VAST credential resolution assumes a single backend connection per role invocation —
-      multiple backends dispatched together in one call are not yet supported.
-  when: _vast_backend_ids | length != 1
+- name: Validate the dispatched tiers reference exactly one backend_id
+  block:
+    - name: Fail if the dispatched tiers reference zero or multiple backend_ids
+      ansible.builtin.fail:
+        msg: >-
+          Expected exactly one backend_id across the dispatched VAST tiers, got
+          {{ _vast_backend_ids | length }}: {{ _vast_backend_ids | to_json }}.
+          VAST credential resolution assumes a single backend connection per role invocation —
+          multiple backends dispatched together in one call are not yet supported.
+      when: _vast_backend_ids | length != 1
+  rescue:
+    - name: Build structured failure artifact for ambiguous backend association
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures:
+          - reason: ambiguous_backend_association
+            tiers: "{{ _provider_tiers | map(attribute='name') | list }}"
+            backend_ids: "{{ _vast_backend_ids }}"
+            message: "{{ ansible_failed_result.msg }}"
+
+    - name: Emit structured failure artifact for ambiguous backend association
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
+
+    - name: Re-raise the original backend_id ambiguity failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"
 
 - name: Set the resolved backend_id
   ansible.builtin.set_fact:
     _vast_backend_id: "{{ _vast_backend_ids[0] }}"
 
-- name: Fail if no connection details were provided for the resolved backend_id
-  ansible.builtin.fail:
-    msg: >-
-      No entry for backend_id '{{ _vast_backend_id }}' in storage_backend_connections.
-      osac-operator must resolve and pass connection details (endpoint, username, password)
-      for every backend_id referenced by storage_tier_definitions.
-  when: _vast_backend_id not in _provider_backend_connections
+- name: Validate connection details exist for the resolved backend_id
+  block:
+    - name: Fail if no connection details were provided for the resolved backend_id
+      ansible.builtin.fail:
+        msg: >-
+          No entry for backend_id '{{ _vast_backend_id }}' in storage_backend_connections.
+          osac-operator must resolve and pass connection details (endpoint, username, password)
+          for every backend_id referenced by storage_tier_definitions.
+      when: _vast_backend_id not in _provider_backend_connections
+  rescue:
+    - name: Build structured failure artifact for unresolved backend connection
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures:
+          - reason: unresolved_backend_connection
+            tiers: "{{ _provider_tiers | map(attribute='name') | list }}"
+            backend_ids:
+              - "{{ _vast_backend_id }}"
+            message: "{{ ansible_failed_result.msg }}"
 
-- name: Fail if the resolved connection is missing endpoint, username, or password
-  ansible.builtin.fail:
-    msg: >-
-      storage_backend_connections['{{ _vast_backend_id }}'] is missing one or more of
-      endpoint, username, password. All three must be set together.
-  when: >-
-    _provider_backend_connections[_vast_backend_id].endpoint | default('') | length == 0 or
-    _provider_backend_connections[_vast_backend_id].username | default('') | length == 0 or
-    _provider_backend_connections[_vast_backend_id].password | default('') | length == 0
+    - name: Emit structured failure artifact for unresolved backend connection
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
+
+    - name: Re-raise the original unresolved-connection failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"
+
+- name: Validate the resolved connection has complete credentials
+  block:
+    - name: Fail if the resolved connection is missing endpoint, username, or password
+      ansible.builtin.fail:
+        msg: >-
+          storage_backend_connections['{{ _vast_backend_id }}'] is missing one or more of
+          endpoint, username, password. All three must be set together.
+      when: >-
+        _provider_backend_connections[_vast_backend_id].endpoint | default('') | length == 0 or
+        _provider_backend_connections[_vast_backend_id].username | default('') | length == 0 or
+        _provider_backend_connections[_vast_backend_id].password | default('') | length == 0
+  rescue:
+    - name: Build structured failure artifact for incomplete backend connection
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures:
+          - reason: incomplete_backend_connection
+            tiers: "{{ _provider_tiers | map(attribute='name') | list }}"
+            backend_ids:
+              - "{{ _vast_backend_id }}"
+            message: "{{ ansible_failed_result.msg }}"
+
+    - name: Emit structured failure artifact for incomplete backend connection
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
+
+    - name: Re-raise the original incomplete-connection failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"
 
 - name: Set VAST credentials from the resolved backend connection
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_credentials.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_credentials.yaml
@@ -1,57 +1,61 @@
 ---
-# Reads VAST admin credentials from environment variables ONLY.
-# Admin credentials are injected via AAP vault -> IG Secret -> pod env vars.
-# There is NO K8s Secret fallback — admin credentials must never be stored
-# in K8s Secrets accessible via the K8s API.
+# Reads VAST admin credentials from storage_backend_connections, resolved by osac-operator
+# from the Tier API and passed through extra_vars (OSAC-1992, absorbing OSAC-1957's AAP-side
+# AC). There is NO env-var or K8s Secret fallback — the prior env-var path (populated via AAP
+# vault -> storage-operations-ig Secret -> pod env vars) is retired outright, clean-slate.
+#
+# Today's credential resolution assumes a single VAST connection per role invocation — the
+# env-var path it replaces was implicitly the same (one global VAST connection for the whole
+# deployment), so this is enforced explicitly here rather than left as a silent assumption.
 
-- name: Read VAST credentials from environment variables
-  ansible.builtin.set_fact:
-    _vast_endpoint_env: "{{ lookup('env', 'VAST_ENDPOINT') }}"
-    _vast_username_env: "{{ lookup('env', 'VAST_USERNAME') }}"
-    _vast_password_env: "{{ lookup('env', 'VAST_PASSWORD') }}"
-  no_log: true
-
-- name: Check if all required env var credentials are available
-  ansible.builtin.set_fact:
-    _vast_env_creds_available: >-
-      {{ _vast_endpoint_env | length > 0 and
-         _vast_username_env | length > 0 and
-         _vast_password_env | length > 0 }}
-    _vast_env_creds_partial: >-
-      {{ (_vast_endpoint_env | length > 0 or
-          _vast_username_env | length > 0 or
-          _vast_password_env | length > 0) and
-         not (_vast_endpoint_env | length > 0 and
-              _vast_username_env | length > 0 and
-              _vast_password_env | length > 0) }}
-  no_log: true
-
-- name: Warn about partial env var credentials
-  when: _vast_env_creds_partial | bool
-  ansible.builtin.debug:
-    msg: >-
-      Partial VAST credential env vars detected — not all of VAST_ENDPOINT,
-      VAST_USERNAME, VAST_PASSWORD are set. All three must be provided together.
-
-- name: Fail if VAST admin credentials are not available
-  when: not (_vast_env_creds_available | bool)
+- name: Fail if any dispatched tier is missing backend_id
   ansible.builtin.fail:
     msg: >-
-      VAST admin credentials not found. VAST_ENDPOINT, VAST_USERNAME, and
-      VAST_PASSWORD environment variables must all be set in the IG pod spec.
-      These are injected via AAP vault into the storage-operations-ig Secret
-      referenced in the IG pod spec envFrom block.
+      Tier '{{ item.name }}' has no backend_id. Every tier dispatched to the VAST
+      provider must reference the backend_id its connection details are keyed by.
+  loop: "{{ _provider_tiers }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: item.backend_id is not defined or item.backend_id | length == 0
 
-- name: Set VAST credentials from environment variables
+- name: Extract unique backend_id values from the dispatched tier subset
   ansible.builtin.set_fact:
-    vast_endpoint: "{{ _vast_endpoint_env }}"
-    vast_username: "{{ _vast_username_env }}"
-    vast_password: "{{ _vast_password_env }}"
-  no_log: true
+    _vast_backend_ids: "{{ _provider_tiers | map(attribute='backend_id') | unique | list }}"
 
-- name: Clear intermediate env credential facts
+- name: Fail if the dispatched tiers reference zero or multiple backend_ids
+  ansible.builtin.fail:
+    msg: >-
+      Expected exactly one backend_id across the dispatched VAST tiers, got
+      {{ _vast_backend_ids | length }}: {{ _vast_backend_ids | to_json }}.
+      VAST credential resolution assumes a single backend connection per role invocation —
+      multiple backends dispatched together in one call are not yet supported.
+  when: _vast_backend_ids | length != 1
+
+- name: Set the resolved backend_id
   ansible.builtin.set_fact:
-    _vast_endpoint_env: ""
-    _vast_username_env: ""
-    _vast_password_env: ""
+    _vast_backend_id: "{{ _vast_backend_ids[0] }}"
+
+- name: Fail if no connection details were provided for the resolved backend_id
+  ansible.builtin.fail:
+    msg: >-
+      No entry for backend_id '{{ _vast_backend_id }}' in storage_backend_connections.
+      osac-operator must resolve and pass connection details (endpoint, username, password)
+      for every backend_id referenced by storage_tier_definitions.
+  when: _vast_backend_id not in _provider_backend_connections
+
+- name: Fail if the resolved connection is missing endpoint, username, or password
+  ansible.builtin.fail:
+    msg: >-
+      storage_backend_connections['{{ _vast_backend_id }}'] is missing one or more of
+      endpoint, username, password. All three must be set together.
+  when: >-
+    _provider_backend_connections[_vast_backend_id].endpoint | default('') | length == 0 or
+    _provider_backend_connections[_vast_backend_id].username | default('') | length == 0 or
+    _provider_backend_connections[_vast_backend_id].password | default('') | length == 0
+
+- name: Set VAST credentials from the resolved backend connection
+  ansible.builtin.set_fact:
+    vast_endpoint: "{{ _provider_backend_connections[_vast_backend_id].endpoint }}"
+    vast_username: "{{ _provider_backend_connections[_vast_backend_id].username }}"
+    vast_password: "{{ _provider_backend_connections[_vast_backend_id].password }}"
   no_log: true

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_credentials.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_credentials.yaml
@@ -9,14 +9,41 @@
 # deployment), so this is enforced explicitly here rather than left as a silent assumption.
 
 - name: Fail if any dispatched tier is missing backend_id
-  ansible.builtin.fail:
-    msg: >-
-      Tier '{{ item.name }}' has no backend_id. Every tier dispatched to the VAST
-      provider must reference the backend_id its connection details are keyed by.
-  loop: "{{ _provider_tiers }}"
-  loop_control:
-    label: "{{ item.name }}"
-  when: item.backend_id is not defined or item.backend_id | length == 0
+  block:
+    - name: Fail if tier is missing backend_id
+      ansible.builtin.fail:
+        msg: >-
+          Tier '{{ item.name }}' has no backend_id. Every tier dispatched to the VAST
+          provider must reference the backend_id its connection details are keyed by.
+      loop: "{{ _provider_tiers }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: item.backend_id is not defined or item.backend_id | length == 0
+  rescue:
+    # Ansible loops evaluate every item rather than stopping at the first failure, so
+    # ansible_failed_result.results may contain more than one failed tier here.
+    - name: Build structured failure artifact for missing backend_id
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: >-
+          {% set _tiers = [] -%}
+          {% set _messages = [] -%}
+          {% for _r in (ansible_failed_result.results | default([])) -%}
+          {% if _r.failed | default(false) -%}
+          {% set _ = _tiers.append(_r.item.name) -%}
+          {% set _ = _messages.append(_r.msg | default('')) -%}
+          {% endif -%}
+          {% endfor -%}
+          {{ [{'reason': 'missing_backend_id', 'tiers': _tiers, 'backend_ids': [], 'message': _messages | join(' ')}] }}
+
+    - name: Emit structured failure artifact for missing backend_id
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
+
+    - name: Re-raise the original missing-backend_id failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"
 
 - name: Extract unique backend_id values from the dispatched tier subset
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/read_tenant_credentials.yaml
@@ -1,6 +1,7 @@
 ---
 # Reads per-tenant VMS Manager credentials from the hub-cluster tenant config Secret.
-# This is NOT the admin credentials reader (read_credentials.yaml reads admin creds from env vars).
+# This is NOT the admin credentials reader (read_credentials.yaml resolves admin creds from
+# storage_backend_connections, populated by osac-operator from the Tier API).
 # This file reads the per-tenant Manager username/password generated during setup.
 # The CSI driver authenticates via username/password, not API tokens.
 #

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -48,14 +48,14 @@
 - name: Validate tier quotas (when specified)
   ansible.builtin.fail:
     msg: >-
-      Tier '{{ item.name }}' has an invalid quota: '{{ item.quota }}'.
-      Quota must be a positive number (bytes).
+      Tier '{{ item.name }}' has an invalid quota_bytes: '{{ item.quota_bytes }}'.
+      quota_bytes must be a positive number (bytes).
   loop: "{{ _provider_tiers }}"
   loop_control:
     label: "{{ item.name }}"
   when:
-    - item.quota is defined
-    - (item.quota | int) <= 0
+    - item.quota_bytes is defined
+    - (item.quota_bytes | int) <= 0
 
 - name: Compute unique protocols from tiers
   ansible.builtin.set_fact:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -63,7 +63,7 @@
 
 - name: Provision VAST resources for tenant
   block:
-    - name: Resolve VAST admin credentials from env vars
+    - name: Resolve VAST admin credentials from storage_backend_connections
       ansible.builtin.include_tasks: read_credentials.yaml
 
     - name: Build VAST VMS connection dict

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -36,14 +36,46 @@
     quiet: true
 
 - name: Validate tier protocols are supported by VAST provider
-  ansible.builtin.fail:
-    msg: >-
-      Tier '{{ item.name }}' has unsupported protocol '{{ item.protocol }}'.
-      VAST provider supports: nfs, block.
-  loop: "{{ _provider_tiers }}"
-  loop_control:
-    label: "{{ item.name }}"
-  when: item.protocol not in ['nfs', 'block']
+  block:
+    - name: Fail if tier protocol is unsupported
+      ansible.builtin.fail:
+        msg: >-
+          Tier '{{ item.name }}' has unsupported protocol '{{ item.protocol }}'.
+          VAST provider supports: nfs, block.
+      loop: "{{ _provider_tiers }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: item.protocol not in ['nfs', 'block']
+  rescue:
+    # Ansible loops evaluate every item rather than stopping at the first failure, so
+    # ansible_failed_result.results may contain more than one failed tier here.
+    - name: Build structured failure artifact for unsupported protocol
+      ansible.builtin.set_fact:
+        osac_storage_provider_failures: >-
+          {% set _tiers = [] -%}
+          {% set _backend_ids = [] -%}
+          {% set _messages = [] -%}
+          {% for _r in (ansible_failed_result.results | default([])) -%}
+          {% if _r.failed | default(false) -%}
+          {% set _ = _tiers.append(_r.item.name) -%}
+          {% set _bid = _r.item.backend_id | default('') -%}
+          {% if (_bid | length > 0) and (_bid not in _backend_ids) -%}
+          {% set _ = _backend_ids.append(_bid) -%}
+          {% endif -%}
+          {% set _ = _messages.append(_r.msg | default('')) -%}
+          {% endif -%}
+          {% endfor -%}
+          {{ [{'reason': 'unsupported_protocol', 'tiers': _tiers, 'backend_ids': _backend_ids, 'message': _messages | join(' ')}] }}
+
+    - name: Emit structured failure artifact for unsupported protocol
+      ansible.builtin.set_stats:
+        data:
+          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
+        aggregate: false
+
+    - name: Re-raise the original protocol validation failure
+      ansible.builtin.fail:
+        msg: "{{ ansible_failed_result.msg }}"
 
 - name: Validate tier quotas (when specified)
   ansible.builtin.fail:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -36,46 +36,7 @@
     quiet: true
 
 - name: Validate tier protocols are supported by VAST provider
-  block:
-    - name: Fail if tier protocol is unsupported
-      ansible.builtin.fail:
-        msg: >-
-          Tier '{{ item.name }}' has unsupported protocol '{{ item.protocol }}'.
-          VAST provider supports: nfs, block.
-      loop: "{{ _provider_tiers }}"
-      loop_control:
-        label: "{{ item.name }}"
-      when: item.protocol not in ['nfs', 'block']
-  rescue:
-    # Ansible loops evaluate every item rather than stopping at the first failure, so
-    # ansible_failed_result.results may contain more than one failed tier here.
-    - name: Build structured failure artifact for unsupported protocol
-      ansible.builtin.set_fact:
-        osac_storage_provider_failures: >-
-          {% set _tiers = [] -%}
-          {% set _backend_ids = [] -%}
-          {% set _messages = [] -%}
-          {% for _r in (ansible_failed_result.results | default([])) -%}
-          {% if _r.failed | default(false) -%}
-          {% set _ = _tiers.append(_r.item.name) -%}
-          {% set _bid = _r.item.backend_id | default('') -%}
-          {% if (_bid | length > 0) and (_bid not in _backend_ids) -%}
-          {% set _ = _backend_ids.append(_bid) -%}
-          {% endif -%}
-          {% set _ = _messages.append(_r.msg | default('')) -%}
-          {% endif -%}
-          {% endfor -%}
-          {{ [{'reason': 'unsupported_protocol', 'tiers': _tiers, 'backend_ids': _backend_ids, 'message': _messages | join(' ')}] }}
-
-    - name: Emit structured failure artifact for unsupported protocol
-      ansible.builtin.set_stats:
-        data:
-          osac_storage_provider_failures: "{{ osac_storage_provider_failures }}"
-        aggregate: false
-
-    - name: Re-raise the original protocol validation failure
-      ansible.builtin.fail:
-        msg: "{{ ansible_failed_result.msg }}"
+  ansible.builtin.include_tasks: _validate_tier_protocols.yaml
 
 - name: Validate tier quotas (when specified)
   ansible.builtin.fail:

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/tasks/setup.yaml
@@ -35,7 +35,7 @@
     fail_msg: "Tier names must be unique."
     quiet: true
 
-- name: Validate tier protocols are supported by VAST provider
+- name: Include shared tier protocol validation
   ansible.builtin.include_tasks: _validate_tier_protocols.yaml
 
 - name: Validate tier quotas (when specified)

--- a/config/base/configmap-storage-operations-ig-example.yaml
+++ b/config/base/configmap-storage-operations-ig-example.yaml
@@ -3,17 +3,10 @@ kind: ConfigMap
 metadata:
   name: storage-operations-ig
 data:
-  # Storage tier definitions — JSON array with per-tier provider selection.
-  # Each tier declares: name (DNS label), protocol (nfs|block), provider (vast).
-  # Optional: qos_policy (string) + qos_limits (dict) for VAST QoS policy creation.
-  # Optional: quota (int, bytes) for per-tier hard quota.
-  STORAGE_TIERS: |
-    [
-      {"name": "default", "protocol": "nfs", "provider": "vast", "qos_policy": "default-qos",
-       "qos_limits": {"static_limits": {"max_reads_bw_mbps": 100, "max_writes_bw_mbps": 100}}},
-      {"name": "high-performance", "protocol": "block", "provider": "vast", "qos_policy": "high-iops",
-       "qos_limits": {"static_limits": {"max_reads_bw_mbps": 500, "max_writes_bw_mbps": 500}}}
-    ]
+  # Storage tier definitions are no longer configured here — osac-operator resolves them
+  # from the Tier API and passes them via the storage_tier_definitions extra_vars key on
+  # each AAP job (OSAC-1992). qos_policy is derived automatically by the storage_provider
+  # role, not configured per tier.
 
   # Create VolumeSnapshotClass alongside StorageClass (requires snapshot-controller CRD).
   STORAGE_SNAPSHOTS_ENABLED: "true"

--- a/config/base/configmap-storage-operations-ig-example.yaml
+++ b/config/base/configmap-storage-operations-ig-example.yaml
@@ -8,8 +8,9 @@ data:
   # each AAP job (OSAC-1992). qos_policy is derived automatically by the storage_provider
   # role, not configured per tier.
 
-  # Create VolumeSnapshotClass alongside StorageClass (requires snapshot-controller CRD).
-  STORAGE_SNAPSHOTS_ENABLED: "true"
+  # Whether to create a VolumeSnapshotClass alongside each StorageClass is no longer
+  # a configurable toggle — the role always checks live whether the VolumeSnapshot CRD
+  # is installed on the target cluster and creates VolumeSnapshotClasses only if so.
 
   # TLS certificate validation for VAST VMS API calls.
   # Set to "false" for self-signed certificates in dev/test environments.
@@ -20,6 +21,6 @@ data:
   # VAST_VIP_POOL_GW_IPV6: ""
 
   # Namespace on hub cluster where VAST config Secrets (vast-tenant-config-*) are stored.
-  # Overrides the OSAC_STORAGE_CONFIG_NAMESPACE env var injected via downward API in the pod spec.
-  # Only set this if the config namespace differs from the IG pod namespace.
+  # Defaults to the IG pod's own namespace (auto-detected, no config needed).
+  # Only set this if the config namespace differs from the IG pod's own namespace.
   # OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"

--- a/config/base/secret-storage-operations-ig-example.yaml
+++ b/config/base/secret-storage-operations-ig-example.yaml
@@ -4,18 +4,11 @@ metadata:
   name: storage-operations-ig
 type: Opaque
 data:
-  # VAST admin credentials — used ONLY for VMS API provisioning during tenant_setup.
+  # VAST admin credentials are no longer configured here — osac-operator resolves them
+  # from the Tier API and passes them via the storage_backend_connections extra_vars key
+  # on each AAP job, keyed by backend_id (OSAC-1992, absorbing OSAC-1957's AAP-side AC).
   # These credentials are NEVER placed into K8s Secrets or CSI Secrets in tenant namespaces.
   # Per-tenant data-plane credentials are generated automatically during tenant_setup.
-
-  # Base64-encoded VAST management API URL (e.g., https://vast-vms.example.com)
-  VAST_ENDPOINT: ""
-
-  # Base64-encoded VAST management API username
-  VAST_USERNAME: ""
-
-  # Base64-encoded VAST management API password
-  VAST_PASSWORD: ""
 
   # Block encryption passphrase comes from the Tenant CR event payload (spec.blockEncryptionPassphrase),
   # not from this Secret. It is per-tenant and passed through the EDA event.

--- a/playbook_osac_create_compute_instance.yml
+++ b/playbook_osac_create_compute_instance.yml
@@ -12,9 +12,17 @@
     _requested_storage_tier: "{{ lookup('env', 'STORAGE_REQUESTED_TIER') | default('default', true) }}"
 
   pre_tasks:
-    - name: Show EDA Event
+    # payload.spec.blockEncryptionPassphrase carries a real secret (see
+    # storage_provider_block_encryption_passphrase below) -- log an explicit
+    # metadata allowlist instead of the whole payload object.
+    - name: Show EDA Event metadata
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        msg:
+          kind: "{{ ansible_eda.event.payload.kind | default('unknown') }}"
+          name: "{{ ansible_eda.event.payload.metadata.name | default('unknown') }}"
+          namespace: "{{ ansible_eda.event.payload.metadata.namespace | default('unknown') }}"
+          uid: "{{ ansible_eda.event.payload.metadata.uid | default('unknown') }}"
+          template_id: "{{ ansible_eda.event.payload.spec.templateID | default('unknown') }}"
 
     - name: Determine tenant target namespace
       # Brings in variables:

--- a/playbook_osac_create_compute_instance.yml
+++ b/playbook_osac_create_compute_instance.yml
@@ -9,7 +9,6 @@
     template_id: "{{ ansible_eda.event.payload.spec.templateID }}"
     template_parameters: {}
     tenant_storage_classes: "{{ ansible_eda.event.tenant_storage_classes | default([]) }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
     _requested_storage_tier: "{{ lookup('env', 'STORAGE_REQUESTED_TIER') | default('default', true) }}"
 
   pre_tasks:
@@ -38,31 +37,22 @@
             else (compute_instance.metadata.annotations | default({})).get('osac.openshift.io/tenant', 'unknown')
           }}
 
-    - name: Parse STORAGE_TIERS for JIT storage
-      when: _storage_tiers_raw | length > 0
+    - name: Filter storage tier definitions to the requested tier for JIT storage
+      when: (ansible_eda.event.storage_tier_definitions | default([])) | length > 0
       block:
-        - name: Parse tier list from STORAGE_TIERS env var
-          ansible.builtin.set_fact:
-            _jit_all_tiers: "{{ _storage_tiers_raw | from_json }}"
-
         - name: Filter to only the requested tier
           ansible.builtin.set_fact:
-            _jit_storage_tiers: "{{ _jit_all_tiers | selectattr('name', 'equalto', _requested_storage_tier) | list }}"
+            _jit_storage_tiers: >-
+              {{ ansible_eda.event.storage_tier_definitions
+                 | selectattr('name', 'equalto', _requested_storage_tier) | list }}
 
-        - name: Warn if requested tier not found in STORAGE_TIERS
+        - name: Warn if requested tier not found in storage_tier_definitions
           ansible.builtin.debug:
             msg: >-
-              Requested storage tier '{{ _requested_storage_tier }}' not found in STORAGE_TIERS.
-              Available tiers: {{ _jit_all_tiers | map(attribute='name') | list | to_json }}.
+              Requested storage tier '{{ _requested_storage_tier }}' not found in storage_tier_definitions.
+              Available tiers: {{ ansible_eda.event.storage_tier_definitions | map(attribute='name') | list | to_json }}.
               JIT storage provisioning will be skipped.
           when: _jit_storage_tiers | length == 0
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
 
     - name: Ensure storage is provisioned for tenant (JIT)
       when: _jit_storage_tiers is defined and _jit_storage_tiers | length > 0
@@ -89,7 +79,7 @@
           ComputeInstance '{{ compute_instance_name }}' has no tenant_storage_classes
           available. Either the osac-operator CI controller should inject the resolved
           storageClasses list before triggering provisioning, or JIT storage provisioning
-          via STORAGE_TIERS must succeed.
+          via storage_tier_definitions must succeed.
       when:
         - tenant_storage_class_storage_classes | length == 0
         - _jit_storage_tiers is not defined or _jit_storage_tiers | length == 0

--- a/playbook_osac_create_compute_instance.yml
+++ b/playbook_osac_create_compute_instance.yml
@@ -13,15 +13,14 @@
 
   pre_tasks:
     # payload.spec.blockEncryptionPassphrase carries a real secret (see
-    # storage_provider_block_encryption_passphrase below) -- log an explicit
-    # metadata allowlist instead of the whole payload object.
+    # storage_provider_block_encryption_passphrase below) -- use the shared,
+    # centralized redaction task instead of debugging the whole payload object.
     - name: Show EDA Event metadata
-      ansible.builtin.debug:
-        msg:
-          kind: "{{ ansible_eda.event.payload.kind | default('unknown') }}"
-          name: "{{ ansible_eda.event.payload.metadata.name | default('unknown') }}"
-          namespace: "{{ ansible_eda.event.payload.metadata.namespace | default('unknown') }}"
-          uid: "{{ ansible_eda.event.payload.metadata.uid | default('unknown') }}"
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
+      vars:
+        eda_event_extra_fields:
           template_id: "{{ ansible_eda.event.payload.spec.templateID | default('unknown') }}"
 
     - name: Determine tenant target namespace
@@ -44,6 +43,17 @@
             if compute_instance.status is defined and compute_instance.status.tenantReference is defined
             else (compute_instance.metadata.annotations | default({})).get('osac.openshift.io/tenant', 'unknown')
           }}
+
+    - name: Validate optional storage_tier_definitions type
+      ansible.builtin.fail:
+        msg: >-
+          ansible_eda.event.storage_tier_definitions must be an array when provided.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001"}]
+      when: >-
+        ansible_eda.event.storage_tier_definitions is defined and
+        (ansible_eda.event.storage_tier_definitions is not sequence or
+         ansible_eda.event.storage_tier_definitions is string or
+         ansible_eda.event.storage_tier_definitions is mapping)
 
     - name: Filter storage tier definitions to the requested tier for JIT storage
       when: (ansible_eda.event.storage_tier_definitions | default([])) | length > 0

--- a/playbook_osac_create_compute_instance.yml
+++ b/playbook_osac_create_compute_instance.yml
@@ -64,7 +64,6 @@
         storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
         storage_provider_provisioning_target: vmaas
         storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
-        storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
     - name: Add JIT-provisioned StorageClasses to resolution list
       ansible.builtin.set_fact:

--- a/playbook_osac_create_compute_instance.yml
+++ b/playbook_osac_create_compute_instance.yml
@@ -61,6 +61,7 @@
       vars:
         storage_provider_action: ensure_storage_class
         storage_provider_tiers: "{{ _jit_storage_tiers }}"
+        storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
         storage_provider_provisioning_target: vmaas
         storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
         storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"

--- a/playbook_osac_create_tenant_cluster_storage.yml
+++ b/playbook_osac_create_tenant_cluster_storage.yml
@@ -79,6 +79,7 @@
           vars:
             storage_provider_action: ensure_storage_class
             storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
+            storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
             storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
             storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"
       rescue:
@@ -94,5 +95,6 @@
           vars:
             storage_provider_action: ensure_storage_class
             storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
+            storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
             storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
             storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"

--- a/playbook_osac_create_tenant_cluster_storage.yml
+++ b/playbook_osac_create_tenant_cluster_storage.yml
@@ -46,7 +46,7 @@
         msg: >-
           ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
           by osac-operator from the Tenant's resolved storage tiers.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
       when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
 
     - name: Write admin_kubeconfig to temporary file when provided

--- a/playbook_osac_create_tenant_cluster_storage.yml
+++ b/playbook_osac_create_tenant_cluster_storage.yml
@@ -24,9 +24,17 @@
     tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
 
   pre_tasks:
-    - name: Show EDA Event
+    # payload.spec.blockEncryptionPassphrase carries a real secret (see
+    # storage_provider_block_encryption_passphrase below) -- log an explicit
+    # metadata allowlist instead of the whole payload object.
+    - name: Show EDA Event metadata
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        msg:
+          kind: "{{ ansible_eda.event.payload.kind | default('unknown') }}"
+          name: "{{ ansible_eda.event.payload.metadata.name | default('unknown') }}"
+          namespace: "{{ ansible_eda.event.payload.metadata.namespace | default('unknown') }}"
+          uid: "{{ ansible_eda.event.payload.metadata.uid | default('unknown') }}"
+          tenant_annotation: "{{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/tenant'] | default('unknown') }}"
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:

--- a/playbook_osac_create_tenant_cluster_storage.yml
+++ b/playbook_osac_create_tenant_cluster_storage.yml
@@ -49,15 +49,6 @@
           Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
       when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
 
-    - name: Derive qos_policy per storage tier
-      ansible.builtin.set_fact:
-        _storage_tiers: >-
-          {% set _tiers = [] -%}
-          {% for _tier in ansible_eda.event.storage_tier_definitions -%}
-          {% set _ = _tiers.append(_tier | combine({'qos_policy': _tier.name + '-qos'})) -%}
-          {% endfor -%}
-          {{ _tiers }}
-
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-
         ansible_eda.event.admin_kubeconfig is defined and
@@ -87,7 +78,7 @@
             name: osac.service.storage_provider
           vars:
             storage_provider_action: ensure_storage_class
-            storage_provider_tiers: "{{ _storage_tiers }}"
+            storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
             storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
             storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"
       rescue:
@@ -102,6 +93,6 @@
             name: osac.service.storage_provider
           vars:
             storage_provider_action: ensure_storage_class
-            storage_provider_tiers: "{{ _storage_tiers }}"
+            storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
             storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
             storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"

--- a/playbook_osac_create_tenant_cluster_storage.yml
+++ b/playbook_osac_create_tenant_cluster_storage.yml
@@ -40,13 +40,18 @@
         ansible_eda.event.payload.metadata.uid is not defined or
         ansible_eda.event.payload.metadata.uid | length == 0
 
-    - name: Validate storage_tier_definitions is present in the EDA event
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
       ansible.builtin.fail:
         msg: >-
           ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
           by osac-operator from the Tenant's resolved storage tiers.
           Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
-      when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
+      when: >-
+        ansible_eda.event.storage_tier_definitions is not defined or
+        ansible_eda.event.storage_tier_definitions is not sequence or
+        ansible_eda.event.storage_tier_definitions is string or
+        ansible_eda.event.storage_tier_definitions is mapping or
+        ansible_eda.event.storage_tier_definitions | length == 0
 
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-

--- a/playbook_osac_create_tenant_cluster_storage.yml
+++ b/playbook_osac_create_tenant_cluster_storage.yml
@@ -22,7 +22,6 @@
       {{ ansible_eda.event.payload.metadata.namespace }}
       {%- endif -%}
     tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
     _storage_snapshots: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
   pre_tasks:
@@ -42,25 +41,22 @@
         ansible_eda.event.payload.metadata.uid is not defined or
         ansible_eda.event.payload.metadata.uid | length == 0
 
-    - name: Validate STORAGE_TIERS env var is configured
+    - name: Validate storage_tier_definitions is present in the EDA event
       ansible.builtin.fail:
         msg: >-
-          STORAGE_TIERS env var must be set at deployment time as a JSON array.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast"}]
-      when: _storage_tiers_raw | length == 0
+          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
+      when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
 
-    - name: Parse STORAGE_TIERS JSON
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+    - name: Derive qos_policy per storage tier
+      ansible.builtin.set_fact:
+        _storage_tiers: >-
+          {% set _tiers = [] -%}
+          {% for _tier in ansible_eda.event.storage_tier_definitions -%}
+          {% set _ = _tiers.append(_tier | combine({'qos_policy': _tier.name + '-qos'})) -%}
+          {% endfor -%}
+          {{ _tiers }}
 
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-

--- a/playbook_osac_create_tenant_cluster_storage.yml
+++ b/playbook_osac_create_tenant_cluster_storage.yml
@@ -25,15 +25,14 @@
 
   pre_tasks:
     # payload.spec.blockEncryptionPassphrase carries a real secret (see
-    # storage_provider_block_encryption_passphrase below) -- log an explicit
-    # metadata allowlist instead of the whole payload object.
+    # storage_provider_block_encryption_passphrase below) -- use the shared,
+    # centralized redaction task instead of debugging the whole payload object.
     - name: Show EDA Event metadata
-      ansible.builtin.debug:
-        msg:
-          kind: "{{ ansible_eda.event.payload.kind | default('unknown') }}"
-          name: "{{ ansible_eda.event.payload.metadata.name | default('unknown') }}"
-          namespace: "{{ ansible_eda.event.payload.metadata.namespace | default('unknown') }}"
-          uid: "{{ ansible_eda.event.payload.metadata.uid | default('unknown') }}"
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
+      vars:
+        eda_event_extra_fields:
           tenant_annotation: "{{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/tenant'] | default('unknown') }}"
 
     - name: Validate tenant payload is present

--- a/playbook_osac_create_tenant_cluster_storage.yml
+++ b/playbook_osac_create_tenant_cluster_storage.yml
@@ -22,7 +22,6 @@
       {{ ansible_eda.event.payload.metadata.namespace }}
       {%- endif -%}
     tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
-    _storage_snapshots: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"
 
   pre_tasks:
     - name: Show EDA Event
@@ -81,7 +80,6 @@
             storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
             storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
             storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
-            storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"
       rescue:
         - name: Warn about StorageClass creation failure
           ansible.builtin.debug:
@@ -97,4 +95,3 @@
             storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
             storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
             storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
-            storage_provider_snapshots_enabled: "{{ _storage_snapshots }}"

--- a/playbook_osac_create_tenant_storage_backend.yml
+++ b/playbook_osac_create_tenant_storage_backend.yml
@@ -25,13 +25,18 @@
         ansible_eda.event.payload.metadata.uid is not defined or
         ansible_eda.event.payload.metadata.uid | length == 0
 
-    - name: Validate storage_tier_definitions is present in the EDA event
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
       ansible.builtin.fail:
         msg: >-
           ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
           by osac-operator from the Tenant's resolved storage tiers.
           Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
-      when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
+      when: >-
+        ansible_eda.event.storage_tier_definitions is not defined or
+        ansible_eda.event.storage_tier_definitions is not sequence or
+        ansible_eda.event.storage_tier_definitions is string or
+        ansible_eda.event.storage_tier_definitions is mapping or
+        ansible_eda.event.storage_tier_definitions | length == 0
 
   tasks:
     - name: Configure tenant storage backend

--- a/playbook_osac_create_tenant_storage_backend.yml
+++ b/playbook_osac_create_tenant_storage_backend.yml
@@ -42,4 +42,3 @@
         storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
         storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
         storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
-        storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"

--- a/playbook_osac_create_tenant_storage_backend.yml
+++ b/playbook_osac_create_tenant_storage_backend.yml
@@ -10,15 +10,12 @@
 
   pre_tasks:
     # payload.spec.blockEncryptionPassphrase carries a real secret (see
-    # storage_provider_block_encryption_passphrase below) -- log an explicit
-    # metadata allowlist instead of the whole payload object.
+    # storage_provider_block_encryption_passphrase below) -- use the shared,
+    # centralized redaction task instead of debugging the whole payload object.
     - name: Show EDA Event metadata
-      ansible.builtin.debug:
-        msg:
-          kind: "{{ ansible_eda.event.payload.kind | default('unknown') }}"
-          name: "{{ ansible_eda.event.payload.metadata.name | default('unknown') }}"
-          namespace: "{{ ansible_eda.event.payload.metadata.namespace | default('unknown') }}"
-          uid: "{{ ansible_eda.event.payload.metadata.uid | default('unknown') }}"
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:

--- a/playbook_osac_create_tenant_storage_backend.yml
+++ b/playbook_osac_create_tenant_storage_backend.yml
@@ -33,21 +33,12 @@
           Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
       when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
 
-    - name: Derive qos_policy per storage tier
-      ansible.builtin.set_fact:
-        _storage_tiers: >-
-          {% set _tiers = [] -%}
-          {% for _tier in ansible_eda.event.storage_tier_definitions -%}
-          {% set _ = _tiers.append(_tier | combine({'qos_policy': _tier.name + '-qos'})) -%}
-          {% endfor -%}
-          {{ _tiers }}
-
   tasks:
     - name: Configure tenant storage backend
       ansible.builtin.include_role:
         name: osac.service.storage_provider
       vars:
         storage_provider_action: setup
-        storage_provider_tiers: "{{ _storage_tiers }}"
+        storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
         storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
         storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"

--- a/playbook_osac_create_tenant_storage_backend.yml
+++ b/playbook_osac_create_tenant_storage_backend.yml
@@ -30,7 +30,7 @@
         msg: >-
           ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
           by osac-operator from the Tenant's resolved storage tiers.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
       when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
 
   tasks:

--- a/playbook_osac_create_tenant_storage_backend.yml
+++ b/playbook_osac_create_tenant_storage_backend.yml
@@ -7,7 +7,6 @@
     tenant_name: "{{ ansible_eda.event.payload.metadata.name }}"
     tenant_namespace: "{{ ansible_eda.event.payload.metadata.namespace }}"
     tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
     - name: Show EDA Event
@@ -26,31 +25,22 @@
         ansible_eda.event.payload.metadata.uid is not defined or
         ansible_eda.event.payload.metadata.uid | length == 0
 
-    - name: Validate STORAGE_TIERS env var is configured
+    - name: Validate storage_tier_definitions is present in the EDA event
       ansible.builtin.fail:
         msg: >-
-          STORAGE_TIERS env var must be set at deployment time as a JSON array.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast"}]
-      when: _storage_tiers_raw | length == 0
+          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
+      when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
 
-    - name: Parse STORAGE_TIERS JSON
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-        - name: Validate STORAGE_TIERS is a JSON array
-          ansible.builtin.assert:
-            that:
-              - _storage_tiers | type_debug == 'list'
-            fail_msg: >-
-              STORAGE_TIERS must be a JSON array of tier objects.
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+    - name: Derive qos_policy per storage tier
+      ansible.builtin.set_fact:
+        _storage_tiers: >-
+          {% set _tiers = [] -%}
+          {% for _tier in ansible_eda.event.storage_tier_definitions -%}
+          {% set _ = _tiers.append(_tier | combine({'qos_policy': _tier.name + '-qos'})) -%}
+          {% endfor -%}
+          {{ _tiers }}
 
   tasks:
     - name: Configure tenant storage backend

--- a/playbook_osac_create_tenant_storage_backend.yml
+++ b/playbook_osac_create_tenant_storage_backend.yml
@@ -40,5 +40,6 @@
       vars:
         storage_provider_action: setup
         storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
+        storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"
         storage_provider_block_encryption_passphrase: "{{ ansible_eda.event.payload.spec.blockEncryptionPassphrase | default('') }}"
         storage_provider_snapshots_enabled: "{{ lookup('env', 'STORAGE_SNAPSHOTS_ENABLED') | default('true', true) | bool }}"

--- a/playbook_osac_create_tenant_storage_backend.yml
+++ b/playbook_osac_create_tenant_storage_backend.yml
@@ -9,9 +9,16 @@
     tenant_uid: "{{ ansible_eda.event.payload.metadata.uid }}"
 
   pre_tasks:
-    - name: Show EDA Event
+    # payload.spec.blockEncryptionPassphrase carries a real secret (see
+    # storage_provider_block_encryption_passphrase below) -- log an explicit
+    # metadata allowlist instead of the whole payload object.
+    - name: Show EDA Event metadata
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        msg:
+          kind: "{{ ansible_eda.event.payload.kind | default('unknown') }}"
+          name: "{{ ansible_eda.event.payload.metadata.name | default('unknown') }}"
+          namespace: "{{ ansible_eda.event.payload.metadata.namespace | default('unknown') }}"
+          uid: "{{ ansible_eda.event.payload.metadata.uid | default('unknown') }}"
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:

--- a/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/playbook_osac_delete_tenant_cluster_storage.yml
@@ -41,7 +41,7 @@
         msg: >-
           ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
           by osac-operator from the Tenant's resolved storage tiers.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
       when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
 
     - name: Write admin_kubeconfig to temporary file when provided

--- a/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/playbook_osac_delete_tenant_cluster_storage.yml
@@ -22,16 +22,16 @@
       {%- endif -%}
 
   pre_tasks:
-    # Log an explicit metadata allowlist rather than the whole payload object, matching
-    # the create-side playbook -- payload.spec is not currently used here, but keeping the
-    # same convention avoids reintroducing a full-payload debug if that ever changes.
+    # Use the shared, centralized redaction task rather than debugging the whole payload
+    # object, matching the create-side playbook -- payload.spec is not currently used
+    # here, but keeping the same convention avoids reintroducing a full-payload debug
+    # if that ever changes.
     - name: Show EDA Event metadata
-      ansible.builtin.debug:
-        msg:
-          kind: "{{ ansible_eda.event.payload.kind | default('unknown') }}"
-          name: "{{ ansible_eda.event.payload.metadata.name | default('unknown') }}"
-          namespace: "{{ ansible_eda.event.payload.metadata.namespace | default('unknown') }}"
-          uid: "{{ ansible_eda.event.payload.metadata.uid | default('unknown') }}"
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
+      vars:
+        eda_event_extra_fields:
           tenant_annotation: "{{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/tenant'] | default('unknown') }}"
 
     - name: Validate tenant payload is present

--- a/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/playbook_osac_delete_tenant_cluster_storage.yml
@@ -20,7 +20,6 @@
       {%- else -%}
       {{ ansible_eda.event.payload.metadata.namespace }}
       {%- endif -%}
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
     - name: Show EDA Event
@@ -37,25 +36,22 @@
         ansible_eda.event.payload.metadata.namespace is not defined or
         ansible_eda.event.payload.metadata.namespace | length == 0
 
-    - name: Parse STORAGE_TIERS JSON
-      when: _storage_tiers_raw | length > 0
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-        - name: Validate STORAGE_TIERS is a JSON array
-          ansible.builtin.assert:
-            that:
-              - _storage_tiers | type_debug == 'list'
-            fail_msg: >-
-              STORAGE_TIERS must be a JSON array of tier objects.
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+    - name: Validate storage_tier_definitions is present in the EDA event
+      ansible.builtin.fail:
+        msg: >-
+          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
+      when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
+
+    - name: Derive qos_policy per storage tier
+      ansible.builtin.set_fact:
+        _storage_tiers: >-
+          {% set _tiers = [] -%}
+          {% for _tier in ansible_eda.event.storage_tier_definitions -%}
+          {% set _ = _tiers.append(_tier | combine({'qos_policy': _tier.name + '-qos'})) -%}
+          {% endfor -%}
+          {{ _tiers }}
 
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-
@@ -78,13 +74,7 @@
         (_remote_kubeconfig is not defined or _remote_kubeconfig | length == 0)
 
   tasks:
-    - name: Skip cleanup when STORAGE_TIERS is not configured
-      when: _storage_tiers_raw | length == 0
-      ansible.builtin.debug:
-        msg: "STORAGE_TIERS env var is not set — nothing to clean up."
-
     - name: Clean up cluster-side tenant storage resources
-      when: _storage_tiers_raw | length > 0
       ansible.builtin.include_role:
         name: osac.service.storage_provider
       vars:

--- a/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/playbook_osac_delete_tenant_cluster_storage.yml
@@ -36,13 +36,18 @@
         ansible_eda.event.payload.metadata.namespace is not defined or
         ansible_eda.event.payload.metadata.namespace | length == 0
 
-    - name: Validate storage_tier_definitions is present in the EDA event
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
       ansible.builtin.fail:
         msg: >-
           ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
           by osac-operator from the Tenant's resolved storage tiers.
           Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
-      when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
+      when: >-
+        ansible_eda.event.storage_tier_definitions is not defined or
+        ansible_eda.event.storage_tier_definitions is not sequence or
+        ansible_eda.event.storage_tier_definitions is string or
+        ansible_eda.event.storage_tier_definitions is mapping or
+        ansible_eda.event.storage_tier_definitions | length == 0
 
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-

--- a/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/playbook_osac_delete_tenant_cluster_storage.yml
@@ -44,15 +44,6 @@
           Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
       when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
 
-    - name: Derive qos_policy per storage tier
-      ansible.builtin.set_fact:
-        _storage_tiers: >-
-          {% set _tiers = [] -%}
-          {% for _tier in ansible_eda.event.storage_tier_definitions -%}
-          {% set _ = _tiers.append(_tier | combine({'qos_policy': _tier.name + '-qos'})) -%}
-          {% endfor -%}
-          {{ _tiers }}
-
     - name: Write admin_kubeconfig to temporary file when provided
       when: >-
         ansible_eda.event.admin_kubeconfig is defined and
@@ -79,4 +70,4 @@
         name: osac.service.storage_provider
       vars:
         storage_provider_action: teardown_cluster_storage
-        storage_provider_tiers: "{{ _storage_tiers }}"
+        storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"

--- a/playbook_osac_delete_tenant_cluster_storage.yml
+++ b/playbook_osac_delete_tenant_cluster_storage.yml
@@ -22,9 +22,17 @@
       {%- endif -%}
 
   pre_tasks:
-    - name: Show EDA Event
+    # Log an explicit metadata allowlist rather than the whole payload object, matching
+    # the create-side playbook -- payload.spec is not currently used here, but keeping the
+    # same convention avoids reintroducing a full-payload debug if that ever changes.
+    - name: Show EDA Event metadata
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        msg:
+          kind: "{{ ansible_eda.event.payload.kind | default('unknown') }}"
+          name: "{{ ansible_eda.event.payload.metadata.name | default('unknown') }}"
+          namespace: "{{ ansible_eda.event.payload.metadata.namespace | default('unknown') }}"
+          uid: "{{ ansible_eda.event.payload.metadata.uid | default('unknown') }}"
+          tenant_annotation: "{{ ansible_eda.event.payload.metadata.annotations['osac.openshift.io/tenant'] | default('unknown') }}"
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:

--- a/playbook_osac_delete_tenant_storage_backend.yml
+++ b/playbook_osac_delete_tenant_storage_backend.yml
@@ -8,9 +8,16 @@
     tenant_namespace: "{{ ansible_eda.event.payload.metadata.namespace }}"
 
   pre_tasks:
-    - name: Show EDA Event
+    # Log an explicit metadata allowlist rather than the whole payload object, matching
+    # the create-side playbook -- payload.spec is not currently used here, but keeping the
+    # same convention avoids reintroducing a full-payload debug if that ever changes.
+    - name: Show EDA Event metadata
       ansible.builtin.debug:
-        var: ansible_eda.event.payload
+        msg:
+          kind: "{{ ansible_eda.event.payload.kind | default('unknown') }}"
+          name: "{{ ansible_eda.event.payload.metadata.name | default('unknown') }}"
+          namespace: "{{ ansible_eda.event.payload.metadata.namespace | default('unknown') }}"
+          uid: "{{ ansible_eda.event.payload.metadata.uid | default('unknown') }}"
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:

--- a/playbook_osac_delete_tenant_storage_backend.yml
+++ b/playbook_osac_delete_tenant_storage_backend.yml
@@ -30,19 +30,10 @@
           Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
       when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
 
-    - name: Derive qos_policy per storage tier
-      ansible.builtin.set_fact:
-        _storage_tiers: >-
-          {% set _tiers = [] -%}
-          {% for _tier in ansible_eda.event.storage_tier_definitions -%}
-          {% set _ = _tiers.append(_tier | combine({'qos_policy': _tier.name + '-qos'})) -%}
-          {% endfor -%}
-          {{ _tiers }}
-
   tasks:
     - name: Delete tenant storage backend
       ansible.builtin.include_role:
         name: osac.service.storage_provider
       vars:
         storage_provider_action: teardown_backend
-        storage_provider_tiers: "{{ _storage_tiers }}"
+        storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"

--- a/playbook_osac_delete_tenant_storage_backend.yml
+++ b/playbook_osac_delete_tenant_storage_backend.yml
@@ -37,3 +37,4 @@
       vars:
         storage_provider_action: teardown_backend
         storage_provider_tiers: "{{ ansible_eda.event.storage_tier_definitions }}"
+        storage_provider_backend_connections: "{{ ansible_eda.event.storage_backend_connections | default({}) }}"

--- a/playbook_osac_delete_tenant_storage_backend.yml
+++ b/playbook_osac_delete_tenant_storage_backend.yml
@@ -8,16 +8,14 @@
     tenant_namespace: "{{ ansible_eda.event.payload.metadata.namespace }}"
 
   pre_tasks:
-    # Log an explicit metadata allowlist rather than the whole payload object, matching
-    # the create-side playbook -- payload.spec is not currently used here, but keeping the
-    # same convention avoids reintroducing a full-payload debug if that ever changes.
+    # Use the shared, centralized redaction task rather than debugging the whole payload
+    # object, matching the create-side playbook -- payload.spec is not currently used
+    # here, but keeping the same convention avoids reintroducing a full-payload debug
+    # if that ever changes.
     - name: Show EDA Event metadata
-      ansible.builtin.debug:
-        msg:
-          kind: "{{ ansible_eda.event.payload.kind | default('unknown') }}"
-          name: "{{ ansible_eda.event.payload.metadata.name | default('unknown') }}"
-          namespace: "{{ ansible_eda.event.payload.metadata.namespace | default('unknown') }}"
-          uid: "{{ ansible_eda.event.payload.metadata.uid | default('unknown') }}"
+      ansible.builtin.include_role:
+        name: osac.service.common
+        tasks_from: show_eda_event_metadata
 
     - name: Validate tenant payload is present
       ansible.builtin.fail:

--- a/playbook_osac_delete_tenant_storage_backend.yml
+++ b/playbook_osac_delete_tenant_storage_backend.yml
@@ -22,13 +22,18 @@
         ansible_eda.event.payload.metadata.namespace is not defined or
         ansible_eda.event.payload.metadata.namespace | length == 0
 
-    - name: Validate storage_tier_definitions is present in the EDA event
+    - name: Validate storage_tier_definitions is a non-empty array in the EDA event
       ansible.builtin.fail:
         msg: >-
           ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
           by osac-operator from the Tenant's resolved storage tiers.
           Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
-      when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
+      when: >-
+        ansible_eda.event.storage_tier_definitions is not defined or
+        ansible_eda.event.storage_tier_definitions is not sequence or
+        ansible_eda.event.storage_tier_definitions is string or
+        ansible_eda.event.storage_tier_definitions is mapping or
+        ansible_eda.event.storage_tier_definitions | length == 0
 
   tasks:
     - name: Delete tenant storage backend

--- a/playbook_osac_delete_tenant_storage_backend.yml
+++ b/playbook_osac_delete_tenant_storage_backend.yml
@@ -27,7 +27,7 @@
         msg: >-
           ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
           by osac-operator from the Tenant's resolved storage tiers.
-          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota_bytes":500}]
       when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
 
   tasks:

--- a/playbook_osac_delete_tenant_storage_backend.yml
+++ b/playbook_osac_delete_tenant_storage_backend.yml
@@ -6,7 +6,6 @@
   vars:
     tenant_name: "{{ ansible_eda.event.payload.metadata.name }}"
     tenant_namespace: "{{ ansible_eda.event.payload.metadata.namespace }}"
-    _storage_tiers_raw: "{{ lookup('env', 'STORAGE_TIERS') }}"
 
   pre_tasks:
     - name: Show EDA Event
@@ -23,28 +22,25 @@
         ansible_eda.event.payload.metadata.namespace is not defined or
         ansible_eda.event.payload.metadata.namespace | length == 0
 
-    - name: Parse STORAGE_TIERS JSON
-      when: _storage_tiers_raw | length > 0
-      block:
-        - name: Parse tier list from env var
-          ansible.builtin.set_fact:
-            _storage_tiers: "{{ _storage_tiers_raw | from_json }}"
-      rescue:
-        - name: Fail on malformed STORAGE_TIERS JSON
-          ansible.builtin.fail:
-            msg: >-
-              STORAGE_TIERS env var contains invalid JSON.
-              Value: '{{ _storage_tiers_raw }}'.
-              Expected a JSON array of tier objects with name, protocol, and provider fields.
+    - name: Validate storage_tier_definitions is present in the EDA event
+      ansible.builtin.fail:
+        msg: >-
+          ansible_eda.event.storage_tier_definitions must be a non-empty array, populated
+          by osac-operator from the Tenant's resolved storage tiers.
+          Example: [{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-001","quota":500}]
+      when: (ansible_eda.event.storage_tier_definitions | default([])) | length == 0
+
+    - name: Derive qos_policy per storage tier
+      ansible.builtin.set_fact:
+        _storage_tiers: >-
+          {% set _tiers = [] -%}
+          {% for _tier in ansible_eda.event.storage_tier_definitions -%}
+          {% set _ = _tiers.append(_tier | combine({'qos_policy': _tier.name + '-qos'})) -%}
+          {% endfor -%}
+          {{ _tiers }}
 
   tasks:
-    - name: Skip teardown when STORAGE_TIERS is not configured
-      when: _storage_tiers_raw | length == 0
-      ansible.builtin.debug:
-        msg: "STORAGE_TIERS env var is not set — nothing to tear down."
-
     - name: Delete tenant storage backend
-      when: _storage_tiers_raw | length > 0
       ansible.builtin.include_role:
         name: osac.service.storage_provider
       vars:

--- a/samples/storage_tier_definitions_payload.json
+++ b/samples/storage_tier_definitions_payload.json
@@ -20,7 +20,7 @@
               "max_writes_bw_mbps": 100
             }
           },
-          "quota": 500
+          "quota_bytes": 536870912000
         }
       ],
       "storage_backend_connections": {

--- a/samples/storage_tier_definitions_payload.json
+++ b/samples/storage_tier_definitions_payload.json
@@ -27,7 +27,7 @@
         "be-001": {
           "endpoint": "vast.example.com:443",
           "username": "admin",
-          "password": "changeme"
+          "password": "admin"
         }
       }
     }

--- a/samples/storage_tier_definitions_payload.json
+++ b/samples/storage_tier_definitions_payload.json
@@ -22,7 +22,14 @@
           },
           "quota": 500
         }
-      ]
+      ],
+      "storage_backend_connections": {
+        "be-001": {
+          "endpoint": "vast.example.com:443",
+          "username": "admin",
+          "password": "changeme"
+        }
+      }
     }
   }
 }

--- a/samples/storage_tier_definitions_payload.json
+++ b/samples/storage_tier_definitions_payload.json
@@ -1,0 +1,28 @@
+{
+  "ansible_eda": {
+    "event": {
+      "payload": {
+        "metadata": {
+          "name": "acme",
+          "namespace": "tenant-acme",
+          "uid": "11111111-1111-1111-1111-111111111111"
+        }
+      },
+      "storage_tier_definitions": [
+        {
+          "name": "default",
+          "protocol": "nfs",
+          "provider": "vast",
+          "backend_id": "be-001",
+          "qos_limits": {
+            "static_limits": {
+              "max_reads_bw_mbps": 100,
+              "max_writes_bw_mbps": 100
+            }
+          },
+          "quota": 500
+        }
+      ]
+    }
+  }
+}

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -3,9 +3,13 @@
 #   envsubst < integration_config.yml.template > integration_config.yml
 #
 # WARNING: NEVER commit integration_config.yml with real credentials.
-# Connection details are keyed by backend_id, matching the
-# storage_provider_backend_connections extra_var the storage_provider role reads.
-storage_backend_connections:
+#
+# NOTE: No automated target in tests/integration/targets/ currently loads this file --
+# there is no live Tier 3 test wired up yet. Keys below are named to match the
+# storage_provider role's extra_vars directly (storage_provider_backend_connections/
+# storage_provider_tiers) so a future live-VMS target can pass this file's parsed
+# content straight through as vars, with no key remapping step.
+storage_provider_backend_connections:
   ${VAST_BACKEND_ID:-be-test}:
     endpoint: "${VAST_BACKEND_ENDPOINT}"
     username: "${VAST_BACKEND_USERNAME}"
@@ -22,4 +26,4 @@ vast_vip_pool_subnet_cidr: ${VAST_VIP_POOL_SUBNET_CIDR:-24}
 # Storage tier definitions — JSON array with per-tier provider selection and backend_id,
 # matching the storage_provider_tiers/ansible_eda.event.storage_tier_definitions shape.
 # Used by test playbooks to exercise the multi-tier storage provider interface.
-storage_tiers: '${VAST_STORAGE_TIERS:-[{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-test"}]}'
+storage_provider_tiers: '${VAST_STORAGE_TIERS:-[{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-test"}]}'

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -1,6 +1,27 @@
 # VAST VMS credentials for live API integration tests (Tier 3)
-# Copy to integration_config.yml and fill in values, or render from CI:
-#   envsubst < integration_config.yml.template > integration_config.yml
+# Copy to integration_config.yml and fill in values, or render from CI.
+#
+# Rendering notes (deliberately described in prose below, with no dollar-brace
+# examples inline, since envsubst treats this whole file as flat text and would
+# substitute a literal example the same as it substitutes the real fields):
+#
+# 1. envsubst (GNU gettext) only expands bare dollar-brace variable references.
+#    It does NOT support bash's colon-dash fallback syntax -- a variable
+#    reference with a fallback baked in is left completely untouched by
+#    envsubst, even when the variable is already set, because the colon breaks
+#    its identifier matching. Resolve every fallback below by exporting the
+#    real VAST_* variable first, then run envsubst.
+#
+# 2. When exporting a fallback yourself, do not reuse bash's own colon-dash
+#    form for the tier-definitions variable: bash's own "${VAR:-default}"
+#    stops at the FIRST unescaped closing brace inside default, so a
+#    JSON-object default silently truncates. Guard that one with a plain
+#    if-unset check and a separate export instead.
+#
+# 3. Render with envsubst restricted to exactly this file's VAST_* variable
+#    names, not bare envsubst on the whole file -- unrestricted envsubst would
+#    also expand any other dollar-prefixed variable that happens to be set in
+#    the calling shell or CI environment.
 #
 # WARNING: NEVER commit integration_config.yml with real credentials.
 #
@@ -10,20 +31,23 @@
 # storage_provider_tiers) so a future live-VMS target can pass this file's parsed
 # content straight through as vars, with no key remapping step.
 storage_provider_backend_connections:
-  ${VAST_BACKEND_ID:-be-test}:
+  ${VAST_BACKEND_ID}:
     endpoint: "${VAST_BACKEND_ENDPOINT}"
     username: "${VAST_BACKEND_USERNAME}"
     password: "${VAST_BACKEND_PASSWORD}"
 vast_tenant_prefix: "osac-test-"
 # TLS validation — set to false for mock server or self-signed cert testing
-vast_validate_certs: ${VAST_VALIDATE_CERTS:-true}
+vast_validate_certs: ${VAST_VALIDATE_CERTS}
 
 # Shared VIP pool configuration
-vast_vip_pool_name: "${VAST_VIP_POOL_NAME:-osac-shared}"
-vast_vip_pool_ip_ranges: '${VAST_VIP_POOL_IP_RANGES:-[["10.0.100.10","10.0.100.50"]]}'
-vast_vip_pool_subnet_cidr: ${VAST_VIP_POOL_SUBNET_CIDR:-24}
+vast_vip_pool_name: "${VAST_VIP_POOL_NAME}"
+vast_vip_pool_ip_ranges: '${VAST_VIP_POOL_IP_RANGES}'
+vast_vip_pool_subnet_cidr: ${VAST_VIP_POOL_SUBNET_CIDR}
 
 # Storage tier definitions — JSON array with per-tier provider selection and backend_id,
 # matching the storage_provider_tiers/ansible_eda.event.storage_tier_definitions shape.
-# Used by test playbooks to exercise the multi-tier storage provider interface.
-storage_provider_tiers: '${VAST_STORAGE_TIERS:-[{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-test"}]}'
+# Used by test playbooks to exercise the multi-tier storage provider interface. Left
+# unquoted (unlike vast_vip_pool_ip_ranges above) so it parses as a native YAML list --
+# the storage_provider role's own validation requires storage_provider_tiers to be a
+# sequence, not a JSON-shaped string requiring a separate from_json step.
+storage_provider_tiers: ${VAST_STORAGE_TIERS}

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -7,9 +7,9 @@
 # storage_provider_backend_connections extra_var the storage_provider role reads.
 storage_backend_connections:
   ${VAST_BACKEND_ID:-be-test}:
-    endpoint: "${VAST_ENDPOINT}"
-    username: "${VAST_USERNAME}"
-    password: "${VAST_PASSWORD}"
+    endpoint: "${VAST_BACKEND_ENDPOINT}"
+    username: "${VAST_BACKEND_USERNAME}"
+    password: "${VAST_BACKEND_PASSWORD}"
 vast_tenant_prefix: "osac-test-"
 # TLS validation — set to false for mock server or self-signed cert testing
 vast_validate_certs: ${VAST_VALIDATE_CERTS:-true}
@@ -22,4 +22,4 @@ vast_vip_pool_subnet_cidr: ${VAST_VIP_POOL_SUBNET_CIDR:-24}
 # Storage tier definitions — JSON array with per-tier provider selection and backend_id,
 # matching the storage_provider_tiers/ansible_eda.event.storage_tier_definitions shape.
 # Used by test playbooks to exercise the multi-tier storage provider interface.
-storage_tiers: '${STORAGE_TIERS:-[{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-test"}]}'
+storage_tiers: '${VAST_STORAGE_TIERS:-[{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-test"}]}'

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -3,9 +3,13 @@
 #   envsubst < integration_config.yml.template > integration_config.yml
 #
 # WARNING: NEVER commit integration_config.yml with real credentials.
-vast_endpoint: "${VAST_ENDPOINT}"
-vast_username: "${VAST_USERNAME}"
-vast_password: "${VAST_PASSWORD}"
+# Connection details are keyed by backend_id, matching the
+# storage_provider_backend_connections extra_var the storage_provider role reads.
+storage_backend_connections:
+  ${VAST_BACKEND_ID:-be-test}:
+    endpoint: "${VAST_ENDPOINT}"
+    username: "${VAST_USERNAME}"
+    password: "${VAST_PASSWORD}"
 vast_tenant_prefix: "osac-test-"
 # TLS validation — set to false for mock server or self-signed cert testing
 vast_validate_certs: ${VAST_VALIDATE_CERTS:-true}
@@ -15,6 +19,7 @@ vast_vip_pool_name: "${VAST_VIP_POOL_NAME:-osac-shared}"
 vast_vip_pool_ip_ranges: '${VAST_VIP_POOL_IP_RANGES:-[["10.0.100.10","10.0.100.50"]]}'
 vast_vip_pool_subnet_cidr: ${VAST_VIP_POOL_SUBNET_CIDR:-24}
 
-# Storage tier definition — JSON array with per-tier provider selection.
+# Storage tier definitions — JSON array with per-tier provider selection and backend_id,
+# matching the storage_provider_tiers/ansible_eda.event.storage_tier_definitions shape.
 # Used by test playbooks to exercise the multi-tier storage provider interface.
-storage_tiers: '${STORAGE_TIERS}'
+storage_tiers: '${STORAGE_TIERS:-[{"name":"default","protocol":"nfs","provider":"vast","backend_id":"be-test"}]}'

--- a/tests/integration/run_tests.sh
+++ b/tests/integration/run_tests.sh
@@ -151,6 +151,37 @@ done
 # Clean up lease test pod
 kubectl delete pod lease-test-pod -n osac-system --ignore-not-found 2>/dev/null || true
 
+echo "=== Running Storage Provider Dispatcher Unit Tests ==="
+echo ""
+
+# Validation-only tests for the storage_provider role's dispatcher logic -- no kind cluster
+# or mock VMS server required, so these run unconditionally (not gated behind
+# STORAGE_TESTS_ENABLED). Requires two separate invocations: ansible-core raises a
+# runner-level ERROR! when include_role targets a genuinely-missing role name (the "invalid
+# provider" scenario), which aborts the whole process even though that scenario's own rescue
+# block already passed. The second invocation resumes at the next scenario to cover
+# everything after it.
+STORAGE_PROVIDER_UNIT_TEST="../../collections/ansible_collections/osac/service/roles/storage_provider/tests/test.yml"
+
+if ansible-playbook "${STORAGE_PROVIDER_UNIT_TEST}" -v; then
+  echo "  ✓ storage_provider unit tests (part 1) passed"
+  PASSED+=("storage_provider_unit_tests:part1")
+else
+  echo "  ✗ storage_provider unit tests (part 1) failed"
+  FAILED+=("storage_provider_unit_tests:part1")
+fi
+
+if ansible-playbook --start-at-task "Attempt with invalid action 'destroy' (expected to fail)" \
+  "${STORAGE_PROVIDER_UNIT_TEST}" -v; then
+  echo "  ✓ storage_provider unit tests (part 2) passed"
+  PASSED+=("storage_provider_unit_tests:part2")
+else
+  echo "  ✗ storage_provider unit tests (part 2) failed"
+  FAILED+=("storage_provider_unit_tests:part2")
+fi
+
+echo ""
+
 # Storage provider tests (conditional)
 if [ "${STORAGE_TESTS_ENABLED:-}" = "true" ]; then
   # Source env vars written by setup_test_env.sh (Make runs each recipe line in a separate shell)

--- a/tests/integration/setup_test_env.sh
+++ b/tests/integration/setup_test_env.sh
@@ -170,15 +170,15 @@ CSIEOF
   kubectl create namespace test-tenant-ns || true
 
   # Write VAST env vars to file for run_tests.sh (Make runs each recipe line in a separate shell)
+  # VAST_ENDPOINT/VAST_USERNAME/VAST_PASSWORD/STORAGE_TIERS are no longer read by any
+  # playbook or role (OSAC-1992 moved credential/tier input to
+  # storage_provider_backend_connections/storage_provider_tiers extra_vars, set directly
+  # by each test target) -- only VIP pool and TLS settings remain relevant here.
   cat > "${SCRIPT_DIR}/.storage_env" <<'ENVEOF'
-export VAST_ENDPOINT="127.0.0.1:18443"
-export VAST_USERNAME="admin"
-export VAST_PASSWORD="admin"
 export VAST_VIP_POOL_NAME="osac-test-pool"
 export VAST_VIP_POOL_IP_RANGES='[["10.0.0.10","10.0.0.50"]]'
 export VAST_VIP_POOL_SUBNET_CIDR="24"
 export VAST_VALIDATE_CERTS="false"
-export STORAGE_TIERS='[{"name":"default","protocol":"nfs","provider":"vast","qos_policy":"test-qos","qos_limits":{"static_limits":{"max_reads_bw_mbps":100,"max_writes_bw_mbps":100}}}]'
 ENVEOF
 fi
 

--- a/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -418,6 +418,145 @@
         fail_msg: "No view policy API calls found — ensure_storage_class should create view policies"
         success_msg: "View policy API calls detected"
 
+# ── Test: storage_provider_snapshots_enabled: false suppresses VolumeSnapshotClass ──
+# Uses a separate tenant from the tests above so this scenario always goes through full
+# provisioning (the short-circuit above would otherwise mask whether the flag is honored).
+- name: "Storage Provider Ensure SC - Setup fixtures (snapshots disabled)"
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Delete hub Secret fixture if exists (clean slate)
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        name: "vast-tenant-config-test-ensuresc-nosnap"
+        namespace: "osac-system"
+      failed_when: false
+
+    - name: Create hub Secret fixture for snapshots-disabled tenant
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "vast-tenant-config-test-ensuresc-nosnap"
+            namespace: "osac-system"
+            labels:
+              app.kubernetes.io/managed-by: osac-aap
+              osac.openshift.io/tenant: "test-ensuresc-nosnap"
+          type: Opaque
+          stringData:
+            tenant_uid_hash: "e1a8c287"
+            vast_tenant_id: "998"
+            vip_pool_name: "osac-test-pool"
+            vast_endpoint: "127.0.0.1:18443"
+            tenant_manager_username: "osac-test-ensuresc-nosnap"
+            tenant_manager_password: "test-csi-password"
+
+- name: "Storage Provider Ensure SC - Run with snapshots disabled"
+  hosts: localhost
+  gather_facts: false
+
+  environment:
+    OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
+
+  vars:
+    tenant_name: "test-ensuresc-nosnap"
+    tenant_namespace: "osac-system"
+    _cluster_name: "test-cluster"
+    storage_provider_tiers:
+      - name: default
+        protocol: nfs
+        provider: vast
+        backend_id: be-test
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
+    storage_provider_action: ensure_storage_class
+    storage_provider_snapshots_enabled: false
+    vast_storage_validate_certs: false
+
+  tasks:
+    - name: Call storage_provider role with snapshots disabled
+      ansible.builtin.include_role:
+        name: osac.service.storage_provider
+      vars:
+        storage_provider_action: ensure_storage_class
+
+- name: "Storage Provider Ensure SC - Verify snapshots_enabled: false is honored"
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Check if VolumeSnapshotClass CRD exists
+      kubernetes.core.k8s_info:
+        api_version: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        name: volumesnapshotclasses.snapshot.storage.k8s.io
+      register: _nosnap_vsc_crd_check
+
+    - name: Assert VolumeSnapshotClass CRD is present (precondition for this test)
+      ansible.builtin.assert:
+        that:
+          - _nosnap_vsc_crd_check.resources | length > 0
+        fail_msg: >-
+          VolumeSnapshotClass CRD not found in the test cluster — this scenario only
+          proves storage_provider_snapshots_enabled is honored when the CRD IS present.
+
+    - name: Read VolumeSnapshotClass for snapshots-disabled tenant
+      kubernetes.core.k8s_info:
+        api_version: snapshot.storage.k8s.io/v1
+        kind: VolumeSnapshotClass
+        name: "vast-snapshot-test-ensuresc-nosnap-default"
+      register: _nosnap_vsc_result
+
+    - name: Assert VolumeSnapshotClass was NOT created when snapshots_enabled is false
+      ansible.builtin.assert:
+        that:
+          - _nosnap_vsc_result.resources | length == 0
+        fail_msg: >-
+          VolumeSnapshotClass 'vast-snapshot-test-ensuresc-nosnap-default' was created even
+          though storage_provider_snapshots_enabled was false — the CRD-availability check
+          must not bypass this opt-out flag.
+        success_msg: "VolumeSnapshotClass correctly suppressed when snapshots_enabled is false"
+
+# ── Cleanup (snapshots-disabled scenario) ──
+- name: "Storage Provider Ensure SC - Cleanup (snapshots disabled)"
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: Delete NFS StorageClass (snapshots-disabled tenant)
+      kubernetes.core.k8s:
+        state: absent
+        api_version: storage.k8s.io/v1
+        kind: StorageClass
+        name: "vast-nfs-test-ensuresc-nosnap-default"
+      failed_when: false
+
+    - name: Delete CSI Secret (snapshots-disabled tenant)
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        name: "vast-csi-test-ensuresc-nosnap"
+        namespace: "osac-system"
+      failed_when: false
+
+    - name: Delete hub Secret (snapshots-disabled tenant)
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        name: "vast-tenant-config-test-ensuresc-nosnap"
+        namespace: "osac-system"
+      failed_when: false
+
 # ── Cleanup ──
 - name: "Storage Provider Ensure SC - Cleanup"
   hosts: localhost

--- a/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -88,9 +88,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
@@ -102,9 +99,16 @@
       - name: default
         protocol: nfs
         provider: vast
+        backend_id: be-test
       - name: block-tier
         protocol: block
         provider: vast
+        backend_id: be-test
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_action: ensure_storage_class
     storage_provider_snapshots_enabled: true
     storage_provider_block_encryption_passphrase: "test-encryption-passphrase"
@@ -343,9 +347,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
@@ -356,9 +357,16 @@
       - name: default
         protocol: nfs
         provider: vast
+        backend_id: be-test
       - name: block-tier
         protocol: block
         provider: vast
+        backend_id: be-test
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_action: ensure_storage_class
     storage_provider_snapshots_enabled: true
     storage_provider_block_encryption_passphrase: "test-encryption-passphrase"

--- a/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -53,6 +53,10 @@
             name: "vast-snapshot-test-ensuresc-default"
           failed_when: false
 
+    - name: Set mock tenant manager credentials for this scenario
+      ansible.builtin.set_fact:
+        mock_tenant_manager_password: "test-csi-password"
+
     - name: Create hub Secret fixture (simulates output from setup action)
       kubernetes.core.k8s:
         state: present
@@ -76,7 +80,7 @@
             storage_provider_type: "vast"
             tenant_manager_name: "osac-test-ensuresc"
             tenant_manager_username: "osac-test-ensuresc"
-            tenant_manager_password: "test-csi-password"
+            tenant_manager_password: "{{ mock_tenant_manager_password }}"
             tenant_manager_id: "42"
             tenant_role_id: "7"
             view_policy_name: "osac-test-ensuresc-nfs"
@@ -269,7 +273,7 @@
           - _csi_secret.resources[0].data.username is defined
           - (_csi_secret.resources[0].data.username | b64decode) == "osac-test-ensuresc"
           - _csi_secret.resources[0].data.password is defined
-          - (_csi_secret.resources[0].data.password | b64decode) == "test-csi-password"
+          - (_csi_secret.resources[0].data.password | b64decode) == mock_tenant_manager_password
           - _csi_secret.resources[0].data.endpoint is defined
           - (_csi_secret.resources[0].data.endpoint | b64decode) == "127.0.0.1:18443"
           - _csi_secret.resources[0].data.tenant is defined
@@ -454,7 +458,7 @@
             vip_pool_name: "osac-test-pool"
             vast_endpoint: "127.0.0.1:18443"
             tenant_manager_username: "osac-test-ensuresc-nosnap"
-            tenant_manager_password: "test-csi-password"
+            tenant_manager_password: "{{ mock_tenant_manager_password }}"
 
 - name: "Storage Provider Ensure SC - Run with snapshots disabled"
   hosts: localhost

--- a/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -110,7 +110,6 @@
         username: "admin"
         password: "admin"
     storage_provider_action: ensure_storage_class
-    storage_provider_snapshots_enabled: true
     storage_provider_block_encryption_passphrase: "test-encryption-passphrase"
     vast_storage_validate_certs: false
 
@@ -368,7 +367,6 @@
         username: "admin"
         password: "admin"
     storage_provider_action: ensure_storage_class
-    storage_provider_snapshots_enabled: true
     storage_provider_block_encryption_passphrase: "test-encryption-passphrase"
     vast_storage_validate_certs: false
 

--- a/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_ensure_sc/tasks/main.yml
@@ -430,14 +430,41 @@
   gather_facts: false
 
   tasks:
-    - name: Delete hub Secret fixture if exists (clean slate)
-      kubernetes.core.k8s:
-        state: absent
-        api_version: v1
-        kind: Secret
-        name: "vast-tenant-config-test-ensuresc-nosnap"
-        namespace: "osac-system"
-      failed_when: false
+    - name: Delete any pre-existing snapshots-disabled test resources (clean slate)
+      block:
+        - name: Delete hub Secret if exists
+          kubernetes.core.k8s:
+            state: absent
+            api_version: v1
+            kind: Secret
+            name: "vast-tenant-config-test-ensuresc-nosnap"
+            namespace: "osac-system"
+          failed_when: false
+
+        - name: Delete CSI Secret if exists
+          kubernetes.core.k8s:
+            state: absent
+            api_version: v1
+            kind: Secret
+            name: "vast-csi-test-ensuresc-nosnap"
+            namespace: "osac-system"
+          failed_when: false
+
+        - name: Delete NFS StorageClass if exists
+          kubernetes.core.k8s:
+            state: absent
+            api_version: storage.k8s.io/v1
+            kind: StorageClass
+            name: "vast-nfs-test-ensuresc-nosnap-default"
+          failed_when: false
+
+        - name: Delete VolumeSnapshotClass if exists
+          kubernetes.core.k8s:
+            state: absent
+            api_version: snapshot.storage.k8s.io/v1
+            kind: VolumeSnapshotClass
+            name: "vast-snapshot-test-ensuresc-nosnap-default"
+          failed_when: false
 
     - name: Create hub Secret fixture for snapshots-disabled tenant
       kubernetes.core.k8s:
@@ -559,6 +586,22 @@
         kind: Secret
         name: "vast-tenant-config-test-ensuresc-nosnap"
         namespace: "osac-system"
+      failed_when: false
+
+    - name: Check if VolumeSnapshotClass CRD exists for cleanup (snapshots-disabled tenant)
+      kubernetes.core.k8s_info:
+        api_version: apiextensions.k8s.io/v1
+        kind: CustomResourceDefinition
+        name: volumesnapshotclasses.snapshot.storage.k8s.io
+      register: _nosnap_cleanup_vsc_crd
+
+    - name: Delete VolumeSnapshotClass (snapshots-disabled tenant, safety net in case the flag ever regresses)
+      when: _nosnap_cleanup_vsc_crd.resources | length > 0
+      kubernetes.core.k8s:
+        state: absent
+        api_version: snapshot.storage.k8s.io/v1
+        kind: VolumeSnapshotClass
+        name: "vast-snapshot-test-ensuresc-nosnap-default"
       failed_when: false
 
 # ── Cleanup ──

--- a/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
@@ -72,7 +72,6 @@
         endpoint: "127.0.0.1:18443"
         username: "admin"
         password: "admin"
-    storage_provider_snapshots_enabled: false
     vast_storage_validate_certs: false
 
   tasks:

--- a/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_onboarding/tasks/main.yml
@@ -52,9 +52,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     VAST_VIP_POOL_NAME: "osac-test-pool"
     VAST_VIP_POOL_IP_RANGES: '[["10.0.0.10","10.0.0.50"]]'
     VAST_VIP_POOL_SUBNET_CIDR: "24"
@@ -69,6 +66,12 @@
       - name: default
         protocol: nfs
         provider: vast
+        backend_id: be-test
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_snapshots_enabled: false
     vast_storage_validate_certs: false
 

--- a/tests/integration/targets/storage_provider_setup/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_setup/tasks/main.yml
@@ -23,7 +23,8 @@
         protocol: nfs
         provider: vast
         backend_id: be-test
-        qos_policy: test-qos
+        # qos_policy intentionally omitted: the role always derives it from the tier
+        # name now, discarding any caller-supplied value.
         qos_limits:
           static_limits:
             max_reads_bw_mbps: 100

--- a/tests/integration/targets/storage_provider_setup/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_setup/tasks/main.yml
@@ -9,9 +9,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     VAST_VIP_POOL_NAME: "osac-test-pool"
     VAST_VIP_POOL_IP_RANGES: '[["10.0.0.10","10.0.0.50"]]'
     VAST_VIP_POOL_SUBNET_CIDR: "24"
@@ -25,11 +22,17 @@
       - name: default
         protocol: nfs
         provider: vast
+        backend_id: be-test
         qos_policy: test-qos
         qos_limits:
           static_limits:
             max_reads_bw_mbps: 100
             max_writes_bw_mbps: 100
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_action: setup
     storage_provider_provisioning_target: vmaas
     storage_provider_snapshots_enabled: false

--- a/tests/integration/targets/storage_provider_setup/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_setup/tasks/main.yml
@@ -35,7 +35,6 @@
         password: "admin"
     storage_provider_action: setup
     storage_provider_provisioning_target: vmaas
-    storage_provider_snapshots_enabled: false
     vast_storage_validate_certs: false
 
   tasks:

--- a/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
@@ -64,7 +64,6 @@
         password: "admin"
     storage_provider_action: setup
     storage_provider_provisioning_target: vmaas
-    storage_provider_snapshots_enabled: false
     vast_storage_validate_certs: false
 
   tasks:

--- a/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
@@ -53,7 +53,8 @@
         protocol: nfs
         provider: vast
         backend_id: be-test
-        qos_policy: rollback-qos
+        # qos_policy intentionally omitted: the role always derives it from the tier
+        # name now, discarding any caller-supplied value.
         qos_limits:
           static_limits:
             max_reads_bw_mbps: 100

--- a/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_setup_rollback/tasks/main.yml
@@ -39,9 +39,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     VAST_VIP_POOL_NAME: "osac-test-pool"
     VAST_VIP_POOL_IP_RANGES: '[["10.0.0.10","10.0.0.50"]]'
     VAST_VIP_POOL_SUBNET_CIDR: "24"
@@ -55,10 +52,16 @@
       - name: default
         protocol: nfs
         provider: vast
+        backend_id: be-test
         qos_policy: rollback-qos
         qos_limits:
           static_limits:
             max_reads_bw_mbps: 100
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_action: setup
     storage_provider_provisioning_target: vmaas
     storage_provider_snapshots_enabled: false

--- a/tests/integration/targets/storage_provider_teardown/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_teardown/tasks/main.yml
@@ -211,9 +211,6 @@
   gather_facts: false
 
   environment:
-    VAST_ENDPOINT: "127.0.0.1:18443"
-    VAST_USERNAME: "admin"
-    VAST_PASSWORD: "admin"
     OSAC_STORAGE_CONFIG_NAMESPACE: "osac-system"
 
   vars:
@@ -223,6 +220,12 @@
       - name: default
         protocol: nfs
         provider: vast
+        backend_id: be-test
+    storage_provider_backend_connections:
+      be-test:
+        endpoint: "127.0.0.1:18443"
+        username: "admin"
+        password: "admin"
     storage_provider_provisioning_target: vmaas
     vast_storage_validate_certs: false
 

--- a/tests/integration/targets/storage_provider_teardown/tasks/main.yml
+++ b/tests/integration/targets/storage_provider_teardown/tasks/main.yml
@@ -10,6 +10,10 @@
   hosts: localhost
   gather_facts: false
 
+  vars:
+    mock_tenant_manager_password: "test-csi-password"
+    mock_csi_token: "test-api-token-for-csi"
+
   tasks:
     - name: Reset mock VMS server (sequential execution — safe to reset)
       ansible.builtin.uri:
@@ -89,7 +93,7 @@
             storage_provider_type: "vast"
             tenant_manager_name: "osac-test-teardown"
             tenant_manager_username: "osac-test-teardown"
-            tenant_manager_password: "test-csi-password"
+            tenant_manager_password: "{{ mock_tenant_manager_password }}"
             tenant_manager_id: "7"
             tenant_role_id: "8"
 
@@ -150,7 +154,7 @@
               osac.openshift.io/tenant: "test-teardown"
           type: Opaque
           stringData:
-            token: "test-api-token-for-csi"
+            token: "{{ mock_csi_token }}"
             endpoint: "127.0.0.1:18443"
 
     - name: Check if VolumeSnapshotClass CRD exists


### PR DESCRIPTION
## Summary
- Replaces the `STORAGE_TIERS` env var and `storage-operations-ig` VAST admin credentials with `ansible_eda.event.storage_tier_definitions`/`storage_backend_connections` extra_vars populated by osac-operator's new Tier API integration, absorbing OSAC-1957's outstanding AAP-side AC
- Centralizes `qos_policy` derivation in the `storage_provider` role so every caller gets consistent naming without duplicating the logic
- Wraps AAP-discovered tier/backend capability-mismatch checks (unsupported protocol, ambiguous/unresolved/incomplete backend connections) in structured `set_stats` failure artifacts, additive scaffolding for a future osac-operator consumer to attribute job failures to a specific StorageTier/StorageBackend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage provisioning/teardown is now event-driven via `storage_tier_definitions` and per-`backend_id` `storage_backend_connections`.
  * Quotas use `quota_bytes`; QoS policy is always derived from the tier name.
  * Storage tier dispatch supports per-provider filtering, with stricter protocol validation and snapshot handling via live VolumeSnapshot CRD detection.
* **Bug Fixes**
  * Improved fail-fast validation and structured failure reporting for invalid inputs and credential/backend issues.
* **Documentation**
  * Updated provider docs, templates, and example payload/configs for the event-driven model.
* **Tests**
  * Expanded dispatcher and integration coverage for new validation, filtering, and credential/snapshot scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->