### PR TITLE
OSAC-1330: include metadata.name in template and NetworkClass API payloads

### DIFF
--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -280,6 +280,7 @@ class NetworkClassCapabilities(Base):
 class Metadata(Base):
     """Metadata about the template"""
 
+    metadata_name: str | None = pydantic.Field(None, validation_alias="name")
     title: str
     description: str | None = None
     template_type: TemplateTypeEnum = pydantic.Field(
@@ -309,6 +310,7 @@ class BaseTemplate(Base):
     collection: str = pydantic.Field(..., exclude=True)
     path: Path = pydantic.Field(..., exclude=True)
     name: str = pydantic.Field(..., exclude=True)
+    metadata_name: str | None = pydantic.Field(None, exclude=True)
     title: str | None = None
     description: str | None = None
     template_type: TemplateTypeEnum = pydantic.Field(exclude=True)
@@ -321,6 +323,11 @@ class BaseTemplate(Base):
     @pydantic.computed_field
     def id(self) -> str:
         return f"{self.collection}.{self.name}"
+
+    @pydantic.computed_field
+    def metadata(self) -> dict[str, str]:
+        name = self.metadata_name if self.metadata_name else self.name.replace("_", "-")
+        return {"name": name}
 
 
 class ClusterTemplate(BaseTemplate):
@@ -373,6 +380,7 @@ class NetworkClassTemplate(Base):
     collection: str = pydantic.Field(..., exclude=True)
     path: Path = pydantic.Field(..., exclude=True)
     name: str = pydantic.Field(..., exclude=True)
+    metadata_name: str | None = pydantic.Field(None, exclude=True)
     template_type: Literal[TemplateTypeEnum.network] = pydantic.Field(
         default=TemplateTypeEnum.network, exclude=True
     )
@@ -387,6 +395,11 @@ class NetworkClassTemplate(Base):
     @pydantic.field_serializer("path")
     def serialize_path(self, value: Path):
         return str(value)
+
+    @pydantic.computed_field
+    def metadata(self) -> dict[str, str]:
+        name = self.metadata_name if self.metadata_name else self.implementation_strategy.replace("_", "-")
+        return {"name": name}
 
 
 def _validate_collection_name(name: str) -> None:
@@ -526,6 +539,7 @@ class Collection(Base):
                         "collection": self.name,
                         "path": path,
                         "name": path.name,
+                        "metadata_name": metadata.metadata_name,
                         "title": metadata.title,
                         "description": metadata.description,
                         "parameters": params,
@@ -548,6 +562,7 @@ class Collection(Base):
                             collection=self.name,
                             path=path,
                             name=path.name,
+                            metadata_name=metadata.metadata_name,
                             title=metadata.title,
                             description=metadata.description,
                             implementation_strategy=metadata.implementation_strategy,

--- a/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_agent_provisioning/meta/osac.yaml
@@ -1,4 +1,5 @@
 # Define the display name and description of the template
+name: bm-host-agent-provisioning
 title: Bare Metal Host Agent Provisioning
 description: >
   Provisions bare metal hosts with agent-based images using OpenStack Ironic.

--- a/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/bm_host_provisioning/meta/osac.yaml
@@ -1,4 +1,5 @@
 ---
+name: bm-host-provisioning
 title: Bare Metal Host Image Provisioning
 description: >
   Provisions bare metal instances using an image. Template name: bm_host_provisioning.

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/meta/osac.yaml
@@ -1,4 +1,5 @@
 ---
+name: cudn-net
 title: CUDN Network Implementation
 description: >
   Provisions networking resources using ClusterUserDefinedNetwork (CUDN) on OpenShift.

--- a/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/metallb_l2/meta/osac.yaml
@@ -1,4 +1,5 @@
 ---
+name: metallb-l2
 title: MetalLB L2 Implementation
 description: >
   Provisions MetalLB resources for PublicIPPool and PublicIP using L2 advertisement.

--- a/collections/ansible_collections/osac/templates/roles/netris/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/netris/meta/osac.yaml
@@ -1,4 +1,5 @@
 ---
+name: netris
 title: Netris Network Implementation
 description: >
   Provisions networking resources using Netris Controller API.

--- a/collections/ansible_collections/osac/templates/roles/network_policy/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/network_policy/meta/osac.yaml
@@ -1,4 +1,5 @@
 ---
+name: network-policy
 title: Kubernetes NetworkPolicy Backend
 description: >
   Implements SecurityGroup enforcement via standard Kubernetes NetworkPolicy.

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_ai_maas/meta/osac.yaml
@@ -1,4 +1,5 @@
 ---
+name: ocp-4-20-ai-maas
 title: OpenShift AI 4.20 Cluster with MaaS
 description: >
   Builds an OpenShift 4.20 cluster with RHOAI 3.4, Models-as-a-Service (GA),

--- a/collections/ansible_collections/osac/templates/roles/ocp_4_20_small_nico/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_4_20_small_nico/meta/osac.yaml
@@ -1,4 +1,5 @@
 # Define the display name and description of the template
+name: ocp-4-20-small-nico
 title: OpenShift 4.20 Cluster on NICo Bare Metal
 description: >
   This template will build a minimally configured OpenShift 4.20 cluster

--- a/collections/ansible_collections/osac/templates/roles/ocp_ci_small/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_ci_small/meta/osac.yaml
@@ -1,3 +1,4 @@
+name: ocp-ci-small
 title: CI OpenShift Cluster
 description: >
   OpenShift 4.17 cluster for CI testing. Uses ci.steps network backend.

--- a/collections/ansible_collections/osac/templates/roles/ocp_small/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_small/meta/osac.yaml
@@ -1,3 +1,4 @@
+name: ocp-small
 title: OpenShift Small Cluster
 description: >
   Builds a minimally configured OpenShift cluster with a configurable OCP

--- a/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/ocp_virt_vm/meta/osac.yaml
@@ -1,4 +1,5 @@
 # Define the display name and description of the template
+name: ocp-virt-vm
 title: Virtual Machine Template (Linux and Windows)
 description: >
   Virtual machine template for OpenShift Virtualization supporting both Linux and Windows guest operating systems.

--- a/collections/ansible_collections/osac/templates/roles/openstack/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/openstack/meta/osac.yaml
@@ -1,4 +1,5 @@
 ---
+name: openstack
 title: OpenStack Neutron Network Implementation
 description: >
   Provisions networking resources using OpenStack Neutron

--- a/collections/ansible_collections/osac/templates/roles/vast_storage/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/vast_storage/meta/osac.yaml
@@ -1,4 +1,5 @@
 ---
+name: vast-storage
 title: VAST Data Storage Provider
 description: >
   Provisions VAST Data storage resources for OSAC tenants.


### PR DESCRIPTION
## Summary

- Add `metadata` computed field to `BaseTemplate` and `NetworkClassTemplate` in `find_template_roles.py`
- Templates derive `metadata.name` from the role name (underscores → hyphens), e.g. `ocp_small` → `ocp-small`
- NetworkClass derives `metadata.name` from `implementation_strategy`, e.g. `cudn_net` → `cudn-net`
- This is the origin fix for catalog resources missing `metadata.name`, which broke name-based reference lookups in [OSAC-1330](https://redhat.atlassian.net/browse/OSAC-1330)

Depends on osac-project/fulfillment-service#986.

## Test plan

- [x] Verified serialization output includes `metadata.name` for all template types (cluster, compute_instance, bare_metal_instance, network)
- [ ] E2E: create templates via `publish_templates`, verify `metadata.name` is set on the fulfillment-service side

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata to template results, including standardized names with underscores converted to hyphens.
  * Added metadata support for network class templates based on their implementation strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->