### PR TITLE
OSAC-2345: add NetworkClass defaults to template role metadata

### DIFF
--- a/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
+++ b/collections/ansible_collections/osac/service/plugins/filter/find_template_roles.py
@@ -269,6 +269,28 @@ class TemplateTypeEnum(StrEnum):
     bare_metal_instance = "bare_metal_instance"
 
 
+class SecurityRule(Base):
+    """A security rule for ingress or egress."""
+
+    protocol: str
+    port_from: int | None = None
+    port_to: int | None = None
+    ipv4_cidr: str | None = None
+    ipv6_cidr: str | None = None
+
+
+class NetworkDefaults(Base):
+    """Default networking configuration for tenant onboarding."""
+
+    virtual_network_ipv4_cidr: str | None = None
+    virtual_network_ipv6_cidr: str | None = None
+    subnet_ipv4_cidr: str | None = None
+    subnet_ipv6_cidr: str | None = None
+    enable_nat_gateway: bool = False
+    ingress_rules: list[SecurityRule] | None = None
+    egress_rules: list[SecurityRule] | None = None
+
+
 class NetworkClassCapabilities(Base):
     """Capabilities supported by a network class"""
 
@@ -293,6 +315,7 @@ class Metadata(Base):
     k8s_manager: str | None = None
     is_default: bool = False
     capabilities: NetworkClassCapabilities | None = None
+    defaults: NetworkDefaults | None = None
     parameters: list[TemplateParameterDefinition] = pydantic.Field(default_factory=list)
 
     # spec_defaults is used to set optional default values for the related spec fields associated
@@ -362,6 +385,12 @@ class BareMetalInstanceTemplate(BaseTemplate):
     parameters: list[TemplateParameter] = pydantic.Field(default_factory=list, exclude=True)
 
 
+class NetworkClassSpec(Base):
+    """Spec for a NetworkClass, containing defaults."""
+
+    defaults: NetworkDefaults | None = None
+
+
 class NetworkClassTemplate(Base):
     """Template for NetworkClass registration.
 
@@ -376,6 +405,7 @@ class NetworkClassTemplate(Base):
     template_type: Literal[TemplateTypeEnum.network] = pydantic.Field(
         default=TemplateTypeEnum.network, exclude=True
     )
+    defaults: NetworkDefaults | None = pydantic.Field(default=None, exclude=True)
     title: str
     description: str | None = None
     implementation_strategy: str
@@ -383,6 +413,17 @@ class NetworkClassTemplate(Base):
     k8s_manager: str | None = None
     is_default: bool = False
     capabilities: NetworkClassCapabilities
+    spec: NetworkClassSpec | None = None
+
+    @pydantic.model_validator(mode="after")
+    def _nest_defaults_in_spec(self) -> "NetworkClassTemplate":
+        if self.defaults is None:
+            return self
+        if self.spec is None:
+            self.spec = NetworkClassSpec(defaults=self.defaults)
+        elif self.spec.defaults is None:
+            self.spec.defaults = self.defaults
+        return self
 
     @pydantic.field_serializer("path")
     def serialize_path(self, value: Path):
@@ -555,6 +596,7 @@ class Collection(Base):
                             k8s_manager=metadata.k8s_manager,
                             is_default=metadata.is_default,
                             capabilities=metadata.capabilities or NetworkClassCapabilities(),
+                            defaults=metadata.defaults,
                         )
                     elif metadata.template_type == TemplateTypeEnum.storage_provider:
                         # Storage provider roles are not yielded as compute instance or

--- a/collections/ansible_collections/osac/templates/roles/cudn_net/meta/osac.yaml
+++ b/collections/ansible_collections/osac/templates/roles/cudn_net/meta/osac.yaml
@@ -15,3 +15,10 @@ capabilities:
   supports_ipv4: true
   supports_ipv6: true
   supports_dual_stack: true
+defaults:
+  virtual_network_ipv4_cidr: "10.200.0.0/16"
+  subnet_ipv4_cidr: "10.200.0.0/20"
+  enable_nat_gateway: false
+  egress_rules:
+    - protocol: PROTOCOL_ALL
+      ipv4_cidr: "0.0.0.0/0"

--- a/tests/unit/plugins/filter/test_find_template_roles.py
+++ b/tests/unit/plugins/filter/test_find_template_roles.py
@@ -6,8 +6,12 @@ import yaml
 
 from find_template_roles import (
     Metadata,
+    NetworkClassCapabilities,
+    NetworkClassTemplate,
+    NetworkDefaults,
     ProtobufAnyValue,
     ProtobufType,
+    SecurityRule,
     TemplateParameter,
     TemplateParameterDefinition,
     TemplateTypeEnum,
@@ -270,6 +274,52 @@ class TestMetadataTemplateTypes:
         metadata = _load_metadata(roles_dir, "cudn_net")
         assert metadata.capabilities is not None
         assert metadata.capabilities.supports_ipv4 is True
+
+    def test_network_has_defaults(self, roles_dir):
+        metadata = _load_metadata(roles_dir, "cudn_net")
+        assert metadata.defaults is not None
+        assert metadata.defaults.virtual_network_ipv4_cidr == "10.200.0.0/16"
+        assert metadata.defaults.subnet_ipv4_cidr == "10.200.0.0/20"
+        assert metadata.defaults.enable_nat_gateway is False
+        assert metadata.defaults.egress_rules is not None
+        assert len(metadata.defaults.egress_rules) == 1
+        assert metadata.defaults.egress_rules[0].protocol == "PROTOCOL_ALL"
+        assert metadata.defaults.egress_rules[0].ipv4_cidr == "0.0.0.0/0"
+
+    def test_network_defaults_serialized_in_spec(self):
+        template = NetworkClassTemplate(
+            collection="test",
+            path=Path("/tmp/test"),
+            name="test_net",
+            title="Test Network",
+            implementation_strategy="test_net",
+            capabilities=NetworkClassCapabilities(supports_ipv4=True),
+            defaults=NetworkDefaults(
+                virtual_network_ipv4_cidr="10.200.0.0/16",
+                subnet_ipv4_cidr="10.200.0.0/20",
+                egress_rules=[SecurityRule(protocol="PROTOCOL_ALL", ipv4_cidr="0.0.0.0/0")],
+            ),
+        )
+        payload = template.model_dump(by_alias=True, exclude_none=True)
+        assert "defaults" not in payload
+        assert "spec" in payload
+        assert payload["spec"]["defaults"]["virtual_network_ipv4_cidr"] == "10.200.0.0/16"
+        assert payload["spec"]["defaults"]["subnet_ipv4_cidr"] == "10.200.0.0/20"
+        assert payload["spec"]["defaults"]["egress_rules"][0]["protocol"] == "PROTOCOL_ALL"
+        assert payload["spec"]["defaults"]["egress_rules"][0]["ipv4_cidr"] == "0.0.0.0/0"
+
+    def test_network_without_defaults_has_no_spec(self):
+        template = NetworkClassTemplate(
+            collection="test",
+            path=Path("/tmp/test"),
+            name="test_net",
+            title="Test Network",
+            implementation_strategy="test_net",
+            capabilities=NetworkClassCapabilities(supports_ipv4=True),
+        )
+        payload = template.model_dump(by_alias=True, exclude_none=True)
+        assert "defaults" not in payload
+        assert "spec" not in payload
 
     def test_cluster_with_parameters(self, roles_dir):
         metadata = _load_metadata(roles_dir, "ocp_4_20_ai_maas")


### PR DESCRIPTION
Add defaults section to cudn_net meta/osac.yaml with tenant onboarding configuration (VN CIDR 10.200.0.0/16, subnet CIDR 10.200.0.0/20, allow-all egress rule). CIDRs avoid OpenShift defaults (10.0.0.0/16 machine CIDR, 10.128.0.0/14 pod CIDR).

Extend the find_template_roles filter plugin with NetworkDefaults and SecurityRule models. The defaults field in meta/osac.yaml is automatically nested inside spec.defaults in the API payload, so the fulfillment-service receives the correct structure for DefaultNetworkingProvisioner to use during tenant onboarding.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable network defaults, including CIDR ranges, NAT gateway settings, and IPv4 egress rules.
  * Network templates now support nested specifications and automatically include configured defaults.
  * Network role discovery carries configured metadata defaults into generated templates.

* **Tests**
  * Added coverage for default serialization and handling templates without configured defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->